### PR TITLE
Gate reports behind BUILD_PLUGINS_DEBUG

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,9 +157,10 @@ jobs:
 
     - name: Build all plugins
       if: steps.cache-build.outputs.cache-hit != 'true'
-      run: BUILD_PLUGINS_DEBUG=1 yarn build:all-no-types
+      run: yarn build:all-no-types
       env:
         ADD_BUILD_PLUGINS: 1
+        BUILD_PLUGINS_REPORTS: 1
         DD_GITHUB_JOB_NAME: Linting # Needs to be the same as the job to have CI Vis link the spans.
         DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
 

--- a/global.d.ts
+++ b/global.d.ts
@@ -20,7 +20,7 @@ declare global {
             /**
              * Add JSON reports to the build through the output plugin.
              */
-            BUILD_PLUGINS_DEBUG?: '1';
+            BUILD_PLUGINS_REPORTS?: '1';
             /**
              * The environment in which the plugins will execute.
              *

--- a/packages/tools/src/rollupConfig.mjs
+++ b/packages/tools/src/rollupConfig.mjs
@@ -93,7 +93,7 @@ export const bundle = (packageJson, config) => ({
 const getPluginConfig = (bundlerName, buildName, addMetrics = false) => {
     const cleanBuildName = buildName.toLowerCase().replace(/@/g, '').replace(/[ /:]/g, '-');
     const packageName = `${bundlerName}-plugin`;
-    const enableReports = !!process.env.BUILD_PLUGINS_DEBUG;
+    const enableReports = !!process.env.BUILD_PLUGINS_REPORTS;
     return {
         auth: {
             apiKey: process.env.DATADOG_API_KEY,


### PR DESCRIPTION
### What and why?

<!-- A short description of what changes this PR introduces and why. -->

The package went from 692kb to 3.6mb 😱

v3.0.4:
<img width="136" height="72" alt="image" src="https://github.com/user-attachments/assets/98046b98-8557-492a-a075-f8a77cd90562" />

v3.0.5:
<img width="142" height="70" alt="image" src="https://github.com/user-attachments/assets/4a603df9-069a-4739-93ab-93a9ba2a93da" />

Because of https://github.com/DataDog/build-plugins/pull/236, the reports are included in the release.

### How?

<!-- A brief description of implementation details of this PR. -->

Gate the reports behind `BUILD_PLUGINS_DEBUG`.
