### PR TITLE
[APPS] Add BackendFunctionRef, hashed query names, and proxy codegen

### DIFF
--- a/packages/plugins/apps/package.json
+++ b/packages/plugins/apps/package.json
@@ -23,7 +23,9 @@
     },
     "dependencies": {
         "@dd/core": "workspace:*",
+        "acorn": "8.14.0",
         "chalk": "2.3.1",
+        "esbuild": "0.25.8",
         "glob": "11.1.0",
         "jszip": "3.10.1",
         "pretty-bytes": "5.6.0"

--- a/packages/plugins/apps/src/backend/discovery.test.ts
+++ b/packages/plugins/apps/src/backend/discovery.test.ts
@@ -66,9 +66,7 @@ describe('Backend Functions - discoverExportedFunctions', () => {
     });
 
     test('Should discover exported const arrow functions', () => {
-        readFileSpy.mockReturnValue(
-            'export const add = (a: number, b: number): number => a + b;',
-        );
+        readFileSpy.mockReturnValue('export const add = (a: number, b: number): number => a + b;');
 
         const result = discoverExportedFunctions('/project/src/math.backend.ts');
         expect(result).toEqual(['add']);

--- a/packages/plugins/apps/src/backend/discovery.test.ts
+++ b/packages/plugins/apps/src/backend/discovery.test.ts
@@ -2,158 +2,184 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import { discoverBackendFunctions } from '@dd/apps-plugin/backend/discovery';
-import { getMockLogger, mockLogFn } from '@dd/tests/_jest/helpers/mocks';
+import {
+    discoverBackendFunctions,
+    discoverExportedFunctions,
+} from '@dd/apps-plugin/backend/discovery';
+import { getMockLogger } from '@dd/tests/_jest/helpers/mocks';
 import fs from 'fs';
-import path from 'path';
+import { globSync } from 'glob';
+
+jest.mock('glob');
 
 const log = getMockLogger();
-const backendDir = '/project/backend';
+const projectRoot = '/project';
 
-const fileStat = { isDirectory: () => false, isFile: () => true };
-const dirStat = { isDirectory: () => true, isFile: () => false };
+const mockedGlobSync = jest.mocked(globSync);
 
-describe('Backend Functions - discoverBackendFunctions', () => {
-    let readdirSpy: jest.SpyInstance;
-    let statSpy: jest.SpyInstance;
+describe('Backend Functions - discoverExportedFunctions', () => {
+    let readFileSpy: jest.SpyInstance;
 
     beforeEach(() => {
-        readdirSpy = jest.spyOn(fs, 'readdirSync');
-        statSpy = jest.spyOn(fs, 'statSync');
+        readFileSpy = jest.spyOn(fs, 'readFileSync');
     });
 
     afterEach(() => {
         jest.restoreAllMocks();
     });
 
-    describe('file discovery', () => {
-        const cases = [
-            {
-                description: 'discover a single .ts file',
-                entries: ['handler.ts'],
-                stats: { [path.join(backendDir, 'handler.ts')]: fileStat },
-                expected: [{ name: 'handler', entryPath: path.join(backendDir, 'handler.ts') }],
-            },
-            {
-                description: 'discover a single .js file',
-                entries: ['handler.js'],
-                stats: { [path.join(backendDir, 'handler.js')]: fileStat },
-                expected: [{ name: 'handler', entryPath: path.join(backendDir, 'handler.js') }],
-            },
-            {
-                description: 'discover a directory with index.ts',
-                entries: ['myFunc'],
-                stats: {
-                    [path.join(backendDir, 'myFunc')]: dirStat,
-                    [path.join(backendDir, 'myFunc', 'index.ts')]: fileStat,
-                },
-                expected: [
-                    {
-                        name: 'myFunc',
-                        entryPath: path.join(backendDir, 'myFunc', 'index.ts'),
-                    },
-                ],
-            },
-            {
-                description: 'discover multiple functions (mix of files and directories)',
-                entries: ['handler.ts', 'myFunc'],
-                stats: {
-                    [path.join(backendDir, 'handler.ts')]: fileStat,
-                    [path.join(backendDir, 'myFunc')]: dirStat,
-                    [path.join(backendDir, 'myFunc', 'index.ts')]: fileStat,
-                },
-                expected: [
-                    { name: 'handler', entryPath: path.join(backendDir, 'handler.ts') },
-                    {
-                        name: 'myFunc',
-                        entryPath: path.join(backendDir, 'myFunc', 'index.ts'),
-                    },
-                ],
-            },
-            {
-                description: 'skip non-matching extensions',
-                entries: ['config.json', 'styles.css', 'handler.ts'],
-                stats: {
-                    [path.join(backendDir, 'config.json')]: fileStat,
-                    [path.join(backendDir, 'styles.css')]: fileStat,
-                    [path.join(backendDir, 'handler.ts')]: fileStat,
-                },
-                expected: [{ name: 'handler', entryPath: path.join(backendDir, 'handler.ts') }],
-            },
-            {
-                description: 'skip directory with no valid index file',
-                entries: ['emptyDir'],
-                stats: {
-                    [path.join(backendDir, 'emptyDir')]: dirStat,
-                },
-                expected: [],
-            },
-            {
-                description: 'return empty array for empty directory',
-                entries: [],
-                stats: {},
-                expected: [],
-            },
-        ];
+    test('Should discover named exports', () => {
+        readFileSpy.mockReturnValue(
+            'export function add(a: number, b: number): number { return a + b; }\nexport function multiply(a: number, b: number): number { return a * b; }',
+        );
 
-        test.each(cases)('Should $description', ({ entries, stats, expected }) => {
-            readdirSpy.mockReturnValue(entries);
-            statSpy.mockImplementation((p: string) => {
-                const stat = stats[p];
-                if (!stat) {
-                    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
-                }
-                return stat;
-            });
-
-            const result = discoverBackendFunctions(backendDir, log);
-            expect(result).toEqual(expected);
-        });
+        const result = discoverExportedFunctions('/project/src/math.backend.ts');
+        expect(result).toEqual(['add', 'multiply']);
+        expect(readFileSpy).toHaveBeenCalledWith('/project/src/math.backend.ts', 'utf-8');
     });
 
-    describe('error handling', () => {
-        test('Should return empty array and log debug when directory does not exist', () => {
-            readdirSpy.mockImplementation(() => {
-                throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
-            });
+    test('Should filter out type exports', () => {
+        readFileSpy.mockReturnValue(
+            'export function add(a: number, b: number): number { return a + b; }\nexport type MathResult = { value: number };',
+        );
 
-            const result = discoverBackendFunctions('/nonexistent', log);
-            expect(result).toEqual([]);
-            expect(mockLogFn).toHaveBeenCalledWith(
-                expect.stringContaining('No backend directory found'),
-                'debug',
-            );
-        });
-
-        test('Should rethrow non-ENOENT errors', () => {
-            readdirSpy.mockImplementation(() => {
-                throw Object.assign(new Error('EACCES'), { code: 'EACCES' });
-            });
-
-            expect(() => discoverBackendFunctions(backendDir, log)).toThrow('EACCES');
-        });
+        const result = discoverExportedFunctions('/project/src/math.backend.ts');
+        expect(result).toEqual(['add']);
     });
 
-    describe('extension priority', () => {
-        test('Should prefer .ts over .js for directory index', () => {
-            readdirSpy.mockReturnValue(['myFunc']);
-            statSpy.mockImplementation((p) => {
-                if (p === path.join(backendDir, 'myFunc')) {
-                    return dirStat;
-                }
-                if (p === path.join(backendDir, 'myFunc', 'index.ts')) {
-                    return fileStat;
-                }
-                throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
-            });
+    test('Should filter out export interface', () => {
+        readFileSpy.mockReturnValue(
+            'export function greet(name: string): string { return name; }\nexport interface Config { timeout: number; }',
+        );
 
-            const result = discoverBackendFunctions(backendDir, log);
-            expect(result).toEqual([
-                {
-                    name: 'myFunc',
-                    entryPath: path.join(backendDir, 'myFunc', 'index.ts'),
-                },
-            ]);
+        const result = discoverExportedFunctions('/project/src/greet.backend.ts');
+        expect(result).toEqual(['greet']);
+    });
+
+    test('Should filter out inline type specifiers in export blocks', () => {
+        readFileSpy.mockReturnValue(
+            'function add(a: number, b: number): number { return a + b; }\ntype Foo = string;\nexport { type Foo, add };',
+        );
+
+        const result = discoverExportedFunctions('/project/src/math.backend.ts');
+        expect(result).toEqual(['add']);
+    });
+
+    test('Should discover exported const arrow functions', () => {
+        readFileSpy.mockReturnValue(
+            'export const add = (a: number, b: number): number => a + b;',
+        );
+
+        const result = discoverExportedFunctions('/project/src/math.backend.ts');
+        expect(result).toEqual(['add']);
+    });
+
+    test('Should throw on default exports', () => {
+        readFileSpy.mockReturnValue('export default function handler() { return 1; }');
+
+        expect(() => discoverExportedFunctions('/project/src/math.backend.ts')).toThrow(
+            'Default exports are not supported in .backend.ts files',
+        );
+    });
+
+    test('Should return empty array for files with no exports', () => {
+        readFileSpy.mockReturnValue('function internal() { return 1; }');
+
+        const result = discoverExportedFunctions('/project/src/empty.backend.ts');
+        expect(result).toEqual([]);
+    });
+});
+
+describe('Backend Functions - discoverBackendFunctions', () => {
+    let readFileSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        readFileSpy = jest.spyOn(fs, 'readFileSync');
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('Should discover .backend.ts files via glob and parse their exports', () => {
+        mockedGlobSync.mockReturnValue([
+            '/project/src/utils/mathUtils.backend.ts',
+            '/project/src/auth/login.backend.ts',
+        ] as any);
+        readFileSpy
+            .mockReturnValueOnce(
+                'export function add() { return 1; }\nexport function multiply() { return 2; }',
+            )
+            .mockReturnValueOnce('export function login() { return true; }');
+
+        const result = discoverBackendFunctions(projectRoot, log);
+
+        expect(result).toEqual([
+            {
+                ref: { path: 'src/utils/mathUtils', name: 'add' },
+                entryPath: '/project/src/utils/mathUtils.backend.ts',
+            },
+            {
+                ref: { path: 'src/utils/mathUtils', name: 'multiply' },
+                entryPath: '/project/src/utils/mathUtils.backend.ts',
+            },
+            {
+                ref: { path: 'src/auth/login', name: 'login' },
+                entryPath: '/project/src/auth/login.backend.ts',
+            },
+        ]);
+    });
+
+    test('Should return empty array when no .backend.ts files exist', () => {
+        mockedGlobSync.mockReturnValue([]);
+
+        const result = discoverBackendFunctions(projectRoot, log);
+        expect(result).toEqual([]);
+    });
+
+    test('Should skip files with no exports', () => {
+        mockedGlobSync.mockReturnValue(['/project/src/empty.backend.ts'] as any);
+        readFileSpy.mockReturnValue('function internal() {}');
+
+        const result = discoverBackendFunctions(projectRoot, log);
+        expect(result).toEqual([]);
+    });
+
+    test('Should continue when a file fails to parse', () => {
+        mockedGlobSync.mockReturnValue([
+            '/project/src/bad.backend.ts',
+            '/project/src/good.backend.ts',
+        ] as any);
+        readFileSpy
+            .mockReturnValueOnce('this is not valid {{ javascript')
+            .mockReturnValueOnce('export function greet() { return "hi"; }');
+
+        const result = discoverBackendFunctions(projectRoot, log);
+        expect(result).toEqual([
+            {
+                ref: { path: 'src/good', name: 'greet' },
+                entryPath: '/project/src/good.backend.ts',
+            },
+        ]);
+    });
+
+    test('Should strip .backend.{ext} to form the ref path', () => {
+        mockedGlobSync.mockReturnValue(['/project/mathUtils.backend.tsx'] as any);
+        readFileSpy.mockReturnValue('export function calc() { return 1; }');
+
+        const result = discoverBackendFunctions(projectRoot, log);
+        expect(result[0].ref.path).toBe('mathUtils');
+    });
+
+    test('Should call globSync with correct pattern and options', () => {
+        mockedGlobSync.mockReturnValue([]);
+
+        discoverBackendFunctions(projectRoot, log);
+
+        expect(mockedGlobSync).toHaveBeenCalledWith('**/*.backend.{ts,tsx,js,jsx}', {
+            cwd: projectRoot,
+            ignore: ['**/node_modules/**', '**/dist/**', '**/.dist/**'],
+            absolute: true,
         });
     });
 });

--- a/packages/plugins/apps/src/backend/discovery.ts
+++ b/packages/plugins/apps/src/backend/discovery.ts
@@ -3,64 +3,147 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import type { Logger } from '@dd/core/types';
+import * as acorn from 'acorn';
+import { createHash } from 'crypto';
+import { transformSync } from 'esbuild';
 import fs from 'fs';
+import { globSync } from 'glob';
 import path from 'path';
 
-export interface BackendFunction {
+export interface BackendFunctionRef {
+    /** Relative path from project root to the .backend.ts file (without extension) */
+    path: string;
+    /** Exported function name */
     name: string;
+}
+
+export interface BackendFunction {
+    /** The BackendFunctionRef identifying this function */
+    ref: BackendFunctionRef;
+    /** Absolute path to the .backend.ts source file */
     entryPath: string;
 }
 
-const EXTENSIONS = ['.ts', '.js', '.tsx', '.jsx'];
+/**
+ * Encode a BackendFunctionRef into an opaque query name string.
+ * Uses a truncated SHA-256 hash of the path so that backend file structure
+ * is never leaked into frontend assets.
+ *
+ * This is the single source of truth for query name encoding — used by
+ * proxy codegen, the production build, and the dev server.
+ */
+export function encodeQueryName(ref: BackendFunctionRef): string {
+    const pathHash = createHash('sha256').update(ref.path).digest('hex').slice(0, 12);
+    return `${pathHash}.${ref.name}`;
+}
 
 /**
- * Discover backend functions in the backend directory (sync).
- * Must be sync because it runs in getPlugins() before the build starts.
- *
- * Supports two patterns:
- *   - Single file module: backend/functionName.{ts,js,tsx,jsx}
- *   - Directory module: backend/functionName/index.{ts,js,tsx,jsx}
+ * Discover exported value (non-type) symbols from a `.backend.ts` file.
+ * Uses esbuild to strip TypeScript types, then acorn (the same parser Rollup
+ * uses internally via `this.parse`) to produce an ESTree AST.
  */
-export function discoverBackendFunctions(backendDir: string, log: Logger): BackendFunction[] {
-    let entries: string[];
-    try {
-        entries = fs.readdirSync(backendDir);
-    } catch (error: any) {
-        if (error.code === 'ENOENT') {
-            log.debug(`No backend directory found at ${backendDir}`);
-            return [];
+export function discoverExportedFunctions(filePath: string): string[] {
+    const source = fs.readFileSync(filePath, 'utf-8');
+
+    // Strip TypeScript types with esbuild — this removes `export type`,
+    // `export interface`, `export { type Foo }`, etc.
+    const { code } = transformSync(source, { loader: 'ts', format: 'esm' });
+
+    // Parse the plain JS with acorn (same parser Rollup/Vite use internally).
+    const ast = acorn.parse(code, { sourceType: 'module', ecmaVersion: 'latest' });
+
+    const exports: string[] = [];
+    for (const node of ast.body) {
+        if (node.type === 'ExportNamedDeclaration') {
+            if (node.declaration) {
+                if (node.declaration.type === 'FunctionDeclaration' && node.declaration.id) {
+                    exports.push(node.declaration.id.name);
+                }
+                if (node.declaration.type === 'VariableDeclaration') {
+                    for (const decl of node.declaration.declarations) {
+                        if (decl.id.type === 'Identifier') {
+                            exports.push(decl.id.name);
+                        }
+                    }
+                }
+            }
+            // export { foo, bar } — also the form esbuild normalizes to.
+            // esbuild also normalizes `export default` into `export { x as default }`.
+            for (const spec of node.specifiers) {
+                if (spec.exported.type === 'Identifier') {
+                    if (spec.exported.name === 'default') {
+                        throw new Error(
+                            `Default exports are not supported in .backend.ts files. Use a named export instead: ${filePath}`,
+                        );
+                    }
+                    exports.push(spec.exported.name);
+                }
+            }
         }
-        throw error;
+        // Catch `export default` that wasn't normalized (plain JS input).
+        if (node.type === 'ExportDefaultDeclaration') {
+            throw new Error(
+                `Default exports are not supported in .backend.ts files. Use a named export instead: ${filePath}`,
+            );
+        }
+    }
+    return exports;
+}
+
+/**
+ * Discover backend functions by scanning for `*.backend.ts` files anywhere
+ * in the project (excluding node_modules, dist, etc.).
+ *
+ * Each exported value function in a `.backend.ts` file produces one
+ * `BackendFunction` entry with a `BackendFunctionRef`.
+ *
+ * Must be sync because it runs in getPlugins() before the build starts.
+ */
+export function discoverBackendFunctions(projectRoot: string, log: Logger): BackendFunction[] {
+    const pattern = '**/*.backend.{ts,tsx,js,jsx}';
+    const files = globSync(pattern, {
+        cwd: projectRoot,
+        ignore: ['**/node_modules/**', '**/dist/**', '**/.dist/**'],
+        absolute: true,
+    });
+
+    if (files.length === 0) {
+        log.debug(`No .backend.ts files found in ${projectRoot}`);
+        return [];
     }
 
     const functions: BackendFunction[] = [];
 
-    for (const entry of entries) {
-        const entryPath = path.join(backendDir, entry);
-        const entryStat = fs.statSync(entryPath);
+    for (const absolutePath of files) {
+        const relativePath = path.relative(projectRoot, absolutePath);
+        // Strip the .backend.{ext} suffix to get the path component of BackendFunctionRef
+        const refPath = relativePath.replace(/\.backend\.\w+$/, '');
 
-        if (entryStat.isDirectory()) {
-            for (const ext of EXTENSIONS) {
-                const indexPath = path.join(entryPath, `index${ext}`);
-                try {
-                    fs.statSync(indexPath);
-                    functions.push({ name: entry, entryPath: indexPath });
-                    break;
-                } catch {
-                    // Try next extension
-                }
-            }
-        } else if (entryStat.isFile()) {
-            const ext = path.extname(entry);
-            if (EXTENSIONS.includes(ext)) {
-                const name = path.basename(entry, ext);
-                functions.push({ name, entryPath });
-            }
+        let exportNames: string[];
+        try {
+            exportNames = discoverExportedFunctions(absolutePath);
+        } catch (error) {
+            log.error(
+                `Failed to parse exports from ${relativePath}: ${error instanceof Error ? error.message : String(error)}`,
+            );
+            continue;
+        }
+
+        if (exportNames.length === 0) {
+            log.debug(`No exported functions found in ${relativePath}`);
+            continue;
+        }
+
+        for (const exportName of exportNames) {
+            functions.push({
+                ref: { path: refPath, name: exportName },
+                entryPath: absolutePath,
+            });
         }
     }
 
     log.debug(
-        `Discovered ${functions.length} backend function(s): ${functions.map((f) => f.name).join(', ')}`,
+        `Discovered ${functions.length} backend function(s): ${functions.map((f) => `${f.ref.path}/${f.ref.name}`).join(', ')}`,
     );
     return functions;
 }

--- a/packages/plugins/apps/src/backend/discovery.ts
+++ b/packages/plugins/apps/src/backend/discovery.ts
@@ -26,14 +26,14 @@ export interface BackendFunction {
 
 /**
  * Encode a BackendFunctionRef into an opaque query name string.
- * Uses a truncated SHA-256 hash of the path so that backend file structure
+ * Uses the full SHA-256 hash of the path so that backend file structure
  * is never leaked into frontend assets.
  *
  * This is the single source of truth for query name encoding — used by
  * proxy codegen, the production build, and the dev server.
  */
 export function encodeQueryName(ref: BackendFunctionRef): string {
-    const pathHash = createHash('sha256').update(ref.path).digest('hex').slice(0, 12);
+    const pathHash = createHash('sha256').update(ref.path).digest('hex');
     return `${pathHash}.${ref.name}`;
 }
 

--- a/packages/plugins/apps/src/index.ts
+++ b/packages/plugins/apps/src/index.ts
@@ -16,6 +16,7 @@ import { resolveIdentifier } from './identifier';
 import type { AppsOptions } from './types';
 import { uploadArchive } from './upload';
 import { validateOptions } from './validate';
+import { getBackendProxyHooks } from './vite/backend-proxy-plugin';
 import { getVitePlugin } from './vite/index';
 
 export { CONFIG_KEY, PLUGIN_NAME };
@@ -37,8 +38,7 @@ export const getPlugins: GetPlugins = ({ options, context, bundler }) => {
     }
 
     // Discover backend functions (sync — must run before build starts).
-    const absoluteBackendDir = path.resolve(context.buildRoot, validatedOptions.backendDir);
-    const backendFunctions = discoverBackendFunctions(absoluteBackendDir, log);
+    const backendFunctions = discoverBackendFunctions(context.buildRoot, log);
     const backendOutputs = new Map<string, string>();
     const hasBackend = backendFunctions.length > 0;
 
@@ -83,15 +83,16 @@ Either:
             // Prefix all frontend assets with frontend/.
             const allAssets: Asset[] = frontendOnly.map((asset) => ({
                 ...asset,
-                relativePath: path.join('frontend', asset.relativePath),
+                relativePath: `frontend/${asset.relativePath}`,
             }));
 
             if (hasBackend) {
                 // Build backend assets from the outputs map populated during the build.
-                for (const [funcName, absolutePath] of backendOutputs) {
+                // Keys are encoded query names ({hash(path)}.{name}).
+                for (const [bundleName, absolutePath] of backendOutputs) {
                     allAssets.push({
                         absolutePath,
-                        relativePath: `backend/${funcName}.js`,
+                        relativePath: `backend/${bundleName}.js`,
                     });
                 }
             }
@@ -149,6 +150,18 @@ Either:
     };
 
     const plugins: PluginOptions[] = [];
+
+    // Register the backend proxy plugin to intercept .backend.ts imports
+    // and replace them with generated proxy modules.
+    if (hasBackend) {
+        const proxyHooks = getBackendProxyHooks(backendFunctions, log);
+        plugins.push({
+            name: 'datadog-apps-backend-proxy-plugin' as const,
+            enforce: 'pre',
+            resolveId: proxyHooks.resolveId,
+            load: proxyHooks.load,
+        });
+    }
 
     // All build + upload logic is handled inside the Vite sub-plugin's closeBundle.
     // When backend functions exist, it builds them first, then uploads everything.

--- a/packages/plugins/apps/src/vite/backend-proxy-plugin.ts
+++ b/packages/plugins/apps/src/vite/backend-proxy-plugin.ts
@@ -1,0 +1,84 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import type { Logger } from '@dd/core/types';
+import path from 'path';
+
+import type { BackendFunction } from '../backend/discovery';
+import { encodeQueryName } from '../backend/discovery';
+
+import { generateProxyModule } from './proxy-codegen';
+
+const PROXY_PREFIX = '\0dd-backend-proxy:';
+
+/**
+ * Returns resolveId/load hooks that intercept imports of `.backend.ts` files
+ * and replace them with generated proxy modules. Each exported function in the
+ * original file is replaced with a wrapper that calls `executeBackendFunction`
+ * with the pre-computed query name (hashed path + export name).
+ *
+ * The raw BackendFunctionRef is never present in the generated proxy code —
+ * only the opaque query name string appears in frontend bundles.
+ */
+export function getBackendProxyHooks(
+    backendFunctions: BackendFunction[],
+    log: Logger,
+): { resolveId: (source: string, importer?: string) => string | null; load: (id: string) => string | null } {
+    // Group backend functions by their source file path, pre-computing query names
+    const proxyDataByEntryPath = new Map<string, Array<{ exportName: string; queryName: string }>>();
+    for (const func of backendFunctions) {
+        const existing = proxyDataByEntryPath.get(func.entryPath) ?? [];
+        existing.push({
+            exportName: func.ref.name,
+            queryName: encodeQueryName(func.ref),
+        });
+        proxyDataByEntryPath.set(func.entryPath, existing);
+    }
+
+    return {
+        resolveId(source: string, importer?: string): string | null {
+            if (!importer) {
+                return null;
+            }
+
+            // Check if the import resolves to a known .backend.ts file
+            const resolved = path.resolve(path.dirname(importer), source);
+
+            // Try with common extensions if the import doesn't have one
+            const candidates = [
+                resolved,
+                `${resolved}.ts`,
+                `${resolved}.tsx`,
+                `${resolved}.js`,
+                `${resolved}.jsx`,
+            ];
+
+            for (const candidate of candidates) {
+                if (proxyDataByEntryPath.has(candidate)) {
+                    log.debug(`Proxying import of ${source} → ${candidate}`);
+                    return `${PROXY_PREFIX}${candidate}`;
+                }
+            }
+
+            return null;
+        },
+
+        load(id: string): string | null {
+            if (!id.startsWith(PROXY_PREFIX)) {
+                return null;
+            }
+
+            const entryPath = id.slice(PROXY_PREFIX.length);
+            const proxyExports = proxyDataByEntryPath.get(entryPath);
+
+            if (!proxyExports) {
+                return null;
+            }
+
+            const proxyCode = generateProxyModule(proxyExports);
+            log.debug(`Generated proxy for ${entryPath} with ${proxyExports.length} export(s)`);
+            return proxyCode;
+        },
+    };
+}

--- a/packages/plugins/apps/src/vite/backend-proxy-plugin.ts
+++ b/packages/plugins/apps/src/vite/backend-proxy-plugin.ts
@@ -24,9 +24,15 @@ const PROXY_PREFIX = '\0dd-backend-proxy:';
 export function getBackendProxyHooks(
     backendFunctions: BackendFunction[],
     log: Logger,
-): { resolveId: (source: string, importer?: string) => string | null; load: (id: string) => string | null } {
+): {
+    resolveId: (source: string, importer?: string) => string | null;
+    load: (id: string) => string | null;
+} {
     // Group backend functions by their source file path, pre-computing query names
-    const proxyDataByEntryPath = new Map<string, Array<{ exportName: string; queryName: string }>>();
+    const proxyDataByEntryPath = new Map<
+        string,
+        Array<{ exportName: string; queryName: string }>
+    >();
     for (const func of backendFunctions) {
         const existing = proxyDataByEntryPath.get(func.entryPath) ?? [];
         existing.push({

--- a/packages/plugins/apps/src/vite/build-backend-functions.test.ts
+++ b/packages/plugins/apps/src/vite/build-backend-functions.test.ts
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import { encodeQueryName } from '@dd/apps-plugin/backend/discovery';
+
+describe('encodeQueryName', () => {
+    test('Should produce a hash-based query name', () => {
+        const result = encodeQueryName({ path: 'mathUtils', name: 'add' });
+        // Should be {12-char hex hash}.{name}
+        expect(result).toMatch(/^[0-9a-f]{12}\.add$/);
+    });
+
+    test('Should produce consistent names for the same ref', () => {
+        const ref = { path: 'src/utils/mathUtils', name: 'multiply' };
+        expect(encodeQueryName(ref)).toBe(encodeQueryName(ref));
+    });
+
+    test('Should produce different names for different exports of the same file', () => {
+        const add = encodeQueryName({ path: 'mathUtils', name: 'add' });
+        const multiply = encodeQueryName({ path: 'mathUtils', name: 'multiply' });
+        expect(add).not.toBe(multiply);
+        // Same hash prefix (same path), different function name suffix
+        expect(add.split('.')[0]).toBe(multiply.split('.')[0]);
+    });
+
+    test('Should produce different names for different files with the same export', () => {
+        const a = encodeQueryName({ path: 'src/a', name: 'handler' });
+        const b = encodeQueryName({ path: 'src/b', name: 'handler' });
+        expect(a).not.toBe(b);
+    });
+
+    test('Should handle paths with slashes', () => {
+        const result = encodeQueryName({ path: 'src/features/auth/login', name: 'login' });
+        expect(result).toMatch(/^[0-9a-f]{12}\.login$/);
+        // Path should not appear in the encoded name
+        expect(result).not.toContain('src');
+        expect(result).not.toContain('/');
+    });
+});

--- a/packages/plugins/apps/src/vite/build-backend-functions.test.ts
+++ b/packages/plugins/apps/src/vite/build-backend-functions.test.ts
@@ -7,8 +7,8 @@ import { encodeQueryName } from '@dd/apps-plugin/backend/discovery';
 describe('encodeQueryName', () => {
     test('Should produce a hash-based query name', () => {
         const result = encodeQueryName({ path: 'mathUtils', name: 'add' });
-        // Should be {12-char hex hash}.{name}
-        expect(result).toMatch(/^[0-9a-f]{12}\.add$/);
+        // Should be {64-char hex hash}.{name}
+        expect(result).toMatch(/^[0-9a-f]{64}\.add$/);
     });
 
     test('Should produce consistent names for the same ref', () => {
@@ -32,7 +32,7 @@ describe('encodeQueryName', () => {
 
     test('Should handle paths with slashes', () => {
         const result = encodeQueryName({ path: 'src/features/auth/login', name: 'login' });
-        expect(result).toMatch(/^[0-9a-f]{12}\.login$/);
+        expect(result).toMatch(/^[0-9a-f]{64}\.login$/);
         // Path should not appear in the encoded name
         expect(result).not.toContain('src');
         expect(result).not.toContain('/');

--- a/packages/plugins/apps/src/vite/build-backend-functions.ts
+++ b/packages/plugins/apps/src/vite/build-backend-functions.ts
@@ -9,6 +9,7 @@ import path from 'path';
 import type { build } from 'vite';
 
 import type { BackendFunction } from '../backend/discovery';
+import { encodeQueryName } from '../backend/discovery';
 import { generateVirtualEntryContent } from '../backend/virtual-entry';
 
 import { getBaseBackendBuildConfig } from './build-config';
@@ -18,6 +19,9 @@ const VIRTUAL_PREFIX = '\0dd-backend:';
 /**
  * Build all backend functions using a separate vite.build() call.
  * Produces one standalone JS file per function in a temp directory.
+ *
+ * Each bundle filename is the encoded query name (`{hash(path)}.{name}.js`)
+ * for the flat backend/ directory in the ZIP.
  */
 export async function buildBackendFunctions(
     viteBuild: typeof build,
@@ -33,8 +37,13 @@ export async function buildBackendFunctions(
     // Build each function individually so that each output is a single
     // self-contained JS file
     for (const func of functions) {
-        const virtualId = `${VIRTUAL_PREFIX}${func.name}`;
-        const virtualContent = generateVirtualEntryContent(func.name, func.entryPath, buildRoot);
+        const bundleName = encodeQueryName(func.ref);
+        const virtualId = `${VIRTUAL_PREFIX}${bundleName}`;
+        const virtualContent = generateVirtualEntryContent(
+            func.ref.name,
+            func.entryPath,
+            buildRoot,
+        );
 
         const baseConfig = getBaseBackendBuildConfig(buildRoot, { [virtualId]: virtualContent });
 
@@ -48,7 +57,7 @@ export async function buildBackendFunctions(
                 emptyOutDir: false,
                 rollupOptions: {
                     ...baseConfig.build.rollupOptions,
-                    input: { [func.name]: virtualId },
+                    input: { [bundleName]: virtualId },
                     output: {
                         ...baseConfig.build.rollupOptions.output,
                         entryFileNames: '[name].js',
@@ -65,8 +74,8 @@ export async function buildBackendFunctions(
                     continue;
                 }
                 const absolutePath = path.resolve(outDir, chunk.fileName);
-                backendOutputs.set(func.name, absolutePath);
-                log.debug(`Backend function "${func.name}" output: ${absolutePath}`);
+                backendOutputs.set(bundleName, absolutePath);
+                log.debug(`Backend function "${bundleName}" output: ${absolutePath}`);
             }
         }
     }

--- a/packages/plugins/apps/src/vite/dev-server.test.ts
+++ b/packages/plugins/apps/src/vite/dev-server.test.ts
@@ -9,7 +9,14 @@ import type { IncomingMessage, ServerResponse } from 'http';
 import nock from 'nock';
 
 import type { BackendFunction } from '../backend/discovery';
-import { encodeQueryName } from '../backend/discovery';
+import { discoverBackendFunctions, encodeQueryName } from '../backend/discovery';
+
+jest.mock('../backend/discovery', () => ({
+    ...jest.requireActual('../backend/discovery'),
+    discoverBackendFunctions: jest.fn(),
+}));
+
+const mockDiscoverBackendFunctions = jest.mocked(discoverBackendFunctions);
 
 const mockViteBuild = jest.fn();
 
@@ -87,18 +94,17 @@ function mockBuildResult(code: string) {
 }
 
 describe('Dev Server Middleware', () => {
+    beforeEach(() => {
+        mockDiscoverBackendFunctions.mockReturnValue(mockFunctions);
+    });
+
     afterEach(() => {
         nock.cleanAll();
+        jest.clearAllMocks();
     });
 
     describe('createDevServerMiddleware routing', () => {
-        const middleware = createDevServerMiddleware(
-            mockViteBuild,
-            mockFunctions,
-            mockAuth,
-            '/project',
-            mockLog,
-        );
+        const middleware = createDevServerMiddleware(mockViteBuild, mockAuth, '/project', mockLog);
 
         test('Should call next() for non-POST requests', () => {
             const req = { method: 'GET', url: '/__dd/debugBundle' } as unknown as IncomingMessage;
@@ -179,13 +185,7 @@ describe('Dev Server Middleware', () => {
     });
 
     describe('debugBundle handler', () => {
-        const middleware = createDevServerMiddleware(
-            mockViteBuild,
-            mockFunctions,
-            mockAuth,
-            '/project',
-            mockLog,
-        );
+        const middleware = createDevServerMiddleware(mockViteBuild, mockAuth, '/project', mockLog);
 
         test('Should return 400 for missing functionRef', async () => {
             const req = createMockRequest('/__dd/debugBundle', {});
@@ -254,13 +254,7 @@ describe('Dev Server Middleware', () => {
     });
 
     describe('executeAction handler', () => {
-        const middleware = createDevServerMiddleware(
-            mockViteBuild,
-            mockFunctions,
-            mockAuth,
-            '/project',
-            mockLog,
-        );
+        const middleware = createDevServerMiddleware(mockViteBuild, mockAuth, '/project', mockLog);
 
         test('Should return 400 for missing functionRef', async () => {
             const req = createMockRequest('/__dd/executeAction', {});
@@ -400,6 +394,37 @@ describe('Dev Server Middleware', () => {
             expect(body.success).toBe(true);
             expect(body.result).toEqual({ ok: true });
             expect(apiScope.isDone()).toBe(true);
+        });
+    });
+
+    describe('dynamic discovery', () => {
+        test('Should pick up newly added backend functions without restart', async () => {
+            const middleware = createDevServerMiddleware(
+                mockViteBuild,
+                mockAuth,
+                '/project',
+                mockLog,
+            );
+
+            // After middleware creation, discovery returns a new function.
+            const newFunc: BackendFunction = {
+                ref: { path: 'backend/newAction', name: 'newAction' },
+                entryPath: '/project/backend/newAction.backend.ts',
+            };
+            mockDiscoverBackendFunctions.mockReturnValue([...mockFunctions, newFunc]);
+
+            mockViteBuild.mockResolvedValue(mockBuildResult('// new action code'));
+
+            const req = createMockRequest('/__dd/debugBundle', {
+                functionName: encodeQueryName(newFunc.ref),
+            });
+            const res = createMockResponse();
+
+            middleware(req, res, jest.fn());
+            await res.done;
+
+            expect(res.statusCode).toBe(200);
+            expect(res.getBody()).toContain('// new action code');
         });
     });
 });

--- a/packages/plugins/apps/src/vite/dev-server.test.ts
+++ b/packages/plugins/apps/src/vite/dev-server.test.ts
@@ -8,13 +8,22 @@ import { EventEmitter } from 'events';
 import type { IncomingMessage, ServerResponse } from 'http';
 import nock from 'nock';
 
+import type { BackendFunction } from '../backend/discovery';
+import { encodeQueryName } from '../backend/discovery';
+
 const mockViteBuild = jest.fn();
 
 const DD_SITE = 'datadoghq.com';
 
-const mockFunctions = [
-    { name: 'greet', entryPath: '/project/backend/greet.ts' },
-    { name: 'compute', entryPath: '/project/backend/compute.ts' },
+const mockFunctions: BackendFunction[] = [
+    {
+        ref: { path: 'backend/greet', name: 'greet' },
+        entryPath: '/project/backend/greet.backend.ts',
+    },
+    {
+        ref: { path: 'backend/compute', name: 'compute' },
+        entryPath: '/project/backend/compute.backend.ts',
+    },
 ];
 
 const mockAuth = {
@@ -117,7 +126,9 @@ describe('Dev Server Middleware', () => {
         test('Should handle /__dd/debugBundle POST', async () => {
             mockViteBuild.mockResolvedValue(mockBuildResult('// bundled code'));
 
-            const req = createMockRequest('/__dd/debugBundle', { functionName: 'greet' });
+            const req = createMockRequest('/__dd/debugBundle', {
+                functionName: encodeQueryName(mockFunctions[0].ref),
+            });
             const res = createMockResponse();
             const next = jest.fn();
 
@@ -148,7 +159,7 @@ describe('Dev Server Middleware', () => {
                 });
 
             const req = createMockRequest('/__dd/executeAction', {
-                functionName: 'greet',
+                functionName: encodeQueryName(mockFunctions[0].ref),
                 args: ['world'],
             });
             const res = createMockResponse();
@@ -176,7 +187,7 @@ describe('Dev Server Middleware', () => {
             mockLog,
         );
 
-        test('Should return 400 for missing functionName', async () => {
+        test('Should return 400 for missing functionRef', async () => {
             const req = createMockRequest('/__dd/debugBundle', {});
             const res = createMockResponse();
 
@@ -189,7 +200,7 @@ describe('Dev Server Middleware', () => {
 
         test('Should return 404 for unknown function', async () => {
             const req = createMockRequest('/__dd/debugBundle', {
-                functionName: 'nonexistent',
+                functionName: 'nonexistent.nonexistent',
             });
             const res = createMockResponse();
 
@@ -203,7 +214,9 @@ describe('Dev Server Middleware', () => {
         test('Should return bundled code as text/plain', async () => {
             mockViteBuild.mockResolvedValue(mockBuildResult('export function main($) {}'));
 
-            const req = createMockRequest('/__dd/debugBundle', { functionName: 'greet' });
+            const req = createMockRequest('/__dd/debugBundle', {
+                functionName: encodeQueryName(mockFunctions[0].ref),
+            });
             const res = createMockResponse();
 
             middleware(req, res, jest.fn());
@@ -218,7 +231,7 @@ describe('Dev Server Middleware', () => {
             mockViteBuild.mockResolvedValue(mockBuildResult('// code'));
 
             const req = createMockRequest('/__dd/debugBundle', {
-                functionName: 'greet',
+                functionName: encodeQueryName(mockFunctions[0].ref),
                 args: [1, 2],
             });
             const res = createMockResponse();
@@ -249,7 +262,7 @@ describe('Dev Server Middleware', () => {
             mockLog,
         );
 
-        test('Should return 400 for missing functionName', async () => {
+        test('Should return 400 for missing functionRef', async () => {
             const req = createMockRequest('/__dd/executeAction', {});
             const res = createMockResponse();
 
@@ -261,7 +274,7 @@ describe('Dev Server Middleware', () => {
 
         test('Should return 404 for unknown function', async () => {
             const req = createMockRequest('/__dd/executeAction', {
-                functionName: 'nonexistent',
+                functionName: 'nonexistent.nonexistent',
             });
             const res = createMockResponse();
 
@@ -277,7 +290,7 @@ describe('Dev Server Middleware', () => {
          * returns 500 because from the caller's perspective this is a
          * server-side failure — the caller's request was valid, the dev server
          * just couldn't fulfill it. This is distinct from the 400/404 cases
-         * above, which represent client mistakes (missing functionName,
+         * above, which represent client mistakes (missing functionRef,
          * unknown function).
          */
         test('Should return 500 when Datadog API fails', async () => {
@@ -288,7 +301,7 @@ describe('Dev Server Middleware', () => {
                 .reply(403, 'Forbidden');
 
             const req = createMockRequest('/__dd/executeAction', {
-                functionName: 'greet',
+                functionName: encodeQueryName(mockFunctions[0].ref),
                 args: [],
             });
             const res = createMockResponse();
@@ -319,7 +332,7 @@ describe('Dev Server Middleware', () => {
                 });
 
             const req = createMockRequest('/__dd/executeAction', {
-                functionName: 'greet',
+                functionName: encodeQueryName(mockFunctions[0].ref),
                 args: [],
             });
             const res = createMockResponse();
@@ -346,7 +359,7 @@ describe('Dev Server Middleware', () => {
                 });
 
             const req = createMockRequest('/__dd/executeAction', {
-                functionName: 'greet',
+                functionName: encodeQueryName(mockFunctions[0].ref),
                 args: [],
             });
             const res = createMockResponse();
@@ -374,7 +387,7 @@ describe('Dev Server Middleware', () => {
                 });
 
             const req = createMockRequest('/__dd/executeAction', {
-                functionName: 'greet',
+                functionName: encodeQueryName(mockFunctions[0].ref),
                 args: [],
             });
             const res = createMockResponse();

--- a/packages/plugins/apps/src/vite/dev-server.ts
+++ b/packages/plugins/apps/src/vite/dev-server.ts
@@ -11,7 +11,7 @@ import type { IncomingMessage, ServerResponse } from 'http';
 import type { build } from 'vite';
 
 import type { BackendFunction } from '../backend/discovery';
-import { encodeQueryName } from '../backend/discovery';
+import { discoverBackendFunctions, encodeQueryName } from '../backend/discovery';
 import { generateDevVirtualEntryContent } from '../backend/virtual-entry';
 
 import { getBaseBackendBuildConfig } from './build-config';
@@ -323,21 +323,12 @@ async function handleExecuteAction(
  */
 export function createDevServerMiddleware(
     viteBuild: typeof build,
-    backendFunctions: BackendFunction[],
     auth: AuthOptionsWithDefaults,
     projectRoot: string,
     log: Logger,
 ): (req: IncomingMessage, res: ServerResponse, next: () => void) => void {
-    const functionsByQueryName = new Map(backendFunctions.map((f) => [encodeQueryName(f.ref), f]));
-
     const bundle = (func: BackendFunction, args: unknown[]) =>
         bundleBackendFunction(viteBuild, func, args, projectRoot, log);
-
-    if (backendFunctions.length > 0) {
-        log.info(
-            `Dev server middleware active for ${backendFunctions.length} backend function(s): ${backendFunctions.map((f) => formatRef(f)).join(', ')}`,
-        );
-    }
 
     // Narrow auth once — executeAction needs all three fields present.
     const fullAuth: AuthConfig | undefined =
@@ -358,6 +349,18 @@ export function createDevServerMiddleware(
             return;
         }
 
+        if (req.url !== '/__dd/debugBundle' && req.url !== '/__dd/executeAction') {
+            next();
+            return;
+        }
+
+        // Re-discover backend functions on each request so newly added
+        // .backend.ts files (or new exports) are picked up without restart.
+        const backendFunctions = discoverBackendFunctions(projectRoot, log);
+        const functionsByQueryName = new Map(
+            backendFunctions.map((f) => [encodeQueryName(f.ref), f]),
+        );
+
         if (req.url === '/__dd/debugBundle') {
             handleDebugBundle(req, res, functionsByQueryName, bundle).catch(() => {
                 sendError(res, 500, 'Unexpected error');
@@ -374,8 +377,6 @@ export function createDevServerMiddleware(
             handleExecuteAction(req, res, functionsByQueryName, bundle, fullAuth, log).catch(() => {
                 sendError(res, 500, 'Unexpected error');
             });
-        } else {
-            next();
         }
     };
 }

--- a/packages/plugins/apps/src/vite/dev-server.ts
+++ b/packages/plugins/apps/src/vite/dev-server.ts
@@ -11,6 +11,7 @@ import type { IncomingMessage, ServerResponse } from 'http';
 import type { build } from 'vite';
 
 import type { BackendFunction } from '../backend/discovery';
+import { encodeQueryName } from '../backend/discovery';
 import { generateDevVirtualEntryContent } from '../backend/virtual-entry';
 
 import { getBaseBackendBuildConfig } from './build-config';
@@ -31,6 +32,13 @@ interface ExecuteActionResponse {
 }
 
 type AuthConfig = Required<AuthOptionsWithDefaults>;
+
+/**
+ * Format a BackendFunction for display in log/error messages.
+ */
+function formatRef(func: BackendFunction): string {
+    return `${func.ref.path}/${func.ref.name}`;
+}
 
 /**
  * Parse JSON body from an incoming request stream.
@@ -63,15 +71,16 @@ async function bundleBackendFunction(
     projectRoot: string,
     log: Logger,
 ): Promise<string> {
-    const virtualId = `${DEV_VIRTUAL_PREFIX}${func.name}`;
+    const displayName = formatRef(func);
+    const virtualId = `${DEV_VIRTUAL_PREFIX}${displayName}`;
     const virtualContent = generateDevVirtualEntryContent(
-        func.name,
+        func.ref.name,
         func.entryPath,
         args,
         projectRoot,
     );
 
-    log.debug(`Bundling backend function "${func.name}" from ${func.entryPath}`);
+    log.debug(`Bundling backend function "${displayName}" from ${func.entryPath}`);
 
     const baseConfig = getBaseBackendBuildConfig(projectRoot, { [virtualId]: virtualContent });
 
@@ -95,12 +104,12 @@ async function bundleBackendFunction(
     const output = Array.isArray(result) ? result[0] : result;
 
     if (!('output' in output)) {
-        throw new Error(`Unexpected vite.build result for "${func.name}"`);
+        throw new Error(`Unexpected vite.build result for "${displayName}"`);
     }
 
     const code = output.output[0].type === 'chunk' ? output.output[0].code : '';
 
-    log.debug(`Bundled "${func.name}" (${code.length} bytes)`);
+    log.debug(`Bundled "${displayName}" (${code.length} bytes)`);
 
     return code;
 }
@@ -110,7 +119,7 @@ async function bundleBackendFunction(
  */
 async function executeScriptViaDatadog(
     scriptBody: string,
-    functionName: string,
+    displayName: string,
     auth: AuthConfig,
     log: Logger,
 ): Promise<unknown> {
@@ -124,7 +133,7 @@ async function executeScriptViaDatadog(
             attributes: {
                 query: {
                     id: randomUUID(),
-                    name: functionName,
+                    name: displayName,
                     type: 'action',
                     properties: {
                         spec: {
@@ -235,26 +244,26 @@ class HttpError extends Error {
 
 /**
  * Shared request pipeline: parse body, validate functionName, look up
- * the backend function, and bundle it.
+ * the backend function by encoded query name, and bundle it.
  */
 async function validateAndBundle(
     req: IncomingMessage,
-    functionsByName: Map<string, BackendFunction>,
+    functionsByQueryName: Map<string, BackendFunction>,
     bundle: BundleFn,
-): Promise<{ functionName: string; code: string }> {
+): Promise<{ displayName: string; code: string }> {
     const { functionName, args = [] } = await parseRequestBody(req);
 
     if (!functionName || typeof functionName !== 'string') {
         throw new HttpError(400, 'Missing or invalid functionName');
     }
 
-    const func = functionsByName.get(functionName);
+    const func = functionsByQueryName.get(functionName);
     if (!func) {
         throw new HttpError(404, `Backend function "${functionName}" not found`);
     }
 
     const code = await bundle(func, args);
-    return { functionName, code };
+    return { displayName: formatRef(func), code };
 }
 
 /**
@@ -263,11 +272,11 @@ async function validateAndBundle(
 async function handleDebugBundle(
     req: IncomingMessage,
     res: ServerResponse,
-    functionsByName: Map<string, BackendFunction>,
+    functionsByQueryName: Map<string, BackendFunction>,
     bundle: BundleFn,
 ): Promise<void> {
     try {
-        const { code } = await validateAndBundle(req, functionsByName, bundle);
+        const { code } = await validateAndBundle(req, functionsByQueryName, bundle);
 
         res.statusCode = 200;
         res.setHeader('Content-Type', 'text/plain');
@@ -285,17 +294,17 @@ async function handleDebugBundle(
 async function handleExecuteAction(
     req: IncomingMessage,
     res: ServerResponse,
-    functionsByName: Map<string, BackendFunction>,
+    functionsByQueryName: Map<string, BackendFunction>,
     bundle: BundleFn,
     auth: AuthConfig,
     log: Logger,
 ): Promise<void> {
     try {
-        const { functionName, code } = await validateAndBundle(req, functionsByName, bundle);
+        const { displayName, code } = await validateAndBundle(req, functionsByQueryName, bundle);
 
-        log.debug(`Executing action: ${functionName} with args`);
+        log.debug(`Executing action: ${displayName} with args`);
 
-        const result = await executeScriptViaDatadog(code, functionName, auth, log);
+        const result = await executeScriptViaDatadog(code, displayName, auth, log);
 
         res.statusCode = 200;
         res.setHeader('Content-Type', 'application/json');
@@ -319,14 +328,14 @@ export function createDevServerMiddleware(
     projectRoot: string,
     log: Logger,
 ): (req: IncomingMessage, res: ServerResponse, next: () => void) => void {
-    const functionsByName = new Map(backendFunctions.map((f) => [f.name, f]));
+    const functionsByQueryName = new Map(backendFunctions.map((f) => [encodeQueryName(f.ref), f]));
 
     const bundle = (func: BackendFunction, args: unknown[]) =>
         bundleBackendFunction(viteBuild, func, args, projectRoot, log);
 
     if (backendFunctions.length > 0) {
         log.info(
-            `Dev server middleware active for ${backendFunctions.length} backend function(s): ${backendFunctions.map((f) => f.name).join(', ')}`,
+            `Dev server middleware active for ${backendFunctions.length} backend function(s): ${backendFunctions.map((f) => formatRef(f)).join(', ')}`,
         );
     }
 
@@ -350,7 +359,7 @@ export function createDevServerMiddleware(
         }
 
         if (req.url === '/__dd/debugBundle') {
-            handleDebugBundle(req, res, functionsByName, bundle).catch(() => {
+            handleDebugBundle(req, res, functionsByQueryName, bundle).catch(() => {
                 sendError(res, 500, 'Unexpected error');
             });
         } else if (req.url === '/__dd/executeAction') {
@@ -362,7 +371,7 @@ export function createDevServerMiddleware(
                 );
                 return;
             }
-            handleExecuteAction(req, res, functionsByName, bundle, fullAuth, log).catch(() => {
+            handleExecuteAction(req, res, functionsByQueryName, bundle, fullAuth, log).catch(() => {
                 sendError(res, 500, 'Unexpected error');
             });
         } else {

--- a/packages/plugins/apps/src/vite/index.test.ts
+++ b/packages/plugins/apps/src/vite/index.test.ts
@@ -5,11 +5,29 @@
 import { getVitePlugin } from '@dd/apps-plugin/vite/index';
 import { getMockLogger } from '@dd/tests/_jest/helpers/mocks';
 
+import type { BackendFunction } from '../backend/discovery';
+import { encodeQueryName } from '../backend/discovery';
+
 const log = getMockLogger();
+
+const functions: BackendFunction[] = [
+    {
+        ref: { path: 'src/backend/myHandler', name: 'myHandler' },
+        entryPath: '/src/backend/myHandler.backend.ts',
+    },
+    {
+        ref: { path: 'src/backend/otherFunc', name: 'otherFunc' },
+        entryPath: '/src/backend/otherFunc.backend.ts',
+    },
+];
+
+const bundleName1 = encodeQueryName(functions[0].ref);
+const bundleName2 = encodeQueryName(functions[1].ref);
+
 const mockViteBuild = jest.fn().mockResolvedValue({
     output: [
-        { type: 'chunk', isEntry: true, name: 'myHandler', fileName: 'myHandler.js' },
-        { type: 'chunk', isEntry: true, name: 'otherFunc', fileName: 'otherFunc.js' },
+        { type: 'chunk', isEntry: true, name: bundleName1, fileName: `${bundleName1}.js` },
+        { type: 'chunk', isEntry: true, name: bundleName2, fileName: `${bundleName2}.js` },
     ],
 });
 const mockHandleUpload = jest.fn().mockResolvedValue(undefined);
@@ -17,11 +35,8 @@ const mockHandleUpload = jest.fn().mockResolvedValue(undefined);
 const defaultOptions = {
     viteBuild: mockViteBuild,
     buildRoot: '/build',
-    functions: [
-        { name: 'myHandler', entryPath: '/src/backend/myHandler.ts' },
-        { name: 'otherFunc', entryPath: '/src/backend/otherFunc/index.ts' },
-    ],
-    backendOutputs: new Map(),
+    functions,
+    backendOutputs: new Map<string, string>(),
     handleUpload: mockHandleUpload,
     log,
     auth: { site: 'datadoghq.com' },
@@ -48,8 +63,8 @@ describe('Backend Functions - getVitePlugin', () => {
 
         expect(mockViteBuild).toHaveBeenCalledTimes(2);
         expect(defaultOptions.backendOutputs.size).toBe(2);
-        expect(defaultOptions.backendOutputs.has('myHandler')).toBe(true);
-        expect(defaultOptions.backendOutputs.has('otherFunc')).toBe(true);
+        expect(defaultOptions.backendOutputs.has(bundleName1)).toBe(true);
+        expect(defaultOptions.backendOutputs.has(bundleName2)).toBe(true);
         // Upload should be called after build completes.
         expect(mockHandleUpload).toHaveBeenCalledTimes(1);
     });

--- a/packages/plugins/apps/src/vite/index.ts
+++ b/packages/plugins/apps/src/vite/index.ts
@@ -59,8 +59,6 @@ export const getVitePlugin = ({
         }
     },
     configureServer(server) {
-        server.middlewares.use(
-            createDevServerMiddleware(viteBuild, functions, auth, buildRoot, log),
-        );
+        server.middlewares.use(createDevServerMiddleware(viteBuild, auth, buildRoot, log));
     },
 });

--- a/packages/plugins/apps/src/vite/proxy-codegen.test.ts
+++ b/packages/plugins/apps/src/vite/proxy-codegen.test.ts
@@ -6,9 +6,7 @@ import { generateProxyModule } from '@dd/apps-plugin/vite/proxy-codegen';
 
 describe('Proxy Codegen - generateProxyModule', () => {
     test('Should generate a proxy module with a pre-computed query name', () => {
-        const result = generateProxyModule([
-            { exportName: 'add', queryName: 'a1b2c3d4e5f6.add' },
-        ]);
+        const result = generateProxyModule([{ exportName: 'add', queryName: 'a1b2c3d4e5f6.add' }]);
 
         expect(result).toContain(
             "import { executeBackendFunction } from '@datadog/apps-function-query'",

--- a/packages/plugins/apps/src/vite/proxy-codegen.test.ts
+++ b/packages/plugins/apps/src/vite/proxy-codegen.test.ts
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import { generateProxyModule } from '@dd/apps-plugin/vite/proxy-codegen';
+
+describe('Proxy Codegen - generateProxyModule', () => {
+    test('Should generate a proxy module with a pre-computed query name', () => {
+        const result = generateProxyModule([
+            { exportName: 'add', queryName: 'a1b2c3d4e5f6.add' },
+        ]);
+
+        expect(result).toContain(
+            "import { executeBackendFunction } from '@datadog/apps-function-query'",
+        );
+        expect(result).toContain('export async function add(...args)');
+        expect(result).toContain('executeBackendFunction("a1b2c3d4e5f6.add", args)');
+    });
+
+    test('Should generate a proxy module for multiple exports', () => {
+        const result = generateProxyModule([
+            { exportName: 'add', queryName: 'a1b2c3d4e5f6.add' },
+            { exportName: 'multiply', queryName: 'a1b2c3d4e5f6.multiply' },
+        ]);
+
+        expect(result).toContain('export async function add(...args)');
+        expect(result).toContain('export async function multiply(...args)');
+        expect(result).toContain('"a1b2c3d4e5f6.add"');
+        expect(result).toContain('"a1b2c3d4e5f6.multiply"');
+    });
+
+    test('Should not contain raw backend file paths', () => {
+        const result = generateProxyModule([
+            { exportName: 'login', queryName: 'deadbeef1234.login' },
+        ]);
+
+        // The generated code should only contain the hashed query name,
+        // not any path information that reveals backend file structure.
+        expect(result).not.toContain('src/features/auth/login');
+        expect(result).not.toContain('.backend');
+        expect(result).toContain('"deadbeef1234.login"');
+    });
+
+    test('Should import executeBackendFunction exactly once', () => {
+        const result = generateProxyModule([
+            { exportName: 'a', queryName: 'abc123.a' },
+            { exportName: 'b', queryName: 'abc123.b' },
+            { exportName: 'c', queryName: 'abc123.c' },
+        ]);
+
+        const importCount = (result.match(/import.*executeBackendFunction/g) || []).length;
+        expect(importCount).toBe(1);
+    });
+});

--- a/packages/plugins/apps/src/vite/proxy-codegen.ts
+++ b/packages/plugins/apps/src/vite/proxy-codegen.ts
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+interface ProxyExport {
+    /** The JS export name (e.g. "add") */
+    exportName: string;
+    /** The pre-computed opaque query name (e.g. "a1b2c3d4e5f6.add") */
+    queryName: string;
+}
+
+/**
+ * Generate a proxy module for a `.backend.ts` file. Each exported function
+ * is replaced with a wrapper that calls `executeBackendFunction` with the
+ * pre-computed query name string.
+ *
+ * The raw BackendFunctionRef (file path) is never present in the generated
+ * code — only the hashed query name appears, preventing backend file
+ * structure from leaking into frontend bundles.
+ *
+ * @param exports - The export name + pre-computed query name for each export
+ * @returns Generated proxy module source code
+ */
+export function generateProxyModule(exports: ProxyExport[]): string {
+    const lines: string[] = [];
+
+    lines.push("import { executeBackendFunction } from '@datadog/apps-function-query';");
+    lines.push('');
+
+    for (const { exportName, queryName } of exports) {
+        lines.push(`export async function ${exportName}(...args) {`);
+        lines.push(`    return executeBackendFunction(${JSON.stringify(queryName)}, args);`);
+        lines.push('}');
+        lines.push('');
+    }
+
+    return lines.join('\n');
+}

--- a/packages/published/vite-plugin/package.json
+++ b/packages/published/vite-plugin/package.json
@@ -24,7 +24,7 @@
     "exports": {
         "./dist/src": "./dist/src/index.js",
         "./dist/src/*": "./dist/src/*",
-        ".": "./src/index.ts"
+        ".": "./dist/src/index.js"
     },
     "publishConfig": {
         "access": "public",
@@ -51,8 +51,10 @@
     },
     "dependencies": {
         "@datadog/js-instrumentation-wasm": "1.0.8",
+        "acorn": "8.14.0",
         "async-retry": "1.3.3",
         "chalk": "2.3.1",
+        "esbuild": "0.25.8",
         "glob": "11.1.0",
         "json-stream-stringify": "3.1.6",
         "jszip": "3.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1817,6 +1817,7 @@ __metadata:
     "@rollup/plugin-terser": "npm:0.4.4"
     "@types/babel__core": "npm:^7"
     "@types/babel__preset-env": "npm:^7"
+    acorn: "npm:8.14.0"
     async-retry: "npm:1.3.3"
     chalk: "npm:2.3.1"
     esbuild: "npm:0.25.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1880,7 +1880,9 @@ __metadata:
   resolution: "@dd/apps-plugin@workspace:packages/plugins/apps"
   dependencies:
     "@dd/core": "workspace:*"
+    acorn: "npm:8.14.0"
     chalk: "npm:2.3.1"
+    esbuild: "npm:0.25.8"
     glob: "npm:11.1.0"
     jszip: "npm:3.10.1"
     pretty-bytes: "npm:5.6.0"
@@ -4673,21 +4675,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn@npm:8.14.0, acorn@npm:^8.4.1, acorn@npm:^8.8.2, acorn@npm:^8.9.0":
+  version: 8.14.0
+  resolution: "acorn@npm:8.14.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 10/6df29c35556782ca9e632db461a7f97947772c6c1d5438a81f0c873a3da3a792487e83e404d1c6c25f70513e91aa18745f6eafb1fcc3a43ecd1920b21dd173d2
+  languageName: node
+  linkType: hard
+
 "acorn@npm:^8.14.0, acorn@npm:^8.15.0":
   version: 8.15.0
   resolution: "acorn@npm:8.15.0"
   bin:
     acorn: bin/acorn
   checksum: 10/77f2de5051a631cf1729c090e5759148459cdb76b5f5c70f890503d629cf5052357b0ce783c0f976dd8a93c5150f59f6d18df1def3f502396a20f81282482fa4
-  languageName: node
-  linkType: hard
-
-"acorn@npm:^8.4.1, acorn@npm:^8.8.2, acorn@npm:^8.9.0":
-  version: 8.14.0
-  resolution: "acorn@npm:8.14.0"
-  bin:
-    acorn: bin/acorn
-  checksum: 10/6df29c35556782ca9e632db461a7f97947772c6c1d5438a81f0c873a3da3a792487e83e404d1c6c25f70513e91aa18745f6eafb1fcc3a43ecd1920b21dd173d2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Motivation

Backend function imports (`.backend.ts`) need a more robust discovery and proxy generation system. The current approach needs to support multiple exports per file, use stable hashed query names, and provide a `BackendFunctionRef` type for type-safe function references.

This PR uses **esbuild + acorn** for AST parsing to discover exported functions and a dedicated Vite `resolveId`/`load` proxy plugin for import interception.

> **Note:** This is one of two competing approaches — see #320 for an alternative using unplugin's `transform` hook with `this.parse()` instead.

## Changes

- **`BackendFunctionRef` type** — typed reference object containing `queryName` (SHA-256 hash of file path + export name) for stable, collision-resistant function identifiers
- **Multi-export discovery** — `discovery.ts` now finds all named exports (not just default) from `.backend.ts` files using esbuild bundling + acorn AST parsing
- **Hashed query names** — query names use SHA-256 of `filePath:exportName` instead of human-readable names, avoiding naming collisions across files
- **Proxy codegen** (`proxy-codegen.ts`) — generates frontend proxy modules that re-export backend functions as `BackendFunctionRef` objects
- **Backend proxy plugin** (`backend-proxy-plugin.ts`) — Vite plugin using `resolveId`/`load` hooks to intercept `.backend.ts` imports and serve generated proxies
- **Updated dev server** — serves individual backend functions by query name with the new hashed naming scheme

## QA Instructions

Draft — not ready for review yet. This branch exists for comparison with #320.

## Blast Radius

- Only affects the apps plugin (`@dd/apps-plugin`) behind the backend functions feature
- No changes to published plugin APIs
- New dependencies: `acorn`, `esbuild` (in apps plugin `package.json`)

## Documentation

-   [How to reliably make frontend production changes](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2286781319/Frontend+Production+Changesp)
-   [PR Description Guidelines](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/3120334387/PR+Checklist+and+Guidelines+for+Web+UI)
-   [Deploy steps](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/1457750032/)