### PR TITLE
[APPS] Stop exposing raw index.html standalone URL

### DIFF
--- a/packages/plugins/apps/src/upload.ts
+++ b/packages/plugins/apps/src/upload.ts
@@ -131,11 +131,13 @@ Would have uploaded ${summary}`,
 
         log.debug(`Uploaded ${summary}\n`);
 
-        if (response.version_id && response.application_id && response.app_builder_id) {
-            const { version_id, application_id, app_builder_id } = response;
-            const appUrl = `https://api.${context.site}/api/unstable/app-builder-code/apps/serve/${application_id}/v/${version_id}/index.html`;
-            const appBuilderUrl = `https://app.${context.site}/app-builder/apps/${app_builder_id}`;
+        if (response.app_builder_id) {
+            const appBuilderUrl = `https://app.${context.site}/app-builder/apps/${response.app_builder_id}`;
 
+            log.info(`Your application is available at:\n  ${cyan(appBuilderUrl)}`);
+        }
+
+        if (response.version_id) {
             const releaseUrl = getReleaseUrl(context.site, context.identifier);
             await doRequest({
                 auth: { apiKey: context.apiKey, appKey: context.appKey },
@@ -157,9 +159,7 @@ Would have uploaded ${summary}`,
                     log.warn(message);
                 },
             });
-            log.info(
-                `Your application is available at:\n${bold('Standalone :')}\n  ${cyan(appUrl)}\n\n${bold('AppBuilder :')}\n  ${cyan(appBuilderUrl)}`,
-            );
+            log.info(`Published uploaded version ${bold(response.version_id)} to live.`);
         }
     } catch (error: unknown) {
         const err = error instanceof Error ? error : new Error(String(error));


### PR DESCRIPTION
## Motivation

After uploading a high-code app, the apps plugin was logging two URLs: a raw `index.html` standalone URL and the AppBuilder URL. We don't want users to rely on the raw `index.html` because backend functions won't work when the app is loaded that way — backend functions rely on a `postMessage` bridge to the parent Datadog document, which only exists when the app is rendered inside AppBuilder. Pointing customers at the standalone URL leads them into a broken state.

## Changes

Dropped the Standalone URL from the post-upload log message. The log now only surfaces the AppBuilder URL, which is the only supported way to run these apps.

Before:
```
Your application is available at:
Standalone :
  https://api.datadoghq.com/api/unstable/app-builder-code/apps/serve/<app>/v/<version>/index.html
AppBuilder :
  https://app.datadoghq.com/app-builder/apps/<id>
```

After:
```
Your application is available at:
  https://app.datadoghq.com/app-builder/apps/<id>
```

## QA Instructions

- Run an apps plugin upload against a test app and confirm the post-upload log only shows the AppBuilder URL, with no Standalone URL.
- Unit: `yarn test:unit packages/plugins/apps/src/upload.test.ts` — the existing `Your application is available at` assertion still passes.

## Blast Radius

- Scoped to the apps plugin post-upload log output. No functional behavior changes — the standalone endpoint still exists, we just no longer advertise it to customers.

## Documentation

-   [How to reliably make frontend production changes](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2286781319/Frontend+Production+Changesp)
-   [PR Description Guidelines](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/3120334387/PR+Checklist+and+Guidelines+for+Web+UI)
-   [Deploy steps](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/1457750032/)