### PR TITLE
[APPS] Add @datadog/eslint-plugin-apps with valid-connections-file rule

### DIFF
--- a/packages/published/eslint-plugin-apps/README.md
+++ b/packages/published/eslint-plugin-apps/README.md
@@ -1,0 +1,50 @@
+# `@datadog/eslint-plugin-apps`
+
+ESLint rules for [Datadog High Code Apps](https://docs.datadoghq.com/service_management/app_builder/).
+
+## Install
+
+```bash
+npm install --save-dev @datadog/eslint-plugin-apps
+```
+
+Requires `eslint >= 8.57.0`.
+
+## Usage — flat config (`eslint.config.js`, ESLint v9)
+
+```js
+import apps from '@datadog/eslint-plugin-apps';
+import tsParser from '@typescript-eslint/parser';
+
+export default [
+    ...apps.configs.recommended,
+    {
+        files: ['connections.{ts,tsx,js,jsx}'],
+        languageOptions: { parser: tsParser },
+    },
+];
+```
+
+## Usage — legacy config (`.eslintrc`)
+
+```json
+{
+    "extends": ["plugin:@datadog/apps/recommended-legacy"],
+    "parser": "@typescript-eslint/parser"
+}
+```
+
+## Rules
+
+### `valid-connections-file`
+
+Validates the project-root `connections.ts` file the Datadog vite plugin reads at build time. Mirrors the build plugin's structural requirements so authors see violations in their editor instead of as a build error.
+
+The rule checks that the file:
+
+- Defines exactly one top-level `export const CONNECTIONS = { … }`
+- Uses an object literal for the initializer (not a function call)
+- Does not use spread elements or computed keys inside the object
+- Uses static string values (string literals or interpolation-free template literals — no env-var lookups, identifiers, concatenation, etc.)
+
+The rule auto-scopes by filename — it only runs on files whose basename matches `connections.{ts,tsx,js,jsx}`.

--- a/packages/published/eslint-plugin-apps/package.json
+++ b/packages/published/eslint-plugin-apps/package.json
@@ -54,6 +54,7 @@
         "@rollup/plugin-json": "6.1.0",
         "@rollup/plugin-node-resolve": "15.3.0",
         "@types/eslint": "9.6.1",
+        "@types/estree": "1.0.8",
         "@typescript-eslint/parser": "7.5.0",
         "esbuild": "0.25.8",
         "eslint": "8.57.0",

--- a/packages/published/eslint-plugin-apps/package.json
+++ b/packages/published/eslint-plugin-apps/package.json
@@ -1,0 +1,71 @@
+{
+    "name": "@datadog/eslint-plugin-apps",
+    "packageManager": "yarn@4.0.2",
+    "version": "3.1.4",
+    "license": "MIT",
+    "author": "Datadog",
+    "description": "ESLint rules for Datadog High Code Apps",
+    "keywords": [
+        "datadog",
+        "eslint",
+        "eslint-plugin",
+        "apps",
+        "high-code-apps"
+    ],
+    "homepage": "https://github.com/DataDog/build-plugins#readme",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/DataDog/build-plugins",
+        "directory": "packages/published/eslint-plugin-apps"
+    },
+    "main": "./dist/src/index.js",
+    "module": "./dist/src/index.mjs",
+    "types": "./dist/src/index.d.ts",
+    "exports": {
+        "./dist/src": "./dist/src/index.js",
+        "./dist/src/*": "./dist/src/*",
+        ".": "./src/index.ts"
+    },
+    "publishConfig": {
+        "access": "public",
+        "types": "./dist/src/index.d.ts",
+        "exports": {
+            "./package.json": "./package.json",
+            ".": {
+                "import": "./dist/src/index.mjs",
+                "require": "./dist/src/index.js",
+                "types": "./dist/src/index.d.ts"
+            }
+        }
+    },
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "buildCmd": "rollup --config rollup.config.mjs",
+        "build": "yarn clean && yarn buildCmd",
+        "clean": "rm -rf dist",
+        "prepack": "yarn build",
+        "typecheck": "tsc --noEmit",
+        "watch": "yarn build --watch"
+    },
+    "devDependencies": {
+        "@dd/tools": "workspace:*",
+        "@rollup/plugin-json": "6.1.0",
+        "@rollup/plugin-node-resolve": "15.3.0",
+        "@types/eslint": "9.6.1",
+        "@typescript-eslint/parser": "7.5.0",
+        "esbuild": "0.25.8",
+        "eslint": "8.57.0",
+        "rollup": "4.45.1",
+        "rollup-plugin-dts": "6.1.1",
+        "rollup-plugin-esbuild": "6.1.1",
+        "typescript": "5.4.3"
+    },
+    "peerDependencies": {
+        "eslint": ">=8.57.0"
+    },
+    "buildPlugin": {
+        "hideFromRootReadme": true
+    }
+}

--- a/packages/published/eslint-plugin-apps/rollup.config.mjs
+++ b/packages/published/eslint-plugin-apps/rollup.config.mjs
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import json from '@rollup/plugin-json';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import dts from 'rollup-plugin-dts';
+import esbuild from 'rollup-plugin-esbuild';
+
+import packageJson from './package.json' with { type: 'json' };
+
+// `@dd/tools/rollupConfig.mjs` is bundler-plugin specific (it parses the
+// package name expecting a `-plugin` suffix and feeds unplugin assumptions
+// into the build), so we hand-roll a minimal config here.
+
+const external = [
+    ...Object.keys(packageJson.peerDependencies ?? {}),
+    ...Object.keys(packageJson.dependencies ?? {}),
+    // Externalize ESLint and Node built-ins.
+    'eslint',
+    'node:path',
+    'path',
+];
+
+const input = 'src/index.ts';
+
+export default [
+    {
+        input,
+        external,
+        output: {
+            file: 'dist/src/index.mjs',
+            format: 'es',
+            sourcemap: true,
+        },
+        plugins: [
+            json(),
+            nodeResolve({ preferBuiltins: true }),
+            esbuild({ target: 'node18' }),
+        ],
+    },
+    {
+        input,
+        external,
+        output: {
+            file: 'dist/src/index.js',
+            format: 'cjs',
+            sourcemap: true,
+            // Rollup's CJS emit for an `export default` source already produces
+            // `module.exports = plugin` directly (no `__esModule` wrapping), so
+            // legacy `.eslintrc` `require()` returns the plugin directly. The
+            // `footer` collapse trick used with esbuild isn't needed here.
+        },
+        plugins: [
+            json(),
+            nodeResolve({ preferBuiltins: true }),
+            esbuild({ target: 'node18' }),
+        ],
+    },
+    {
+        input,
+        external,
+        output: {
+            file: 'dist/src/index.d.ts',
+            format: 'es',
+        },
+        plugins: [dts()],
+    },
+];

--- a/packages/published/eslint-plugin-apps/src/index.ts
+++ b/packages/published/eslint-plugin-apps/src/index.ts
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import type { ESLint, Linter, Rule } from 'eslint';
+
+import validConnectionsFile from './rules/valid-connections-file';
+
+const PLUGIN_NAME = 'apps';
+const PLUGIN_PACKAGE = '@datadog/eslint-plugin-apps';
+const VERSION = '3.1.4';
+
+const rules: Record<string, Rule.RuleModule> = {
+    'valid-connections-file': validConnectionsFile,
+};
+
+interface AppsPlugin extends ESLint.Plugin {
+    meta: { name: string; version: string };
+    rules: Record<string, Rule.RuleModule>;
+    configs: {
+        recommended: Linter.Config[];
+        'recommended-legacy': Linter.LegacyConfig;
+    };
+}
+
+const plugin: AppsPlugin = {
+    meta: { name: PLUGIN_PACKAGE, version: VERSION },
+    rules,
+    configs: {
+        recommended: [],
+        'recommended-legacy': {
+            plugins: ['@datadog/apps'],
+            rules: {
+                '@datadog/apps/valid-connections-file': 'error',
+            },
+        },
+    },
+};
+
+plugin.configs.recommended = [
+    {
+        plugins: { [PLUGIN_NAME]: plugin },
+        rules: {
+            [`${PLUGIN_NAME}/valid-connections-file`]: 'error',
+        },
+    },
+];
+
+export default plugin;

--- a/packages/published/eslint-plugin-apps/src/rules/valid-connections-file.test.ts
+++ b/packages/published/eslint-plugin-apps/src/rules/valid-connections-file.test.ts
@@ -1,0 +1,122 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import { RuleTester } from 'eslint';
+
+import rule from './valid-connections-file';
+
+// ESLint 8 RuleTester uses the legacy `parser` + `parserOptions` shape (string
+// path to the parser module, parserOptions at top level), not the v9 flat
+// `languageOptions.parser`. The repo's @types/eslint is v9 so the legacy
+// shape isn't typed; cast through `unknown` to keep the tests honest about
+// runtime. The published plugin also supports v9 flat config at runtime; this
+// test only validates the rule logic against the AST shape @typescript-eslint
+// /parser produces.
+const ruleTester = new RuleTester({
+    parser: require.resolve('@typescript-eslint/parser'),
+    parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+} as unknown as ConstructorParameters<typeof RuleTester>[0]);
+
+const filename = 'connections.ts';
+
+ruleTester.run('valid-connections-file', rule, {
+    valid: [
+        {
+            name: 'CONNECTIONS with string-literal values',
+            filename,
+            code: `export const CONNECTIONS = { OPEN_AI: '00000000-0000-0000-0000-000000000000' } as const;`,
+        },
+        {
+            name: 'template literal without interpolation is allowed',
+            filename,
+            code: `export const CONNECTIONS = { A: \`abc\` } as const;`,
+        },
+        {
+            name: 'string literal key is allowed',
+            filename,
+            code: `export const CONNECTIONS = { 'open-ai': 'uuid-1' } as const;`,
+        },
+        {
+            name: 'out-of-scope file is ignored even when malformed',
+            filename: 'src/something.ts',
+            code: `export const OTHER = makeConnections();`,
+        },
+    ],
+    invalid: [
+        {
+            name: 'missing CONNECTIONS export',
+            filename,
+            code: `export const OTHER = { foo: 'bar' } as const;`,
+            errors: [{ messageId: 'missingExport' }],
+        },
+        {
+            name: 'lowercase `connections` is not accepted',
+            filename,
+            code: `export const connections = { foo: 'a' } as const;`,
+            errors: [{ messageId: 'missingExport' }],
+        },
+        {
+            name: 'CONNECTIONS not initialized with object literal',
+            filename,
+            code: `export const CONNECTIONS = makeConnections();`,
+            errors: [{ messageId: 'notObjectLiteral' }],
+        },
+        {
+            name: 'duplicate CONNECTIONS exports',
+            filename,
+            code: `export const CONNECTIONS = { A: 'x' } as const;
+export const CONNECTIONS = { B: 'y' } as const;`,
+            errors: [{ messageId: 'duplicateExport' }],
+        },
+        {
+            name: 'spread element in CONNECTIONS',
+            filename,
+            code: `const other = { B: 'y' };
+export const CONNECTIONS = { ...other, A: 'x' } as const;`,
+            errors: [{ messageId: 'spreadElement' }],
+        },
+        {
+            name: 'computed key in CONNECTIONS',
+            filename,
+            code: `const k = 'A';
+export const CONNECTIONS = { [k]: 'x' } as const;`,
+            errors: [{ messageId: 'computedKey' }],
+        },
+        {
+            name: 'value is an identifier (env-like reference)',
+            filename,
+            code: `declare const ENV_ID: string;
+export const CONNECTIONS = { A: ENV_ID } as const;`,
+            errors: [
+                {
+                    messageId: 'valueNotStaticString',
+                    data: { key: 'A', valueType: 'Identifier' },
+                },
+            ],
+        },
+        {
+            name: 'value is a binary expression',
+            filename,
+            code: `export const CONNECTIONS = { A: 'a' + 'b' } as const;`,
+            errors: [
+                {
+                    messageId: 'valueNotStaticString',
+                    data: { key: 'A', valueType: 'BinaryExpression' },
+                },
+            ],
+        },
+        {
+            name: 'value is a template literal with interpolation',
+            filename,
+            code: `declare const id: string;
+export const CONNECTIONS = { A: \`prefix-\${id}\` } as const;`,
+            errors: [
+                {
+                    messageId: 'templateInterpolation',
+                    data: { key: 'A' },
+                },
+            ],
+        },
+    ],
+});

--- a/packages/published/eslint-plugin-apps/src/rules/valid-connections-file.ts
+++ b/packages/published/eslint-plugin-apps/src/rules/valid-connections-file.ts
@@ -1,0 +1,193 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import type { Rule } from 'eslint';
+import path from 'node:path';
+
+// Local structural aliases. We intentionally do NOT import from 'estree' here:
+// the monorepo has multiple copies of @types/estree resolved transitively, and
+// pulling the named types causes TypeScript identity mismatches against
+// `Rule.Node` (which references its own bundled estree). Structural typing is
+// enough — we only branch on `.type` strings.
+type EstreeNode = { type: string; [key: string]: unknown };
+
+const CONNECTIONS_BASENAME_RE = /^connections\.(ts|tsx|js|jsx)$/;
+// Only `CONNECTIONS` (uppercase) is accepted, matching the build plugin's
+// extractor at packages/plugins/apps/src/backend/extract-connections.ts.
+const CONNECTIONS_EXPORT_NAME = 'CONNECTIONS';
+
+type Messages =
+    | 'missingExport'
+    | 'notObjectLiteral'
+    | 'duplicateExport'
+    | 'spreadElement'
+    | 'computedKey'
+    | 'valueNotStaticString'
+    | 'templateInterpolation';
+
+const rule: Rule.RuleModule = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Validate the structure of a Datadog Apps `connections.ts` file',
+            url: 'https://github.com/DataDog/build-plugins/tree/main/packages/published/eslint-plugin-apps#valid-connections-file',
+        },
+        schema: [],
+        messages: {
+            missingExport:
+                'connections file must define a top-level `export const CONNECTIONS = { … }`.',
+            notObjectLiteral:
+                '`export const CONNECTIONS` must be initialized with an object literal.',
+            duplicateExport:
+                'Multiple top-level `export const CONNECTIONS` declarations are not allowed.',
+            spreadElement: 'Spread elements are not supported inside the connections object.',
+            computedKey: 'Computed keys are not supported inside the connections object.',
+            valueNotStaticString:
+                'Value for "{{ key }}" must be a string literal; got {{ valueType }}.',
+            templateInterpolation:
+                'Value for "{{ key }}" must be a static string — template literals with interpolations are not allowed.',
+        } satisfies Record<Messages, string>,
+    },
+
+    create(context) {
+        const basename = path.basename(context.filename);
+        if (!CONNECTIONS_BASENAME_RE.test(basename)) {
+            return {};
+        }
+
+        return {
+            'Program:exit'(programNode) {
+                const matches: EstreeNode[] = [];
+
+                for (const node of programNode.body as EstreeNode[]) {
+                    if (node.type !== 'ExportNamedDeclaration' || !node.declaration) {
+                        continue;
+                    }
+                    const decl = node.declaration as EstreeNode;
+                    if (decl.type !== 'VariableDeclaration') {
+                        continue;
+                    }
+                    for (const declarator of decl.declarations as EstreeNode[]) {
+                        const id = declarator.id as EstreeNode;
+                        if (id.type === 'Identifier' && id.name === CONNECTIONS_EXPORT_NAME) {
+                            matches.push(declarator);
+                        }
+                    }
+                }
+
+                if (matches.length === 0) {
+                    context.report({
+                        node: programNode,
+                        messageId: 'missingExport',
+                    });
+                    return;
+                }
+
+                if (matches.length > 1) {
+                    for (let i = 1; i < matches.length; i += 1) {
+                        context.report({
+                            node: matches[i] as unknown as Rule.Node,
+                            messageId: 'duplicateExport',
+                        });
+                    }
+                }
+
+                const declarator = matches[0];
+                const declaratorInit = declarator.init as EstreeNode | null | undefined;
+                const init = unwrapTsAssertion(declaratorInit);
+                if (!init || init.type !== 'ObjectExpression') {
+                    context.report({
+                        node: (declaratorInit ?? declarator) as unknown as Rule.Node,
+                        messageId: 'notObjectLiteral',
+                    });
+                    return;
+                }
+
+                checkObject(init, context);
+            },
+        };
+    },
+};
+
+function checkObject(obj: EstreeNode, context: Rule.RuleContext): void {
+    for (const property of obj.properties as EstreeNode[]) {
+        if (property.type === 'SpreadElement') {
+            context.report({
+                node: property as unknown as Rule.Node,
+                messageId: 'spreadElement',
+            });
+            continue;
+        }
+
+        if (property.computed) {
+            context.report({
+                node: property as unknown as Rule.Node,
+                messageId: 'computedKey',
+            });
+            continue;
+        }
+
+        const key = readKeyName(property);
+        const propertyValue = property.value as EstreeNode;
+        const value = unwrapTsAssertion(propertyValue);
+
+        if (value && value.type === 'Literal' && typeof value.value === 'string') {
+            continue;
+        }
+
+        if (value && value.type === 'TemplateLiteral') {
+            const expressions = value.expressions as unknown[];
+            if (expressions.length === 0) {
+                continue;
+            }
+            context.report({
+                node: value as unknown as Rule.Node,
+                messageId: 'templateInterpolation',
+                data: { key },
+            });
+            continue;
+        }
+
+        const reported = value ?? propertyValue;
+        context.report({
+            node: reported as unknown as Rule.Node,
+            messageId: 'valueNotStaticString',
+            data: { key, valueType: reported.type },
+        });
+    }
+}
+
+function readKeyName(property: EstreeNode): string {
+    const key = property.key as EstreeNode;
+    if (key.type === 'Identifier') {
+        return String(key.name);
+    }
+    if (key.type === 'Literal') {
+        return String(key.value);
+    }
+    return '<unknown>';
+}
+
+/**
+ * Unwrap TypeScript-specific assertion wrappers (`as const`, `as Foo`,
+ * `<Foo>x`, `x!`) so we can validate the underlying expression. ESLint with
+ * @typescript-eslint/parser preserves these as TSAsExpression / TSTypeAssertion
+ * /TSSatisfiesExpression /TSNonNullExpression nodes; pure estree ASTs never
+ * see them.
+ */
+function unwrapTsAssertion(node: EstreeNode | null | undefined): EstreeNode | null | undefined {
+    let current = node;
+    while (
+        current &&
+        (current.type === 'TSAsExpression' ||
+            current.type === 'TSTypeAssertion' ||
+            current.type === 'TSSatisfiesExpression' ||
+            current.type === 'TSNonNullExpression')
+    ) {
+        current = current.expression as EstreeNode | null | undefined;
+    }
+    return current;
+}
+
+export default rule;

--- a/packages/published/eslint-plugin-apps/src/rules/valid-connections-file.ts
+++ b/packages/published/eslint-plugin-apps/src/rules/valid-connections-file.ts
@@ -3,14 +3,16 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import type { Rule } from 'eslint';
+import type {
+    Expression,
+    ObjectExpression,
+    Pattern,
+    Program,
+    Property,
+    SpreadElement,
+    VariableDeclarator,
+} from 'estree';
 import path from 'node:path';
-
-// Local structural aliases. We intentionally do NOT import from 'estree' here:
-// the monorepo has multiple copies of @types/estree resolved transitively, and
-// pulling the named types causes TypeScript identity mismatches against
-// `Rule.Node` (which references its own bundled estree). Structural typing is
-// enough — we only branch on `.type` strings.
-type EstreeNode = { type: string; [key: string]: unknown };
 
 const CONNECTIONS_BASENAME_RE = /^connections\.(ts|tsx|js|jsx)$/;
 // Only `CONNECTIONS` (uppercase) is accepted, matching the build plugin's
@@ -25,6 +27,14 @@ type Messages =
     | 'computedKey'
     | 'valueNotStaticString'
     | 'templateInterpolation';
+
+// `@types/eslint` ships a nested copy of `@types/estree` whose ArrayExpression
+// /Pattern/etc. types are structurally identical but a different TS module
+// identity from the top-level `@types/estree` we depend on. We use named
+// estree types internally for traversal (real type safety) and cast through
+// `unknown` to `Rule.Node` only at `context.report` boundaries, where the two
+// type universes meet.
+const asRuleNode = (node: { type: string }): Rule.Node => node as unknown as Rule.Node;
 
 const rule: Rule.RuleModule = {
     meta: {
@@ -58,19 +68,21 @@ const rule: Rule.RuleModule = {
 
         return {
             'Program:exit'(programNode) {
-                const matches: EstreeNode[] = [];
+                const program = programNode as unknown as Program;
+                const matches: VariableDeclarator[] = [];
 
-                for (const node of programNode.body as EstreeNode[]) {
+                for (const node of program.body) {
                     if (node.type !== 'ExportNamedDeclaration' || !node.declaration) {
                         continue;
                     }
-                    const decl = node.declaration as EstreeNode;
-                    if (decl.type !== 'VariableDeclaration') {
+                    if (node.declaration.type !== 'VariableDeclaration') {
                         continue;
                     }
-                    for (const declarator of decl.declarations as EstreeNode[]) {
-                        const id = declarator.id as EstreeNode;
-                        if (id.type === 'Identifier' && id.name === CONNECTIONS_EXPORT_NAME) {
+                    for (const declarator of node.declaration.declarations) {
+                        if (
+                            declarator.id.type === 'Identifier' &&
+                            declarator.id.name === CONNECTIONS_EXPORT_NAME
+                        ) {
                             matches.push(declarator);
                         }
                     }
@@ -87,18 +99,17 @@ const rule: Rule.RuleModule = {
                 if (matches.length > 1) {
                     for (let i = 1; i < matches.length; i += 1) {
                         context.report({
-                            node: matches[i] as unknown as Rule.Node,
+                            node: asRuleNode(matches[i]),
                             messageId: 'duplicateExport',
                         });
                     }
                 }
 
                 const declarator = matches[0];
-                const declaratorInit = declarator.init as EstreeNode | null | undefined;
-                const init = unwrapTsAssertion(declaratorInit);
+                const init = unwrapTsAssertion(declarator.init);
                 if (!init || init.type !== 'ObjectExpression') {
                     context.report({
-                        node: (declaratorInit ?? declarator) as unknown as Rule.Node,
+                        node: asRuleNode(declarator.init ?? declarator),
                         messageId: 'notObjectLiteral',
                     });
                     return;
@@ -110,11 +121,11 @@ const rule: Rule.RuleModule = {
     },
 };
 
-function checkObject(obj: EstreeNode, context: Rule.RuleContext): void {
-    for (const property of obj.properties as EstreeNode[]) {
+function checkObject(obj: ObjectExpression, context: Rule.RuleContext): void {
+    for (const property of obj.properties) {
         if (property.type === 'SpreadElement') {
             context.report({
-                node: property as unknown as Rule.Node,
+                node: asRuleNode(property),
                 messageId: 'spreadElement',
             });
             continue;
@@ -122,49 +133,48 @@ function checkObject(obj: EstreeNode, context: Rule.RuleContext): void {
 
         if (property.computed) {
             context.report({
-                node: property as unknown as Rule.Node,
+                node: asRuleNode(property),
                 messageId: 'computedKey',
             });
             continue;
         }
 
         const key = readKeyName(property);
-        const propertyValue = property.value as EstreeNode;
-        const value = unwrapTsAssertion(propertyValue);
+        // Property values may be wrapped in TypeScript-specific assertion nodes
+        // when parsed by @typescript-eslint/parser; unwrap before validating.
+        const value = unwrapTsAssertion(property.value as Expression);
 
         if (value && value.type === 'Literal' && typeof value.value === 'string') {
             continue;
         }
 
         if (value && value.type === 'TemplateLiteral') {
-            const expressions = value.expressions as unknown[];
-            if (expressions.length === 0) {
+            if (value.expressions.length === 0) {
                 continue;
             }
             context.report({
-                node: value as unknown as Rule.Node,
+                node: asRuleNode(value),
                 messageId: 'templateInterpolation',
                 data: { key },
             });
             continue;
         }
 
-        const reported = value ?? propertyValue;
+        const reported = (value ?? property.value) as Expression;
         context.report({
-            node: reported as unknown as Rule.Node,
+            node: asRuleNode(reported),
             messageId: 'valueNotStaticString',
             data: { key, valueType: reported.type },
         });
     }
 }
 
-function readKeyName(property: EstreeNode): string {
-    const key = property.key as EstreeNode;
-    if (key.type === 'Identifier') {
-        return String(key.name);
+function readKeyName(property: Property): string {
+    if (property.key.type === 'Identifier') {
+        return property.key.name;
     }
-    if (key.type === 'Literal') {
-        return String(key.value);
+    if (property.key.type === 'Literal') {
+        return String(property.key.value);
     }
     return '<unknown>';
 }
@@ -174,10 +184,15 @@ function readKeyName(property: EstreeNode): string {
  * `<Foo>x`, `x!`) so we can validate the underlying expression. ESLint with
  * @typescript-eslint/parser preserves these as TSAsExpression / TSTypeAssertion
  * /TSSatisfiesExpression /TSNonNullExpression nodes; pure estree ASTs never
- * see them.
+ * see them and `@types/estree` doesn't model them, so we work with a structural
+ * shape here and cast back at the call sites.
  */
-function unwrapTsAssertion(node: EstreeNode | null | undefined): EstreeNode | null | undefined {
-    let current = node;
+type EstreeNodeLike = { type: string; expression?: unknown };
+
+function unwrapTsAssertion<T extends Expression | Pattern | SpreadElement | null | undefined>(
+    node: T,
+): T {
+    let current = node as EstreeNodeLike | null | undefined;
     while (
         current &&
         (current.type === 'TSAsExpression' ||
@@ -185,9 +200,9 @@ function unwrapTsAssertion(node: EstreeNode | null | undefined): EstreeNode | nu
             current.type === 'TSSatisfiesExpression' ||
             current.type === 'TSNonNullExpression')
     ) {
-        current = current.expression as EstreeNode | null | undefined;
+        current = current.expression as EstreeNodeLike | null | undefined;
     }
-    return current;
+    return current as T;
 }
 
 export default rule;

--- a/packages/published/eslint-plugin-apps/tsconfig.json
+++ b/packages/published/eslint-plugin-apps/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../../tsconfig.json",
+    "compilerOptions": {
+        "baseUrl": "./",
+        "rootDir": "./",
+        "outDir": "./dist"
+    },
+    "include": ["**/*"],
+    "exclude": ["dist", "node_modules"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1729,6 +1729,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@datadog/eslint-plugin-apps@workspace:packages/published/eslint-plugin-apps":
+  version: 0.0.0-use.local
+  resolution: "@datadog/eslint-plugin-apps@workspace:packages/published/eslint-plugin-apps"
+  dependencies:
+    "@dd/tools": "workspace:*"
+    "@rollup/plugin-json": "npm:6.1.0"
+    "@rollup/plugin-node-resolve": "npm:15.3.0"
+    "@types/eslint": "npm:9.6.1"
+    "@typescript-eslint/parser": "npm:7.5.0"
+    esbuild: "npm:0.25.8"
+    eslint: "npm:8.57.0"
+    rollup: "npm:4.45.1"
+    rollup-plugin-dts: "npm:6.1.1"
+    rollup-plugin-esbuild: "npm:6.1.1"
+    typescript: "npm:5.4.3"
+  peerDependencies:
+    eslint: ">=8.57.0"
+  languageName: unknown
+  linkType: soft
+
 "@datadog/js-instrumentation-wasm@npm:1.0.8":
   version: 1.0.8
   resolution: "@datadog/js-instrumentation-wasm@npm:1.0.8"
@@ -4018,7 +4038,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint@npm:*":
+"@types/eslint@npm:*, @types/eslint@npm:9.6.1":
   version: 9.6.1
   resolution: "@types/eslint@npm:9.6.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1737,6 +1737,7 @@ __metadata:
     "@rollup/plugin-json": "npm:6.1.0"
     "@rollup/plugin-node-resolve": "npm:15.3.0"
     "@types/eslint": "npm:9.6.1"
+    "@types/estree": "npm:1.0.8"
     "@typescript-eslint/parser": "npm:7.5.0"
     esbuild: "npm:0.25.8"
     eslint: "npm:8.57.0"


### PR DESCRIPTION
## Motivation

Stacked on top of #331. That PR introduced the build-time `extract-connections.ts` extractor that fails the build when a project's `connections.ts` is malformed. PR #331 explicitly defers an ESLint rule for the same shape to a follow-up — this is that follow-up.

The rule mirrors the extractor's failure cases one-for-one so customers see violations in their editor instead of as a build error. Living in the same repo as the extractor means the two stay in lockstep — extractor contract changes land in the same PR as the rule that mirrors them.

## Changes

New publishable npm package `@datadog/eslint-plugin-apps` at `packages/published/eslint-plugin-apps/`. Builds with rollup (custom config — `getDefaultBuildConfigs` is bundler-plugin specific and would mis-parse the package name), emits dual ESM (`.mjs`) + CJS (`.js`) + `.d.ts` to `dist/src/`. Versioned in lockstep with the rest of the `@datadog/*` packages (`3.1.4`) so `yarn version:all` keeps everything aligned.

Customers wire it up with either flat config or legacy `.eslintrc`:

```js
// eslint.config.js (flat config, ESLint v9)
import apps from '@datadog/eslint-plugin-apps';
import tsParser from '@typescript-eslint/parser';

export default [
    ...apps.configs.recommended,
    {
        files: ['connections.{ts,tsx,js,jsx}'],
        languageOptions: { parser: tsParser },
    },
];
```

```json
// .eslintrc.json (legacy)
{
    "extends": ["plugin:@datadog/apps/recommended-legacy"],
    "parser": "@typescript-eslint/parser"
}
```

The package is structured to grow: more rules can be added under `src/rules/<name>.ts` and registered in `src/index.ts`.

### Initial rule: `valid-connections-file`

Mirrors the extractor at `packages/plugins/apps/src/backend/extract-connections.ts`. Auto-scopes by basename — only runs on files matching `connections.{ts,tsx,js,jsx}`. Reports:

| Violation | Message ID |
|---|---|
| Missing top-level `export const CONNECTIONS = {…}` | `missingExport` |
| Initializer not an object literal (after unwrapping `as const` etc.) | `notObjectLiteral` |
| Two top-level `export const CONNECTIONS` | `duplicateExport` |
| Spread element inside the object | `spreadElement` |
| Computed key | `computedKey` |
| Non-string-literal value | `valueNotStaticString` |
| Template literal with interpolation | `templateInterpolation` |

Only `CONNECTIONS` (uppercase) is accepted, matching the extractor. The rule unwraps `TSAsExpression` / `TSTypeAssertion` / `TSSatisfiesExpression` / `TSNonNullExpression` before structural checks since `@typescript-eslint/parser` preserves those as AST nodes.

### Notable build details

- `format: 'cjs'` output, `external: ['eslint', 'node:path', 'path']` — eslint plugins must be `require()`-loadable for legacy `.eslintrc`. Rollup's CJS emit for an `export default` source already produces `module.exports = plugin` directly, so no `module.exports.default` footer trick is needed (that workaround is only required when the bundler is esbuild).
- Three rollup configs (ESM, CJS, DTS via `rollup-plugin-dts`).
- `buildPlugin.hideFromRootReadme: true` keeps `yarn cli integrity`'s root-README plugin table from gaining a row that doesn't fit (it's wired for bundler plugins).
- The rule uses named `@types/estree` types internally for traversal (real type-checking on field access) and casts `as unknown as Rule.Node` only at the few `context.report` call sites. The reason for the casts: `@types/eslint@9.6.1` ships a nested copy of `@types/estree@1.0.7`, while the rest of the repo (rollup, webpack, `@dd/apps-plugin`) pins `1.0.8`. The two physical type modules are structurally identical but TypeScript treats them as distinct identities, so a `VariableDeclarator` from our top-level estree doesn't satisfy `Rule.Node` (which references `@types/eslint`'s nested copy). Pinning our package to `1.0.7` doesn't help either — Node's module resolution still finds a different physical install path adjacent to our package vs. the one nested under `@types/eslint`. A small, localized cast at the report boundary is the cleanest fix; an `asRuleNode` helper documents the intent in one place.

## QA Instructions

1. `yarn workspace @datadog/eslint-plugin-apps build` — emits `dist/src/index.{js,mjs,d.ts}`.
2. `yarn workspace @dd/tests jest packages/published/eslint-plugin-apps/src/rules/valid-connections-file.test.ts` — 13 RuleTester cases pass (4 valid + 9 invalid, including a "lowercase `connections` is not accepted" assertion).
3. `yarn lint`, `yarn typecheck:all` — clean.
4. `yarn cli integrity` — clean (no required updates).
5. End-to-end against a scaffolded customer app:
   - `yarn pack --out /tmp/eslint-plugin-apps.tgz` from `packages/published/eslint-plugin-apps/`.
   - `npm install --no-save /tmp/eslint-plugin-apps.tgz @typescript-eslint/parser eslint@9` in the test app.
   - Walk each violation case in `connections.ts` (missing export, lowercase `connections`, non-object init, duplicate, spread, computed key, identifier value, template interpolation). Each fires its corresponding `messageId` at the offending line:col.
   - CJS smoke test: `node -e "console.log(Object.keys(require('@datadog/eslint-plugin-apps').rules))"` → `[ 'valid-connections-file' ]`.

## Blast Radius

- Adds a new published-package directory; nothing in the existing build pipeline depends on it.
- Not yet published to npm — until a release ships, no customer can install it.
- New `@datadog/*` package picks up the existing `version:all` and release workflow automatically.
- `yarn cli integrity` doesn't auto-add a row to the root README's plugin table thanks to `buildPlugin.hideFromRootReadme: true`. Future contributors browsing the table won't be misled into thinking this is a bundler plugin.