### PR TITLE
[fix] Fix build-report path and filename cleaning for bundlers' specificities

### DIFF
--- a/packages/plugins/build-report/src/xpack.ts
+++ b/packages/plugins/build-report/src/xpack.ts
@@ -14,7 +14,7 @@ import type {
     PluginOptions,
 } from '@dd/core/types';
 
-import { cleanName, cleanPath, getType } from './helpers';
+import { cleanIdentifier, cleanName, cleanPath, getType } from './helpers';
 
 export const getXpackPlugin =
     (
@@ -264,10 +264,12 @@ export const getXpackPlugin =
                             depDeps.dependents.add(moduleIdentifier);
                             moduleDeps.dependencies.add(depIdentifier);
                             tempDeps.set(depIdentifier, depDeps);
+                            tempDeps.set(cleanIdentifier(depIdentifier), depDeps);
                         }
 
                         // Store the dependencies.
                         tempDeps.set(moduleIdentifier, moduleDeps);
+                        tempDeps.set(cleanIdentifier(moduleIdentifier), moduleDeps);
 
                         // Store the inputs.
                         const file: Input = isExternal(module)
@@ -276,7 +278,7 @@ export const getXpackPlugin =
                                   name: cleanExternalName(moduleName),
                                   dependencies: new Set(),
                                   dependents: new Set(),
-                                  filepath: moduleIdentifier,
+                                  filepath: cleanIdentifier(moduleIdentifier),
                                   type: 'external',
                               }
                             : {
@@ -284,7 +286,7 @@ export const getXpackPlugin =
                                   name: moduleName,
                                   dependencies: new Set(),
                                   dependents: new Set(),
-                                  filepath: moduleIdentifier,
+                                  filepath: cleanIdentifier(moduleIdentifier),
                                   type: getType(moduleIdentifier),
                               };
 


### PR DESCRIPTION
- Extract `cleanIdentifier()` function to handle webpack loader prefixes (! and |)
- Fix QUERY_RX to only match actual query parameters (? and %3F), not pipe characters
- Apply cleanIdentifier() to module identifiers before storing in build report
- Store both original and cleaned identifiers in tempDeps map for proper lookups
- Ensures build report correctly tracks dependencies with webpack loader syntax
