### PR TITLE
Publish on NPM

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,9 +10,8 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: '12.x'
-    - run: yarn config set npmRegistryServer "https://npm.pkg.github.com"
     - run: yarn config set npmAuthToken $YARN_NPM_AUTH_TOKEN
       env:
-        YARN_NPM_AUTH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+        YARN_NPM_AUTH_TOKEN: ${{ secrets.PUBLISH_NPM_TOKEN }}
     - run: yarn
     - run: yarn npm publish


### PR DESCRIPTION
### What and why?

<!-- A short description of what changes this PR introduces and why. -->

We can't install a package from the GitHub registry anonymously.
Which is very counter productive.

### How?

<!-- A brief description of implementation details of this PR. -->

Publish it on NPM instead.
