### PR TITLE
[peerDependencies] mark as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,13 @@
     "peerDependencies": {
         "esbuild": "*",
         "webpack": "*"
+    },
+    "peerDependenciesMeta": {
+        "esbuild": {
+            "optional": true
+        },
+        "webpack": {
+            "optional": true
+        }
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -442,6 +442,11 @@ __metadata:
   peerDependencies:
     esbuild: "*"
     webpack: "*"
+  peerDependenciesMeta:
+    esbuild:
+      optional: true
+    webpack:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### What and why?

Let's say you only use `webpack` and you want to use `@datadog/build-plugin`, most package managers will still send a warning because of unmet peer deps on `esbuild`.

And same for the other way.


### How?

Use `peerDependenciesMeta` supported by all package managers ([npm](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependenciesmeta), [yarn](https://yarnpkg.com/configuration/manifest#peerDependenciesMeta), and [pnpm](https://pnpm.io/package_json#peerdependenciesmeta)) to mark `webpack` & `esbuild` as optional
