### PR TITLE
Display full HTML body response for errors

### DIFF
--- a/packages/core/src/helpers/request.ts
+++ b/packages/core/src/helpers/request.ts
@@ -99,28 +99,40 @@ export const doRequest = <T>(opts: RequestOpts): Promise<T> => {
             // Not instantiating the error here, as it will make Jest throw in the tests.
             let errorMessage = `HTTP ${response.status} ${response.statusText}`;
             try {
-                // try to parse the error message as a Datadog JSON:API encoded error
-                const body = (await response.json()) as any;
-                const details = body?.errors
-                    ?.map((e: any) => {
-                        if (e.title && e.detail) {
-                            return `${e.title}: ${e.detail}`;
-                        }
-                        if (e.title) {
-                            return e.title;
-                        }
-                        if (e.detail) {
-                            return `detail: ${e.detail}`;
-                        }
-                        return '';
-                    })
-                    .filter((s: string) => s.length > 0)
-                    .join('\n');
+                const bodyText = await response.text();
+                let details: string | undefined;
+                try {
+                    // try to parse the error message as a Datadog JSON:API encoded error
+                    const body = JSON.parse(bodyText) as any;
+                    if (Array.isArray(body?.errors)) {
+                        details = body.errors
+                            .map((e: any) => {
+                                if (e.title && e.detail) {
+                                    return `${e.title}: ${e.detail}`;
+                                }
+                                if (e.title) {
+                                    return e.title;
+                                }
+                                if (e.detail) {
+                                    return `detail: ${e.detail}`;
+                                }
+                                return '';
+                            })
+                            .filter((s: string) => s.length > 0)
+                            .join('\n');
+                    } else {
+                        // Body is JSON but not a JSON:API error array, use raw text.
+                        details = bodyText;
+                    }
+                } catch {
+                    // Body is not JSON, use raw text.
+                    details = bodyText;
+                }
                 if (details) {
                     errorMessage += `\n${details}`;
                 }
             } catch {
-                // Ignore if body is not JSON.
+                // Ignore if body cannot be read.
             }
             if (ERROR_CODES_NO_RETRY.includes(response.status)) {
                 bail(new Error(errorMessage));

--- a/packages/core/src/helpers/request.ts
+++ b/packages/core/src/helpers/request.ts
@@ -10,6 +10,49 @@ import { createGzip } from 'zlib';
 
 import type { RequestOpts } from '../types';
 
+const formatErrorEntry = (e: unknown): string => {
+    if (e === null || typeof e !== 'object') {
+        return '';
+    }
+    const title = 'title' in e && typeof e.title === 'string' ? e.title : undefined;
+    const detail = 'detail' in e && typeof e.detail === 'string' ? e.detail : undefined;
+    if (title && detail) {
+        return `${title}: ${detail}`;
+    }
+    if (title) {
+        return title;
+    }
+    if (detail) {
+        return `detail: ${detail}`;
+    }
+    return '';
+};
+
+const parseErrorDetails = (bodyText: string): string => {
+    try {
+        const body: unknown = JSON.parse(bodyText);
+        if (body !== null && typeof body === 'object') {
+            if ('errors' in body && Array.isArray(body.errors)) {
+                const details = body.errors
+                    .map(formatErrorEntry)
+                    .filter((s) => s.length > 0)
+                    .join('\n');
+                if (details) {
+                    return details;
+                }
+            } else {
+                const entry = formatErrorEntry(body);
+                if (entry) {
+                    return entry;
+                }
+            }
+        }
+    } catch {
+        // Body is not JSON.
+    }
+    return bodyText;
+};
+
 export const getOriginHeaders = (opts: { bundler: string; plugin: string; version: string }) => {
     return {
         'DD-EVP-ORIGIN': `${opts.bundler}-build-plugin_${opts.plugin}`,
@@ -100,34 +143,7 @@ export const doRequest = <T>(opts: RequestOpts): Promise<T> => {
             let errorMessage = `HTTP ${response.status} ${response.statusText}`;
             try {
                 const bodyText = await response.text();
-                let details: string | undefined;
-                try {
-                    // try to parse the error message as a Datadog JSON:API encoded error
-                    const body = JSON.parse(bodyText) as any;
-                    if (Array.isArray(body?.errors)) {
-                        details = body.errors
-                            .map((e: any) => {
-                                if (e.title && e.detail) {
-                                    return `${e.title}: ${e.detail}`;
-                                }
-                                if (e.title) {
-                                    return e.title;
-                                }
-                                if (e.detail) {
-                                    return `detail: ${e.detail}`;
-                                }
-                                return '';
-                            })
-                            .filter((s: string) => s.length > 0)
-                            .join('\n');
-                    } else {
-                        // Body is JSON but not a JSON:API error array, use raw text.
-                        details = bodyText;
-                    }
-                } catch {
-                    // Body is not JSON, use raw text.
-                    details = bodyText;
-                }
+                const details = parseErrorDetails(bodyText);
                 if (details) {
                     errorMessage += `\n${details}`;
                 }


### PR DESCRIPTION
### What and why?

<!-- A short description of what changes this PR introduces and why. -->

In the event of an error response, don't silently swallow the HTTP response body as it can contain useful information as to the source of the error (e.g. why it returned a 403), e.g. in the case of Datadog APIs.

### How?

First tries to parse it as an array of JSON:API errors. Then try to parse it as a single error. If it still isn't, then it returns the full HTTP response body in error details
