### PR TITLE
Esbuild plugin fixes

### DIFF
--- a/src/__tests__/esbuild/plugins.test.ts
+++ b/src/__tests__/esbuild/plugins.test.ts
@@ -2,18 +2,15 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import { BaseClass } from '../../BaseClass';
 import { PluginBuild, Plugin } from 'esbuild';
 import { wrapPlugins, getResults } from '../../esbuild/plugins';
 
 describe('esbuild plugins', () => {
-    let baseMock: BaseClass;
     let pluginSetupMock: (build: PluginBuild) => void | Promise<void>;
     let pluginMock: Plugin;
     let buildMock: PluginBuild;
 
     beforeEach(() => {
-        baseMock = new BaseClass();
         pluginSetupMock = jest.fn();
         pluginMock = {
             name: 'Plugin1',
@@ -32,12 +29,12 @@ describe('esbuild plugins', () => {
 
     test('It should wrap plugins', () => {
         expect(pluginMock.setup).toBe(pluginSetupMock);
-        wrapPlugins(baseMock, buildMock);
+        wrapPlugins(buildMock, '');
         expect(pluginMock.setup).not.toBe(pluginSetupMock);
     });
 
     test('It should return results', () => {
-        wrapPlugins(baseMock, buildMock);
+        wrapPlugins(buildMock, '');
         pluginMock.setup(buildMock);
         const results = getResults();
         expect(results.plugins).toBeDefined();

--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -24,7 +24,7 @@ export class BuildPluginClass extends BaseClass {
         const startBuild = Date.now();
         // We force esbuild to produce its metafile.
         build.initialOptions.metafile = true;
-        wrapPlugins(this, build);
+        wrapPlugins(build, this.options.context || process.cwd());
         build.onEnd(async (result: BuildResult) => {
             const { plugins, modules } = getPluginsResults();
             // We know it exists since we're setting the option earlier.

--- a/src/esbuild/plugins.ts
+++ b/src/esbuild/plugins.ts
@@ -23,11 +23,21 @@ const modulesMap: TimingsMap = new Map();
 export const wrapPlugins = (build: PluginBuild, context: string) => {
     const plugins = build.initialOptions.plugins;
     if (plugins) {
+        // We clone plugins so we don't pass modified options to other plugins.
+        const initialPlugins = plugins.map((plugin) => {
+            return {
+                ...plugin,
+            };
+        });
         for (const plugin of plugins) {
             const newBuildObject = getNewBuildObject(build, plugin.name, context);
             const oldSetup = plugin.setup;
             plugin.setup = () => {
-                oldSetup(newBuildObject);
+                oldSetup({
+                    ...newBuildObject,
+                    // Use non-modified plugins for other plugins
+                    initialOptions: { ...newBuildObject.initialOptions, plugins: initialPlugins },
+                });
             };
         }
     }

--- a/src/esbuild/plugins.ts
+++ b/src/esbuild/plugins.ts
@@ -9,7 +9,6 @@ import { performance } from 'perf_hooks';
 
 import { TimingsMap, Timing, Value } from '../types';
 import { getContext, formatModuleName } from '../helpers';
-import { BaseClass } from '../BaseClass';
 
 enum FN_TO_WRAP {
     START = 'onStart',
@@ -21,11 +20,11 @@ enum FN_TO_WRAP {
 const pluginsMap: TimingsMap = new Map();
 const modulesMap: TimingsMap = new Map();
 
-export const wrapPlugins = (self: BaseClass, build: PluginBuild) => {
+export const wrapPlugins = (build: PluginBuild, context: string) => {
     const plugins = build.initialOptions.plugins;
     if (plugins) {
         for (const plugin of plugins) {
-            const newBuildObject = getNewBuildObject(self, build, plugin.name);
+            const newBuildObject = getNewBuildObject(build, plugin.name, context);
             const oldSetup = plugin.setup;
             plugin.setup = () => {
                 oldSetup(newBuildObject);
@@ -35,9 +34,9 @@ export const wrapPlugins = (self: BaseClass, build: PluginBuild) => {
 };
 
 const getNewBuildObject = (
-    self: BaseClass,
     build: PluginBuild,
-    pluginName: string
+    pluginName: string,
+    context: string
 ): PluginBuild => {
     const newBuildObject: any = Object.assign({}, build);
     for (const fn of Object.values(FN_TO_WRAP)) {
@@ -55,8 +54,7 @@ const getNewBuildObject = (
             };
 
             return build[fn](opts, async (...args: any[]) => {
-                // console.log(`${pluginName} on ${fn} has path?`, args[0].path ? 'true' : 'false');
-                const modulePath = formatModuleName(args[0].path, self.options.context!);
+                const modulePath = formatModuleName(args[0].path, context);
                 const moduleTiming: Timing = modulesMap.get(modulePath) || {
                     name: modulePath,
                     increment: 0,


### PR DESCRIPTION
### What and why?

- Our plugin is passing down modified plugins to others which is not great citizenship.
- Computation of the context used in the plugin is weirdly passed down and complexify some calls.

### How?

- Pass down an unmodified array of plugins in the event callbacks of other plugins.
- Simplify context creation and computation.
