### PR TITLE
Skip CI jobs on merge queue branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ jobs:
   unit-test:
     name: Unit tests
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.ref_name, 'mq-working-branch-') }}
     env:
       FORCE_COLOR: true
 
@@ -53,6 +54,7 @@ jobs:
 
     name: End to End
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.ref_name, 'mq-working-branch-') }}
     env:
       FORCE_COLOR: true
 
@@ -127,6 +129,7 @@ jobs:
   lint:
     name: Linting
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.ref_name, 'mq-working-branch-') }}
     env:
       FORCE_COLOR: true
 

--- a/.vitrine/project.json
+++ b/.vitrine/project.json
@@ -1,0 +1,12 @@
+{
+    "name": "Build Plugins",
+    "urls": [],
+    "cmd": "yarn dev",
+    "baseBranch": "master",
+    "defaultWorktree": "none",
+    "defaultPlannerAgent": "coding",
+    "defaultWorkerAgent": "coding",
+    "defaultPage": "tasks",
+    "autoRunAtLaunch": false,
+    "scoutEnabled": false
+}


### PR DESCRIPTION
### What and why?

All three CI jobs (`unit-test`, `e2e`, `lint`) were running on `mq-working-branch-*` pushes triggered by the merge queue. These branches are safe to skip given the repo's contribution level, so we skip the jobs there to save CI minutes.

The `push: branches: mq-working-branch-*` trigger must stay so GitHub's merge queue sees a workflow run and can mark required checks as "skipped" (rather than "missing", which would block the queue).

### How?

Added `if: ${{ !startsWith(github.ref_name, 'mq-working-branch-') }}` at the job level on all three jobs. When triggered by a merge queue branch the condition is false → jobs skip. For normal PR branches the condition is true → jobs run as before.