### PR TITLE
Allow object in output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,23 +23,23 @@ Track your build performances like never before.
 <details>
 <summary>Click to expand</summary>
 
--   [Installation](#installation)
--   [Usage](#usage)
--   [Configuration](#configuration)
-    -   [`disabled`](#disabled)
-    -   [`output`](#output)
-    -   [`context`](#context)
--   [Integrations](#integrations)
-    -   [`datadog`](#datadog)
--   [Contributing](#contributing)
-    -   [Clone the repo](#clone-the-repo)
-    -   [Install dependencies](#install-dependencies)
-    -   [Tests](#tests)
-    -   [Formatting, Linting and Compiling](#formatting-linting-and-compiling)
-    -   [Open Source compliance](#open-source-compliance)
-    -   [Documentation](#documentation)
-    -   [Publishing](#publishing)
--   [License](#license)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Configuration](#configuration)
+  - [`disabled`](#disabled)
+  - [`output`](#output)
+  - [`context`](#context)
+- [Integrations](#integrations)
+  - [`datadog`](#datadog)
+- [Contributing](#contributing)
+  - [Clone the repo](#clone-the-repo)
+  - [Install dependencies](#install-dependencies)
+  - [Tests](#tests)
+  - [Formatting, Linting and Compiling](#formatting-linting-and-compiling)
+  - [Open Source compliance](#open-source-compliance)
+  - [Documentation](#documentation)
+  - [Publishing](#publishing)
+- [License](#license)
 
 </details>
 
@@ -92,6 +92,16 @@ If a path, you'll also save json files at this location:
 -   `metrics.json`: an array of all the metrics that would be sent to Datadog.
 -   `stats.json`: the `stats` object of webpack.
 -   `timings.json`: timing data for modules, loaders and plugins.
+
+You can also pass an object of the form:
+
+```javascript
+{
+    destination: 'path/to/destination',
+    timings: true
+}
+```
+To only output a specified file.
 
 ### `context`
 

--- a/src/hooks/__tests__/outputFiles.test.ts
+++ b/src/hooks/__tests__/outputFiles.test.ts
@@ -22,7 +22,7 @@ describe('Output Files', () => {
         );
     };
 
-    const getExistsProms = async (output: string) => {
+    const getExistsProms = (output: string) => {
         return [
             fs.pathExists(path.join(output, 'dependencies.json')),
             fs.pathExists(path.join(output, 'timings.json')),
@@ -40,8 +40,7 @@ describe('Output Files', () => {
             'It should allow an absolute and relative path',
             async (output) => {
                 await init(output, __dirname);
-                const existProms = await getExistsProms(output);
-                const exists = await Promise.all(existProms);
+                const exists = await Promise.all(getExistsProms(output));
 
                 expect(exists.reduce((prev, curr) => prev && curr, true));
             }
@@ -61,11 +60,12 @@ describe('Output Files', () => {
             };
             await init(output, __dirname);
             const destination = output.destination;
+            const exists = await Promise.all(getExistsProms(destination));
 
-            expect(fs.pathExistsSync(path.join(destination, 'dependencies.json'))).toBeFalsy();
-            expect(fs.pathExistsSync(path.join(destination, 'timings.json'))).toBeTruthy();
-            expect(fs.pathExistsSync(path.join(destination, 'stats.json'))).toBeFalsy();
-            expect(fs.pathExistsSync(path.join(destination, 'metrics.json'))).toBeFalsy();
+            expect(exists[0]).toBeFalsy();
+            expect(exists[1]).toBeTruthy();
+            expect(exists[2]).toBeFalsy();
+            expect(exists[3]).toBeFalsy();
         });
     });
 });

--- a/src/hooks/outputFiles.ts
+++ b/src/hooks/outputFiles.ts
@@ -9,36 +9,62 @@ import { HooksContext } from '../types';
 import { BuildPlugin } from '../webpack';
 
 const output = async function output(this: BuildPlugin, { report, metrics, stats }: HooksContext) {
-    if (typeof this.options.output === 'string') {
+    const opts = this.options.output;
+    if (typeof opts === 'string' || typeof opts === 'object') {
         const startWriting = Date.now();
-        const outputPath = path.resolve(this.options.context!, this.options.output);
+        let destination;
+        const files = {
+            timings: true,
+            dependencies: true,
+            stats: true,
+            metrics: true,
+        };
+
+        if (typeof opts === 'object') {
+            destination = opts.destination;
+            files.timings = opts.timings || false;
+            files.dependencies = opts.dependencies || false;
+            files.stats = opts.stats || false;
+            files.metrics = opts.metrics || false;
+        } else {
+            destination = opts;
+        }
+
+        const outputPath = path.resolve(this.options.context!, destination);
 
         try {
             const spaces = '  ';
-            await outputJson(
-                path.join(outputPath, 'timings.json'),
-                {
-                    tapables: report.timings.tapables,
-                    loaders: report.timings.loaders,
-                    modules: report.timings.modules,
-                },
-                { spaces }
-            );
-            this.log(`Wrote timings.json`);
-            await outputJson(path.join(outputPath, 'dependencies.json'), report.dependencies, {
-                spaces,
-            });
-            this.log(`Wrote dependencies.json`);
-            await outputJson(
-                path.join(outputPath, 'stats.json'),
-                stats.toJson({ children: false }),
-                { spaces }
-            );
-            this.log(`Wrote stats.json`);
-            if (metrics) {
+            if (files.timings) {
+                await outputJson(
+                    path.join(outputPath, 'timings.json'),
+                    {
+                        tapables: report.timings.tapables,
+                        loaders: report.timings.loaders,
+                        modules: report.timings.modules,
+                    },
+                    { spaces }
+                );
+                this.log(`Wrote timings.json`);
+            }
+            if (files.dependencies) {
+                await outputJson(path.join(outputPath, 'dependencies.json'), report.dependencies, {
+                    spaces,
+                });
+                this.log(`Wrote dependencies.json`);
+            }
+            if (files.stats) {
+                await outputJson(
+                    path.join(outputPath, 'stats.json'),
+                    stats.toJson({ children: false }),
+                    { spaces }
+                );
+                this.log(`Wrote stats.json`);
+            }
+            if (metrics && files.metrics) {
                 await outputJson(path.join(outputPath, 'metrics.json'), metrics, { spaces });
                 this.log(`Wrote metrics.json`);
             }
+
             this.log(`Wrote files in ${Date.now() - startWriting}ms.`);
         } catch (e) {
             this.log(`Couldn't write files. ${e.toString()}`, 'error');

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,9 +30,20 @@ export interface Options {
     context?: string;
 }
 
+export type OutputOptions =
+    | boolean
+    | string
+    | {
+          destination: string;
+          timings?: boolean;
+          dependencies?: boolean;
+          stats?: boolean;
+          metrics?: boolean;
+      };
+
 export interface LocalOptions {
     disabled?: boolean;
-    output?: boolean | string;
+    output?: OutputOptions;
     context?: string;
     datadog: any;
 }


### PR DESCRIPTION
### What and why?

<!-- A short description of what changes this PR introduces and why. -->

It can take some time to write files depending on their size.
And we don't need all of them.

### How?

<!-- A brief description of implementation details of this PR. -->
Add the possibility to have an object in the `output` option.

```javascript
{
    output: {
        destination: 'path/to/destination/',
        timings: true
    }
}
```

