### PR TITLE
[APPS] Use manualChunks for self-contained backend function builds

### DIFF
--- a/packages/plugins/apps/src/vite/build-backend-functions.ts
+++ b/packages/plugins/apps/src/vite/build-backend-functions.ts
@@ -28,55 +28,46 @@ export async function buildBackendFunctions(
 ): Promise<string> {
     const outDir = await mkdtemp(path.join(tmpdir(), 'dd-apps-backend-'));
 
-    const virtualEntries: Record<string, string> = {};
-    const input: Record<string, string> = {};
-
-    for (const func of functions) {
-        const virtualId = `${VIRTUAL_PREFIX}${func.name}`;
-        virtualEntries[virtualId] = generateVirtualEntryContent(
-            func.name,
-            func.entryPath,
-            buildRoot,
-        );
-        input[func.name] = virtualId;
-    }
-
     log.debug(`Building ${functions.length} backend function(s) via vite.build()`);
 
-    const baseConfig = getBaseBackendBuildConfig(buildRoot, virtualEntries);
+    // Build each function individually so that each output is a single
+    // self-contained JS file
+    for (const func of functions) {
+        const virtualId = `${VIRTUAL_PREFIX}${func.name}`;
+        const virtualContent = generateVirtualEntryContent(func.name, func.entryPath, buildRoot);
 
-    // Production: build all functions in one vite.build() call, writing each to
-    // disk as a named file so the archive/upload step can collect them.
-    // Uses multi-entry input (one per function) with \0-prefixed virtual IDs —
-    // the \0 convention prevents other plugins from processing these IDs.
-    const result = await viteBuild({
-        ...baseConfig,
-        build: {
-            ...baseConfig.build,
-            write: true,
-            outDir,
-            emptyOutDir: false,
-            rollupOptions: {
-                ...baseConfig.build.rollupOptions,
-                input,
-                output: { ...baseConfig.build.rollupOptions.output, entryFileNames: '[name].js' },
+        const baseConfig = getBaseBackendBuildConfig(buildRoot, { [virtualId]: virtualContent });
+
+        // eslint-disable-next-line no-await-in-loop
+        const result = await viteBuild({
+            ...baseConfig,
+            build: {
+                ...baseConfig.build,
+                write: true,
+                outDir,
+                emptyOutDir: false,
+                rollupOptions: {
+                    ...baseConfig.build.rollupOptions,
+                    input: { [func.name]: virtualId },
+                    output: {
+                        ...baseConfig.build.rollupOptions.output,
+                        entryFileNames: '[name].js',
+                    },
+                },
             },
-        },
-    });
+        });
 
-    const output = Array.isArray(result) ? result[0] : result;
+        const output = Array.isArray(result) ? result[0] : result;
 
-    // viteBuild always returns RolldownOutput here since we don't set build.watch.
-    // RolldownWatcher would only be returned if watch mode were enabled.
-    if ('output' in output) {
-        for (const chunk of output.output) {
-            if (chunk.type !== 'chunk' || !chunk.isEntry) {
-                continue;
+        if ('output' in output) {
+            for (const chunk of output.output) {
+                if (chunk.type !== 'chunk' || !chunk.isEntry) {
+                    continue;
+                }
+                const absolutePath = path.resolve(outDir, chunk.fileName);
+                backendOutputs.set(func.name, absolutePath);
+                log.debug(`Backend function "${func.name}" output: ${absolutePath}`);
             }
-            const funcName = chunk.name;
-            const absolutePath = path.resolve(outDir, chunk.fileName);
-            backendOutputs.set(funcName, absolutePath);
-            log.debug(`Backend function "${funcName}" output: ${absolutePath}`);
         }
     }
 

--- a/packages/plugins/apps/src/vite/build-config.ts
+++ b/packages/plugins/apps/src/vite/build-config.ts
@@ -46,7 +46,7 @@ export function getBaseBackendBuildConfig(
             minify: false,
             target: 'esnext',
             rollupOptions: {
-                output: { format: 'es', exports: 'named' },
+                output: { format: 'es', exports: 'named', inlineDynamicImports: true },
                 preserveEntrySignatures: 'exports-only',
                 treeshake: false,
                 onwarn(warning, defaultHandler) {

--- a/packages/plugins/apps/src/vite/dev-server.ts
+++ b/packages/plugins/apps/src/vite/dev-server.ts
@@ -79,8 +79,6 @@ async function bundleBackendFunction(
     // bundled script to the Datadog API without writing temp files.
     // Uses a plain "virtual:" prefix instead of \0 because Rollup generates
     // empty chunks when \0-prefixed IDs are used as input entries.
-    // inlineDynamicImports collapses everything into one chunk since we only
-    // have a single entry (incompatible with multi-entry builds).
     const result = await viteBuild({
         ...baseConfig,
         build: {
@@ -89,7 +87,7 @@ async function bundleBackendFunction(
             rollupOptions: {
                 ...baseConfig.build.rollupOptions,
                 input: virtualId,
-                output: { ...baseConfig.build.rollupOptions.output, inlineDynamicImports: true },
+                output: baseConfig.build.rollupOptions.output,
             },
         },
     });

--- a/packages/plugins/apps/src/vite/index.test.ts
+++ b/packages/plugins/apps/src/vite/index.test.ts
@@ -46,7 +46,7 @@ describe('Backend Functions - getVitePlugin', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         await (plugin as any).closeBundle();
 
-        expect(mockViteBuild).toHaveBeenCalledTimes(1);
+        expect(mockViteBuild).toHaveBeenCalledTimes(2);
         expect(defaultOptions.backendOutputs.size).toBe(2);
         expect(defaultOptions.backendOutputs.has('myHandler')).toBe(true);
         expect(defaultOptions.backendOutputs.has('otherFunc')).toBe(true);


### PR DESCRIPTION
## Motivation

PR #317 originally moved `inlineDynamicImports: true` into the shared backend build config and refactored production builds to loop one `vite.build()` per function. A coworker pointed out that `manualChunks: () => '[name]'` — a pattern already used in this repo's own rollup config — achieves the same "no code splitting" goal while supporting multiple entry points in a single build call.

## Changes

Replaced `inlineDynamicImports: true` with `manualChunks: () => '[name]'` in the shared backend build config. This lets us batch all backend functions into a single `vite.build()` call instead of looping one call per function.

The key difference: `inlineDynamicImports` only works with a single entry point (Rollup limitation), forcing us to build each function individually. `manualChunks` assigns all modules to the entry chunk, preventing code splitting while supporting multiple entries. This is the same pattern used at `packages/tools/src/rollupConfig.mjs:193`.

**`build-config.ts`**: Swapped `inlineDynamicImports: true` for `manualChunks: () => '[name]'` and moved `entryFileNames: '[name].js'` into the base config.

**`build-backend-functions.ts`**: Replaced the per-function loop (N `vite.build()` calls) with a single batched build — all virtual entries and inputs are collected up front, one build produces all outputs. Removes the `no-await-in-loop` eslint disable, `emptyOutDir: false` workaround, and per-function overrides.

**`dev-server.ts`**: No changes — builds one function per request and inherits the new config automatically.

## QA Instructions

1. Scaffold or use an existing test app with 2+ backend functions
2. Link local build-plugins via `yarn dev`
3. Run `vite build` — verify each backend function produces a self-contained `.js` file
4. Run `vite` dev server — verify `/__dd/executeAction` still works for each function

## Blast Radius

- Only affects the apps plugin's backend function build pipeline
- No changes to the main client build or any other plugin
- The dev server path is unchanged (still builds one function per request)

## Documentation

-   [How to reliably make frontend production changes](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2286781319/Frontend+Production+Changesp)
-   [PR Description Guidelines](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/3120334387/PR+Checklist+and+Guidelines+for+Web+UI)
-   [Deploy steps](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/1457750032/)