### PR TITLE
[debug] Enable build reports output in CI and improve logging

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,6 +163,14 @@ jobs:
         DD_GITHUB_JOB_NAME: Linting # Needs to be the same as the job to have CI Vis link the spans.
         DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
 
+    - uses: actions/upload-artifact@v4
+      if: steps.cache-build.outputs.cache-hit != 'true'
+      with:
+        name: build-reports
+        path: |
+          packages/published/*/dist/reports
+        retention-days: 1
+
     - run: yarn cli integrity
 
     - run: git diff --exit-code && git diff --cached --exit-code || (echo "Please run 'yarn cli integrity' and commit the result." && exit 1)

--- a/packages/plugins/metrics/src/index.test.ts
+++ b/packages/plugins/metrics/src/index.test.ts
@@ -85,10 +85,10 @@ describe('Metrics Universal Plugin', () => {
     ];
 
     beforeAll(() => {
-        nock(`https://${FAKE_SITE}`)
+        nock(new RegExp(`${FAKE_SITE.replace('.', '\\.')}`))
             .persist()
             // Intercept metrics submissions.
-            .post(`/${METRICS_API_PATH}?api_key=123`)
+            .post(new RegExp(`${METRICS_API_PATH.replace('/', '\\/')}`))
             .reply(200, {});
     });
 

--- a/packages/plugins/output/src/index.ts
+++ b/packages/plugins/output/src/index.ts
@@ -117,7 +117,7 @@ export const getPlugins: GetPlugins = ({ options, context }) => {
             if (error) {
                 log.error(`Failed writing ${fileValue}: ${error}`);
             } else {
-                log.info(`Wrote "${filePath}"`);
+                log.info(`Wrote "./${path.relative(context.buildRoot, filePath)}"`);
             }
 
             timeWrite.end();

--- a/packages/tools/src/rollupConfig.mjs
+++ b/packages/tools/src/rollupConfig.mjs
@@ -101,6 +101,7 @@ const getPluginConfig = (bundlerName, buildName, addMetrics = false) => {
         metadata: {
             name: buildName,
         },
+        output: { enable: true, path: `../reports/${cleanBuildName}` },
         metrics: addMetrics
             ? {
                   tags: [


### PR DESCRIPTION
- Enable build report output in rollupConfig for all local builds
- Configure reports to output to ../reports/{buildName} directory
- Add GitHub Actions artifact upload for build reports with 1-day retention
- Improve output plugin logging to show relative paths instead of absolute paths
- Reports are now uploaded as CI artifacts for inspection
- Better intercept requests in metrics plugins tests to avoid having error logs in CI
