### PR TITLE
Support Node 10

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -343,7 +343,8 @@ module.exports = {
     "overrides": [
         {
             "files": [
-                '**/*.test.*'
+                '**/*.test.*',
+                '**/*.ignore.*'
             ],
             "env": {
                 "jest": true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,15 @@ on: pull_request
 
 jobs:
   unit-test:
-    name: Unit tests
+    strategy:
+      fail-fast: false
+      matrix:
+        node:
+        - 10
+        - 12
+        - 14
+
+    name: Unit tests w/ Node.js ${{matrix.node}}.x
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install node
+    - name: Install Node ${{matrix.node}}.x
       uses: actions/setup-node@v1
       with:
-        node-version: '12.16.1'
+        node-version: ${{matrix.node}}.x
     - run: yarn test
   check-oss:
     name: Check Open Source compliance

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
     globals: {
         'ts-jest': {
             tsConfig: 'tsconfig.json',
+            packageJson: 'package.json',
         },
     },
     testPathIgnorePatterns: ['.+\\.ignore\\.+'],

--- a/src/__tests__/customHook.ignore.ts
+++ b/src/__tests__/customHook.ignore.ts
@@ -2,10 +2,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-module.exports = {
-    hooks: {
-        preoutput: () => {
-            return { test: 'test' };
-        },
+export const hooks = {
+    preoutput: () => {
+        return { test: 'test' };
     },
 };

--- a/src/__tests__/testHelpers.ignore.ts
+++ b/src/__tests__/testHelpers.ignore.ts
@@ -1,3 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
 import { Stats, Report, Compilation, Compiler } from '../types';
 
 export const mockStats = ({

--- a/src/__tests__/testHelpers.ignore.ts
+++ b/src/__tests__/testHelpers.ignore.ts
@@ -1,0 +1,58 @@
+import { Stats, Report, Compilation, Compiler } from '../types';
+
+export const mockStats = ({
+    toJson: jest.fn(() => ({
+        modules: [],
+        chunks: [],
+        assets: [],
+        entrypoints: {},
+        warnings: [],
+        errors: [],
+        time: 0,
+    })),
+    endTime: 0,
+    startTime: 0,
+    compilation: {
+        assets: {},
+        fileDependencies: new Set(),
+        emittedAssets: new Set(),
+        warnings: [],
+        modules: new Set(),
+        chunks: new Set(),
+        entries: new Map(),
+    },
+} as unknown) as Stats;
+
+export const mockReport = {
+    timings: {
+        tapables: {},
+        loaders: {},
+        modules: {},
+    },
+    dependencies: {},
+} as Report;
+
+const mockTapable = { tap: jest.fn() };
+export const mockCompilation = {
+    options: {
+        context: '/default/context',
+    },
+    hooks: {
+        buildModule: mockTapable,
+        succeedModule: mockTapable,
+        afterOptimizeTree: mockTapable,
+    },
+} as Compilation;
+
+export const mockCompiler = {
+    hooks: {
+        thisCompilation: {
+            tap: (opts: any, cb: (c: Compilation) => void) => {
+                cb(mockCompilation);
+            },
+        },
+        done: {
+            tapPromise: (opts: any, cb: any) => cb(mockStats),
+        },
+    },
+} as Compiler;

--- a/src/__tests__/webpack.test.ts
+++ b/src/__tests__/webpack.test.ts
@@ -3,7 +3,7 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import { BuildPlugin } from '../webpack';
-import { Compilation, Compiler } from '../types';
+import { mockCompiler } from './testHelpers.ignore';
 
 type ConsoleError = (message?: any, ...optionalParams: any[]) => void;
 
@@ -24,30 +24,6 @@ describe('webpack', () => {
     });
 
     test(`It should use given context or default to webpack's configuration`, () => {
-        const mockTapable = { tap: jest.fn() };
-        const mockCompilation = {
-            options: {
-                context: '/default/context',
-            },
-            hooks: {
-                buildModule: mockTapable,
-                succeedModule: mockTapable,
-                afterOptimizeTree: mockTapable,
-            },
-        } as Compilation;
-        const mockCompiler = {
-            hooks: {
-                thisCompilation: {
-                    tap: (opts: any, cb: (c: Compilation) => void) => {
-                        cb(mockCompilation);
-                    },
-                },
-                done: {
-                    tapPromise: (opts: any, cb: any) => cb({}),
-                },
-            },
-        } as Compiler;
-
         const plugin1 = new BuildPlugin({
             context: '/fake/path',
         });
@@ -70,6 +46,7 @@ describe('webpack', () => {
             .mockImplementation(
                 (message?: any, ...optionalParams: any[]) => {}
             ) as unknown) as ConsoleError;
+
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const plugin = new BuildPlugin({
             hooks: ['./broken/path.ts'],

--- a/src/hooks/__tests__/outputFiles.test.ts
+++ b/src/hooks/__tests__/outputFiles.test.ts
@@ -5,23 +5,16 @@
 import fs from 'fs-extra';
 import path from 'path';
 
-describe('Output Files', () => {
-    const reportMock = {
-        timings: {
-            tapables: {},
-            loaders: {},
-            modules: {},
-        },
-        dependencies: {},
-    };
+import { mockReport } from '../../__tests__/testHelpers.ignore';
 
+describe('Output Files', () => {
     const getExistsProms = async (output: string, context: string) => {
         const { hooks } = require('../outputFiles');
         await hooks.output.call(
             // eslint-disable-next-line no-console
             { log: console.log, options: { output, context } },
             {
-                report: reportMock,
+                report: mockReport,
                 metrics: {},
                 stats: { toJson: () => ({}) },
             }

--- a/src/hooks/datadog/__tests__/aggregator.test.ts
+++ b/src/hooks/datadog/__tests__/aggregator.test.ts
@@ -1,3 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
 import { mockReport, mockStats } from '../../../__tests__/testHelpers.ignore';
 
 describe('Aggregator', () => {

--- a/src/hooks/datadog/__tests__/aggregator.test.ts
+++ b/src/hooks/datadog/__tests__/aggregator.test.ts
@@ -1,24 +1,8 @@
+import { mockReport, mockStats } from '../../../__tests__/testHelpers.ignore';
+
 describe('Aggregator', () => {
     test('It should aggregate metrics without throwing.', () => {
         const { getMetrics } = require('../aggregator');
-        const mockReport = {
-            timings: {
-                tapables: [],
-                loaders: [],
-            },
-            dependencies: {},
-        };
-        const mockStats = {
-            toJson: jest.fn(() => ({
-                modules: [],
-                chunks: [],
-                assets: [],
-                entrypoints: {},
-                warnings: [],
-                errors: [],
-                time: 0,
-            })),
-        };
         const opts = { context: '', filters: [], tags: [] };
         expect(() => {
             getMetrics(mockReport, mockStats, opts);

--- a/src/hooks/datadog/__tests__/aggregator.test.ts
+++ b/src/hooks/datadog/__tests__/aggregator.test.ts
@@ -1,0 +1,27 @@
+describe('Aggregator', () => {
+    test('It should aggregate metrics without throwing.', () => {
+        const { getMetrics } = require('../aggregator');
+        const mockReport = {
+            timings: {
+                tapables: [],
+                loaders: [],
+            },
+            dependencies: {},
+        };
+        const mockStats = {
+            toJson: jest.fn(() => ({
+                modules: [],
+                chunks: [],
+                assets: [],
+                entrypoints: {},
+                warnings: [],
+                errors: [],
+                time: 0,
+            })),
+        };
+        const opts = { context: '', filters: [], tags: [] };
+        expect(() => {
+            getMetrics(mockReport, mockStats, opts);
+        }).not.toThrow();
+    });
+});

--- a/src/hooks/datadog/__tests__/index.test.ts
+++ b/src/hooks/datadog/__tests__/index.test.ts
@@ -2,31 +2,18 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+import { mockStats, mockReport } from '../../../__tests__/testHelpers.ignore';
+
 describe('Datadog Hook', () => {
     const buildPluginMock = {
         options: {},
-    };
-    const statsMock = {
-        modules: [],
-        chunks: [],
-        assets: [],
-        warnings: [],
-        errors: [],
-        entrypoints: {},
-    };
-    const reportMock = {
-        timings: {
-            tapables: {},
-            loaders: {},
-        },
-        dependencies: {},
     };
 
     test('It should not fail given undefined options', async () => {
         const { hooks } = require('../index');
         const obj = await hooks.preoutput.call(buildPluginMock, {
-            report: reportMock,
-            stats: { toJson: () => statsMock },
+            report: mockReport,
+            stats: mockStats,
         });
 
         expect(typeof obj).toBe('object');

--- a/src/hooks/datadog/aggregator.ts
+++ b/src/hooks/datadog/aggregator.ts
@@ -19,6 +19,8 @@ import {
 import { getMetric } from './helpers';
 import { Metric, MetricToSend, GetMetricsOptions } from './types';
 
+const flattened = (arr: any[]) => [].concat(...arr);
+
 const getType = (name: string) => name.split('.').pop();
 
 const getGenerals = (timings: TimingsReport, stats: StatsJson): Metric[] => [
@@ -79,8 +81,8 @@ const getGenerals = (timings: TimingsReport, stats: StatsJson): Metric[] => [
 ];
 
 const getDependencies = (modules: LocalModule[]): Metric[] =>
-    modules
-        .map((m) => [
+    flattened(
+        modules.map((m) => [
             {
                 metric: 'modules.dependencies',
                 type: 'count',
@@ -94,7 +96,7 @@ const getDependencies = (modules: LocalModule[]): Metric[] =>
                 tags: [`moduleName:${m.name}`, `moduleType:${getType(m.name)}`],
             },
         ])
-        .flat(2);
+    );
 
 const getPlugins = (plugins: TapableTimings): Metric[] => {
     const metrics: Metric[] = [];
@@ -145,9 +147,9 @@ const getPlugins = (plugins: TapableTimings): Metric[] => {
     return metrics;
 };
 
-const getLoaders = (loaders: ResultLoaders): Metric[] => {
-    return Object.values(loaders)
-        .map((loader) => [
+const getLoaders = (loaders: ResultLoaders): Metric[] =>
+    flattened(
+        Object.values(loaders).map((loader) => [
             {
                 metric: 'loaders.duration',
                 type: 'duration',
@@ -161,8 +163,7 @@ const getLoaders = (loaders: ResultLoaders): Metric[] => {
                 tags: [`loaderName:${loader.name}`],
             },
         ])
-        .flat(Infinity);
-};
+    );
 
 // Register the imported tree of a module
 const findDependencies = (
@@ -188,8 +189,8 @@ const getModules = (modules: Module[], dependencies: LocalModules, context: stri
         modulesPerName[formatModuleName(module.name, context)] = module;
     }
     const clonedModules: Module[] = [...modules];
-    return clonedModules
-        .map((module) => {
+    return flattened(
+        clonedModules.map((module) => {
             // Modules are sometimes registered with their loader.
             if (module.name.includes('!')) {
                 return [];
@@ -223,12 +224,12 @@ const getModules = (modules: Module[], dependencies: LocalModules, context: stri
                 },
             ];
         })
-        .flat(Infinity);
+    );
 };
 
-const getChunks = (chunks: Chunk[]): Metric[] => {
-    return chunks
-        .map((chunk) => {
+const getChunks = (chunks: Chunk[]): Metric[] =>
+    flattened(
+        chunks.map((chunk) => {
             const chunkName = chunk.names.length ? chunk.names.join(' ') : chunk.id;
             return [
                 {
@@ -245,8 +246,7 @@ const getChunks = (chunks: Chunk[]): Metric[] => {
                 },
             ];
         })
-        .flat(Infinity);
-};
+    );
 
 const getAssets = (assets: Asset[]): Metric[] => {
     return assets.map((asset) => {
@@ -260,9 +260,9 @@ const getAssets = (assets: Asset[]): Metric[] => {
     });
 };
 
-const getEntries = (stats: StatsJson): Metric[] => {
-    return Object.keys(stats.entrypoints)
-        .map((entryName) => {
+const getEntries = (stats: StatsJson): Metric[] =>
+    flattened(
+        Object.keys(stats.entrypoints).map((entryName) => {
             const entry = stats.entrypoints[entryName];
             const chunks = entry.chunks.map(
                 (chunkId) => stats.chunks.find((chunk) => chunk.id === chunkId)!
@@ -303,8 +303,7 @@ const getEntries = (stats: StatsJson): Metric[] => {
                 },
             ];
         })
-        .flat(Infinity);
-};
+    );
 
 export const getMetrics = (
     report: Report,

--- a/src/hooks/datadog/aggregator.ts
+++ b/src/hooks/datadog/aggregator.ts
@@ -306,12 +306,11 @@ const getEntries = (stats: StatsJson): Metric[] => {
         .flat(Infinity);
 };
 
-export const getMetrics = async (
+export const getMetrics = (
     report: Report,
     stats: Stats,
     opts: GetMetricsOptions
-): Promise<MetricToSend[]> => {
-    // TODO use context's stats
+): MetricToSend[] => {
     const statsJson = stats.toJson({ children: false });
     const { timings, dependencies } = report;
     const metrics: Metric[] = [];

--- a/src/hooks/datadog/index.ts
+++ b/src/hooks/datadog/index.ts
@@ -24,7 +24,7 @@ const preoutput = async function output(this: BuildPlugin, { report, stats }: DD
 
     let metrics: MetricToSend[] = [];
     try {
-        metrics = await getMetrics(report, stats, {
+        metrics = getMetrics(report, stats, {
             ...optionsDD,
             context: this.options.context!,
         });


### PR DESCRIPTION
### What and why?

<!-- A short description of what changes this PR introduces and why. -->
Using the build plugin in Yarn's pipeline revealed that the build-plugin doesn't support Node 10.x because of the use of `Array.prototype.flat()`.

### How?

<!-- A brief description of implementation details of this PR. -->
- Use an helper function instead of the native function.
- Run tests on older Node versions.
