### PR TITLE
Always publish app on each upload

### DIFF
--- a/packages/plugins/apps/src/index.test.ts
+++ b/packages/plugins/apps/src/index.test.ts
@@ -219,11 +219,14 @@ describe('Apps Plugin - getPlugins', () => {
 
     test('Should upload assets with vite bundler', async () => {
         const intakeHost = 'https://api.example.com';
-        const scope = nock(intakeHost).post(`/${APPS_API_PATH}/app-id/upload`).reply(200, {
+        const uploadScope = nock(intakeHost).post(`/${APPS_API_PATH}/app-id/upload`).reply(200, {
             version_id: 'v123',
             application_id: 'app123',
             app_builder_id: 'builder123',
         });
+        const releaseScope = nock(intakeHost)
+            .put(`/${APPS_API_PATH}/app-id/release/live`)
+            .reply(200, {});
 
         const { errors } = await runBundlers(
             { apps: { identifier: 'app-id', name: 'test-app', dryRun: false } },
@@ -232,6 +235,7 @@ describe('Apps Plugin - getPlugins', () => {
         );
 
         expect(errors).toHaveLength(0);
-        expect(scope.isDone()).toBe(true);
+        expect(uploadScope.isDone()).toBe(true);
+        expect(releaseScope.isDone()).toBe(true);
     });
 });

--- a/packages/plugins/apps/src/upload.test.ts
+++ b/packages/plugins/apps/src/upload.test.ts
@@ -258,13 +258,7 @@ describe('Apps Plugin - upload', () => {
             );
         });
 
-        test('Should make PUT request to release version when APPS_VERSION_NAME is set', async () => {
-            getDDEnvValueMock.mockImplementation((key) => {
-                if (key === 'APPS_VERSION_NAME') {
-                    return 'my-version';
-                }
-                return undefined;
-            });
+        test('Should make PUT request to release version after successful upload', async () => {
             doRequestMock
                 .mockResolvedValueOnce({
                     version_id: 'v123',
@@ -287,7 +281,7 @@ describe('Apps Plugin - upload', () => {
                 onRetry: expect.any(Function),
             });
             expect(mockLogFn).toHaveBeenCalledWith(
-                expect.stringContaining('Released version'),
+                expect.stringContaining('Your application is available at'),
                 'info',
             );
         });

--- a/packages/plugins/apps/src/upload.ts
+++ b/packages/plugins/apps/src/upload.ts
@@ -136,13 +136,6 @@ Would have uploaded ${summary}`,
             const appUrl = `https://api.${context.site}/api/unstable/app-builder-code/apps/serve/${application_id}/v/${version_id}/index.html`;
             const appBuilderUrl = `https://app.${context.site}/app-builder/apps/${app_builder_id}`;
 
-            log.info(
-                `Your application is available at:\n${bold('Standalone :')}\n  ${cyan(appUrl)}\n\n${bold('AppBuilder :')}\n  ${cyan(appBuilderUrl)}`,
-            );
-        }
-
-        const versionName = getDDEnvValue('APPS_VERSION_NAME')?.trim();
-        if (versionName) {
             const releaseUrl = getReleaseUrl(context.site, context.identifier);
             await doRequest({
                 auth: { apiKey: context.apiKey, appKey: context.appKey },
@@ -150,7 +143,7 @@ Would have uploaded ${summary}`,
                 method: 'PUT',
                 type: 'json',
                 getData: async () => ({
-                    data: Readable.from(JSON.stringify({ version_id: versionName })),
+                    data: Readable.from(JSON.stringify({ version_id: response.version_id })),
                     headers: {
                         'Content-Type': 'application/json',
                         ...defaultHeaders,
@@ -164,7 +157,9 @@ Would have uploaded ${summary}`,
                     log.warn(message);
                 },
             });
-            log.info(`Released version ${bold(versionName)} to live.`);
+            log.info(
+                `Your application is available at:\n${bold('Standalone :')}\n  ${cyan(appUrl)}\n\n${bold('AppBuilder :')}\n  ${cyan(appBuilderUrl)}`,
+            );
         }
     } catch (error: unknown) {
         const err = error instanceof Error ? error : new Error(String(error));

--- a/packages/tests/src/e2e/appsPlugin/appsPlugin.spec.ts
+++ b/packages/tests/src/e2e/appsPlugin/appsPlugin.spec.ts
@@ -30,6 +30,24 @@ type UploadRequest = {
 // We write to a temp directory because Playwright workers are separate processes —
 // only the worker that actually builds captures the nock request.
 nock('https://api.datadoghq.com')
+    .put(new RegExp(`/api/unstable/app-builder-code/apps/.*/release/live`))
+    .reply(function handleReleaseMock(uri, body) {
+        const applicationId = uri.split('/apps/')[1]?.split('/release')[0] ?? '';
+        const parsed = typeof body === 'string' ? JSON.parse(body) : body;
+        return [
+            200,
+            {
+                application_id: applicationId,
+                release: {
+                    environment: 'live',
+                    version_id: parsed.version_id ?? '',
+                },
+            },
+        ];
+    })
+    .persist();
+
+nock('https://api.datadoghq.com')
     .post(new RegExp(`/api/unstable/app-builder-code/apps/.*/upload`))
     .reply(function handleUploadMock(uri, body) {
         const data: UploadRequest = {


### PR DESCRIPTION
### What and why?                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                               
  Previously, the apps plugin published the uploaded version to live only when                                                                                                                                                                                 
  `APPS_VERSION_NAME` was set as an environment variable, and the `version_id`                                                                                                                                                                                 
  sent in the release request used that env var's value rather than the ID                                                                                                                                                                                     
  returned by the upload API. This meant a live publish was skipped on every                                                                                                                                                                                   
  upload that didn't set the env var, even though the upload itself succeeded.                                                                                                                                                                                 
                                                                                                                                                                                                                                                               
  This PR makes the live publish happen on every successful upload, using the
  `version_id` from the upload response.                                                                                                                                                                                                                       
                                                                  
  ### How?

  - The `APPS_VERSION_NAME` guard around the release PUT request is removed. The
    release now fires whenever the upload response contains `version_id`,
    `application_id`, and `app_builder_id`.                                                                                                                                                                                                                    
  - The PUT body is updated to use `response.version_id` instead of the
    `APPS_VERSION_NAME` env var value.                                                                                                                                                                                                                         
  - The "Your application is available at" log is moved to after the release                                                                                                                                                                                   
    request so it only appears once the version is live.
  - Tests are updated to reflect the new trigger condition and log message, and                                                                                                                                                                                
    the integration test now mocks the release endpoint.  