### PR TITLE
[esbuild] add chunknames to esbuild results

### DIFF
--- a/src/__tests__/esbuild/modules.test.ts
+++ b/src/__tests__/esbuild/modules.test.ts
@@ -13,4 +13,11 @@ describe('esbuild modules', () => {
             expect(module.size).toBeDefined();
         }
     });
+
+    test('It should add chunkNames to the results', () => {
+        const results = getModulesResults(mockLocalOptions, mockMetaFile);
+        for (const module of Object.values(results) as LocalModule[]) {
+            expect(module.chunkNames.length).not.toBe(0);
+        }
+    });
 });

--- a/src/__tests__/helpers/testHelpers.ts
+++ b/src/__tests__/helpers/testHelpers.ts
@@ -80,8 +80,25 @@ export const mockMetaFile: Metafile = {
             bytes: 1,
             imports: [],
         },
+        module2: {
+            bytes: 1,
+            imports: [],
+        },
     },
-    outputs: {},
+    outputs: {
+        module1: {
+            imports: [],
+            exports: [],
+            inputs: { module2: { bytesInOutput: 0 } },
+            bytes: 0,
+        },
+        module2: {
+            imports: [],
+            exports: [],
+            inputs: { module1: { bytesInOutput: 0 } },
+            bytes: 0,
+        },
+    },
 };
 
 export const mockLocalOptions: LocalOptions = {

--- a/src/esbuild/modules.ts
+++ b/src/esbuild/modules.ts
@@ -21,11 +21,42 @@ export const getModulesResults = (options: LocalOptions, esbuildMeta?: Metafile)
     if (!esbuildMeta) {
         return {};
     }
+
+    // Indexing chunks so we can access them faster.
+    const outputs = esbuildMeta.outputs;
+    const chunkIndexedSets: Record<string, Set<string>> = {};
+    const chunkIndexed: Record<string, string[]> = {};
+    const parseModules = (chunkName: string, moduleName: string) => {
+        const formatedModuleName = formatModuleName(moduleName, context);
+        chunkIndexedSets[formatedModuleName] = chunkIndexedSets[formatedModuleName] || new Set();
+        const formatedChunkName = chunkName.split('/').pop()?.split('.').shift() || 'unknown';
+        chunkIndexedSets[formatedModuleName].add(formatedChunkName);
+
+        if (outputs[moduleName] && outputs[moduleName].inputs.length) {
+            for (const inputModuleName of Object.keys(outputs[moduleName].inputs)) {
+                parseModules(moduleName, inputModuleName);
+            }
+        }
+    };
+
+    for (const [chunkName, chunk] of Object.entries(outputs)) {
+        for (const moduleName of Object.keys(chunk.inputs)) {
+            parseModules(chunkName, moduleName);
+        }
+    }
+
+    for (const key of Object.keys(chunkIndexedSets)) {
+        chunkIndexed[key] = Array.from(chunkIndexedSets[key]);
+    }
+
     for (const [path, obj] of Object.entries(esbuildMeta.inputs)) {
         const moduleName = formatModuleName(path, context);
         const module: LocalModule = modulesMap[moduleName] || getDefaultLocalModule(moduleName);
 
         module.size = obj.bytes;
+        if (chunkIndexed[moduleName]) {
+            module.chunkNames = chunkIndexed[moduleName];
+        }
 
         for (const dependency of obj.imports) {
             const depName = formatModuleName(dependency.path, context);

--- a/src/esbuild/modules.ts
+++ b/src/esbuild/modules.ts
@@ -24,13 +24,12 @@ export const getModulesResults = (options: LocalOptions, esbuildMeta?: Metafile)
 
     // Indexing chunks so we can access them faster.
     const outputs = esbuildMeta.outputs;
-    const chunkIndexedSets: Record<string, Set<string>> = {};
-    const chunkIndexed: Record<string, string[]> = {};
+    const chunkIndexed: Record<string, Set<string>> = {};
     const parseModules = (chunkName: string, moduleName: string) => {
         const formatedModuleName = formatModuleName(moduleName, context);
-        chunkIndexedSets[formatedModuleName] = chunkIndexedSets[formatedModuleName] || new Set();
+        chunkIndexed[formatedModuleName] = chunkIndexed[formatedModuleName] || new Set();
         const formatedChunkName = chunkName.split('/').pop()?.split('.').shift() || 'unknown';
-        chunkIndexedSets[formatedModuleName].add(formatedChunkName);
+        chunkIndexed[formatedModuleName].add(formatedChunkName);
 
         if (outputs[moduleName] && outputs[moduleName].inputs.length) {
             for (const inputModuleName of Object.keys(outputs[moduleName].inputs)) {
@@ -45,17 +44,13 @@ export const getModulesResults = (options: LocalOptions, esbuildMeta?: Metafile)
         }
     }
 
-    for (const key of Object.keys(chunkIndexedSets)) {
-        chunkIndexed[key] = Array.from(chunkIndexedSets[key]);
-    }
-
     for (const [path, obj] of Object.entries(esbuildMeta.inputs)) {
         const moduleName = formatModuleName(path, context);
         const module: LocalModule = modulesMap[moduleName] || getDefaultLocalModule(moduleName);
 
         module.size = obj.bytes;
         if (chunkIndexed[moduleName]) {
-            module.chunkNames = chunkIndexed[moduleName];
+            module.chunkNames = Array.from(chunkIndexed[moduleName]);
         }
 
         for (const dependency of obj.imports) {


### PR DESCRIPTION
### What and why?

<!-- A short description of what changes this PR introduces and why. -->

Esbuild was missing `chunkNames` on its modules.

### How?

<!-- A brief description of implementation details of this PR. -->

Add `chunkNames` to each module.
