### PR TITLE
Add chunkNames to modules output

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -207,7 +207,8 @@ module.exports = {
             {
                 "allowAfterThis": true,
                 "allowAfterSuper": false,
-                "enforceInMethodNames": false
+                "enforceInMethodNames": false,
+                "allow": ["_chunks"]
             }
         ],
         "no-unneeded-ternary": [

--- a/src/__tests__/modules.test.ts
+++ b/src/__tests__/modules.test.ts
@@ -2,7 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import { Module } from '../types';
+import { LocalModule } from '../types';
 
 describe('Modules', () => {
     const { Modules } = require('../modules');
@@ -19,6 +19,7 @@ describe('Modules', () => {
         {
             name: 'moduleWebpack4',
             size: 50,
+            _chunks: new Set([{ name: 'chunk1' }, { name: 'chunk2' }]),
             dependencies: [
                 { name: 'dep1', module: { name: 'dep1' }, size: 1 },
                 { name: 'dep2', size: 2 },
@@ -34,12 +35,20 @@ describe('Modules', () => {
                 getThrowingDependency({ name: 'dep3', size: () => 3 }),
             ],
         },
+        { name: 'dep1', size: () => 1, dependencies: [] },
+        { name: 'dep2', size: () => 2, dependencies: [] },
+        { name: 'dep3', size: () => 3, dependencies: [] },
     ];
 
     const mockCompilation = {
         moduleGraph: {
             getModule(dep: any) {
                 return mockedModules[0].dependencies.find((d) => d.name === dep.name && d.module);
+            },
+        },
+        chunkGraph: {
+            getModuleChunks(module: any) {
+                return mockedModules[0]._chunks;
             },
         },
     };
@@ -56,8 +65,15 @@ describe('Modules', () => {
 
     test('It should add module size to the results', () => {
         const results = modules.getResults();
-        for (const module of Object.values(results.modules) as Module[]) {
+        for (const module of Object.values(results.modules) as LocalModule[]) {
             expect(module.size).toBeDefined();
+        }
+    });
+
+    test('It should add chunk names to the results', () => {
+        const results = modules.getResults();
+        for (const module of Object.values(results.modules) as LocalModule[]) {
+            expect(module.chunkNames).toBeDefined();
         }
     });
 });

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -22,6 +22,10 @@ export class Modules {
             }
         };
 
+        const getChunks = (module: Module): Set<any> => {
+            return module._chunks || compilation.chunkGraph?.getModuleChunks(module);
+        };
+
         for (const module of modules) {
             const moduleName = getModuleName(module, context);
             moduleMap[moduleName] = module;
@@ -43,6 +47,7 @@ export class Modules {
             this.storedModules[moduleName] = {
                 name: getDisplayName(moduleName),
                 size: getModuleSize(module),
+                chunkNames: Array.from(getChunks(module)).map((c) => c.name),
                 dependencies,
                 dependents: [],
             };
@@ -63,6 +68,9 @@ export class Modules {
                     this.storedModules[storedDepName] = {
                         name: storedDepName,
                         size: getModuleSize(moduleMap[storedDepName]),
+                        chunkNames: Array.from(getChunks(moduleMap[storedDepName])).map(
+                            (c) => c.name
+                        ),
                         dependencies: [],
                         dependents: [],
                     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export interface Compilation {
         context: string;
     };
     moduleGraph?: ModuleGraph;
+    chunkGraph?: { getModuleChunks: (module: any) => Set<Chunk> };
     hooks: {
         buildModule: { tap(opts: any, callback: (module: any) => void): void };
         succeedModule: { tap(opts: any, callback: (module: any) => void): void };
@@ -212,6 +213,9 @@ export interface Module {
         loader: string;
     }[];
     chunks: string[];
+    _chunks: Set<{
+        name: string;
+    }>;
     dependencies: Dependency[];
 }
 
@@ -255,6 +259,7 @@ export interface LoadersResult {
 export interface LocalModule {
     name: string;
     size: number;
+    chunkNames: string[];
     dependencies: string[];
     dependents: string[];
 }


### PR DESCRIPTION
### What and why?

<!-- A short description of what changes this PR introduces and why. -->

We're missing chunk names in the modules report.

### How?

<!-- A brief description of implementation details of this PR. -->

Add `chunkNames` information for each module in the report.
Sometime, a module can be in multiple chunks, so it needs to be an array.
