### PR TITLE
chore(ci): bump GitHub actions to latest version

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -3,15 +3,14 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'What to bump?'
+        description: "What to bump?"
         required: true
-        default: 'patch'
+        default: "patch"
         type: choice
         options:
-        - 'patch'
-        - 'minor'
-        - 'major'
-
+          - "patch"
+          - "minor"
+          - "major"
 
 jobs:
   bump:
@@ -19,125 +18,124 @@ jobs:
       id-token: write # Needed to federate tokens.
     runs-on: ubuntu-latest
     steps:
-    - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80
-      id: octo-sts
-      with:
-        scope: DataDog/build-plugins
-        audience: dd-octo-sts
-        policy: self.bump
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      with:
-        fetch-depth: 0 # Needed for "yarn version" to work.
-        token: ${{ steps.octo-sts.outputs.token }}
-    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version-file: 'package.json'
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80
+        id: octo-sts
+        with:
+          scope: DataDog/build-plugins
+          audience: dd-octo-sts
+          policy: self.bump
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0 # Needed for "yarn version" to work.
+          token: ${{ steps.octo-sts.outputs.token }}
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: "package.json"
 
-    - name: Install dependencies
-      run: yarn install
-    - name: Bump version
-      run: yarn version:all ${{ inputs.version }}
-    - name: Add files
-      run: git add .
-    - name: Variables
-      id: vars
-      run: |
-        VERSION=$(yarn info @datadog/build-plugins --json | jq -r '.children.Version')
-        echo "Version: $VERSION"
+      - name: Install dependencies
+        run: yarn install
+      - name: Bump version
+        run: yarn version:all ${{ inputs.version }}
+      - name: Add files
+        run: git add .
+      - name: Variables
+        id: vars
+        run: |
+          VERSION=$(yarn info @datadog/build-plugins --json | jq -r '.children.Version')
+          echo "Version: $VERSION"
 
-        TAG_NAME="v$VERSION"
-        echo "Tag name: $TAG_NAME"
+          TAG_NAME="v$VERSION"
+          echo "Tag name: $TAG_NAME"
 
-        CURRENT_BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
-        echo "Current branch name: $CURRENT_BRANCH_NAME"
+          CURRENT_BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
+          echo "Current branch name: $CURRENT_BRANCH_NAME"
 
-        BRANCH_NAME="bump-version-$TAG_NAME"
-        echo "Branch name: $BRANCH_NAME"
-
-
-        # Outputs for the next steps.
-        echo "current_branch_name=$CURRENT_BRANCH_NAME" >> $GITHUB_OUTPUT
-        echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
-        echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-    - name: Configure git
-      run: |
-        # Set the git user.
-        git config --global user.name 'Bumper Bot'
-        git config --global user.email '200755185+dd-octo-sts[bot]@users.noreply.github.com'
-
-    - name: Create branch
-      run: |
-        echo "Checking out branch ${{ steps.vars.outputs.branch_name }}..."
-        git checkout -b ${{ steps.vars.outputs.branch_name }}
-
-        echo "Pushing branch ${{ steps.vars.outputs.branch_name }}..."
-        git push -u origin ${{ steps.vars.outputs.branch_name }}
-      env:
-        GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          BRANCH_NAME="bump-version-$TAG_NAME"
+          echo "Branch name: $BRANCH_NAME"
 
 
-    - name: Create commit
-      if: success()
-      run: |
-        echo "Committing..."
-        git commit -m ${{ steps.vars.outputs.tag_name }} --no-verify
-      env:
-        GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          # Outputs for the next steps.
+          echo "current_branch_name=$CURRENT_BRANCH_NAME" >> $GITHUB_OUTPUT
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-    - name: Push commit
-      if: success()
-      uses: Asana/push-signed-commits@d615ca88d8e1a946734c24970d1e7a6c56f34897
-      with:
-        github-token: ${{ steps.octo-sts.outputs.token }}
-        local_branch_name: ${{ steps.vars.outputs.branch_name }}
-        remote_name: origin
-        remote_branch_name: ${{ steps.vars.outputs.branch_name }}
+      - name: Configure git
+        run: |
+          # Set the git user.
+          git config --global user.name 'Bumper Bot'
+          git config --global user.email '200755185+dd-octo-sts[bot]@users.noreply.github.com'
 
-    - name: Create tag
-      if: success()
-      run: |
-        echo "Creating tag..."
-        git tag -a ${{ steps.vars.outputs.tag_name }} -m ${{ steps.vars.outputs.tag_name }}
-        echo "Pushing tag..."
-        git push origin ${{ steps.vars.outputs.tag_name }}
-      env:
-        GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
+      - name: Create branch
+        run: |
+          echo "Checking out branch ${{ steps.vars.outputs.branch_name }}..."
+          git checkout -b ${{ steps.vars.outputs.branch_name }}
 
-    - name: Create PR
-      if: success()
-      run: |
-        echo "Creating PR..."
-        TITLE="[bot] Bump versions to \`${{ steps.vars.outputs.tag_name }}\`"
-        PR_URL=$(gh pr create \
-          --title "$TITLE" \
-          --body "This PR bumps the package versions to \`${{ steps.vars.outputs.tag_name }}\`" \
-          --base "${{ steps.vars.outputs.current_branch_name }}" \
-          --head "${{ steps.vars.outputs.branch_name }}")
-        OUTPUT="### PR Created\n**[$TITLE]($PR_URL)**"
-        echo -e "$OUTPUT" >> $GITHUB_STEP_SUMMARY
-      env:
-        GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          echo "Pushing branch ${{ steps.vars.outputs.branch_name }}..."
+          git push -u origin ${{ steps.vars.outputs.branch_name }}
+        env:
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
 
-    - name: Log bump
-      if: success()
-      run: |
-        HEADERS=(
-          -H "Content-Type: application/json"
-          -H "X-Datadog-Origin: build-plugins"
-          -H "DD-API-KEY: $DATADOG_API_KEY"
-        )
-        DATA="{
-          \"ddsource\": \"github\",
-          \"service\": \"build-plugins\",
-          \"message\": \"Version bumped: ${{ steps.vars.outputs.version }}\",
-          \"status\": \"success\",
-          \"env\": \"production\",
-          \"team\": \"language-foundations\",
-          \"version\": \"${{ steps.vars.outputs.version }}\"
-        }"
-        URL="https://http-intake.logs.datadoghq.com/api/v2/logs"
-        curl -X POST "${HEADERS[@]}" -d "$DATA" "$URL"
-      env:
-        DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      - name: Create commit
+        if: success()
+        run: |
+          echo "Committing..."
+          git commit -m ${{ steps.vars.outputs.tag_name }} --no-verify
+        env:
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
+
+      - name: Push commit
+        if: success()
+        uses: Asana/push-signed-commits@d615ca88d8e1a946734c24970d1e7a6c56f34897
+        with:
+          github-token: ${{ steps.octo-sts.outputs.token }}
+          local_branch_name: ${{ steps.vars.outputs.branch_name }}
+          remote_name: origin
+          remote_branch_name: ${{ steps.vars.outputs.branch_name }}
+
+      - name: Create tag
+        if: success()
+        run: |
+          echo "Creating tag..."
+          git tag -a ${{ steps.vars.outputs.tag_name }} -m ${{ steps.vars.outputs.tag_name }}
+          echo "Pushing tag..."
+          git push origin ${{ steps.vars.outputs.tag_name }}
+        env:
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
+
+      - name: Create PR
+        if: success()
+        run: |
+          echo "Creating PR..."
+          TITLE="[bot] Bump versions to \`${{ steps.vars.outputs.tag_name }}\`"
+          PR_URL=$(gh pr create \
+            --title "$TITLE" \
+            --body "This PR bumps the package versions to \`${{ steps.vars.outputs.tag_name }}\`" \
+            --base "${{ steps.vars.outputs.current_branch_name }}" \
+            --head "${{ steps.vars.outputs.branch_name }}")
+          OUTPUT="### PR Created\n**[$TITLE]($PR_URL)**"
+          echo -e "$OUTPUT" >> $GITHUB_STEP_SUMMARY
+        env:
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
+
+      - name: Log bump
+        if: success()
+        run: |
+          HEADERS=(
+            -H "Content-Type: application/json"
+            -H "X-Datadog-Origin: build-plugins"
+            -H "DD-API-KEY: $DATADOG_API_KEY"
+          )
+          DATA="{
+            \"ddsource\": \"github\",
+            \"service\": \"build-plugins\",
+            \"message\": \"Version bumped: ${{ steps.vars.outputs.version }}\",
+            \"status\": \"success\",
+            \"env\": \"production\",
+            \"team\": \"language-foundations\",
+            \"version\": \"${{ steps.vars.outputs.version }}\"
+          }"
+          URL="https://http-intake.logs.datadoghq.com/api/v2/logs"
+          curl -X POST "${HEADERS[@]}" -d "$DATA" "$URL"
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - 'mq-working-branch-*'
+      - "mq-working-branch-*"
 
 jobs:
   unit-test:
@@ -14,39 +14,42 @@ jobs:
       FORCE_COLOR: true
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Install Node
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version-file: 'package.json'
+      - name: Install Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: "package.json"
 
-    - name: Cache build:all
-      id: cache-build
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-      with:
-        path: packages/published/**/dist
-        key: ${{ matrix.node }}-cache-build-${{ hashFiles('packages/core/**', 'packages/factory/**', 'packages/plugins/**', 'packages/published/**', 'packages/tools/src/rollupConfig.mjs', 'yarn.lock') }}
+      - name: Cache build:all
+        id: cache-build
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: packages/published/**/dist
+          key: ${{ matrix.node }}-cache-build-${{ hashFiles('packages/core/**',
+            'packages/factory/**', 'packages/plugins/**',
+            'packages/published/**', 'packages/tools/src/rollupConfig.mjs',
+            'yarn.lock') }}
 
-    - name: Configure Datadog Test Optimization
-      uses: datadog/test-visibility-github-action@f76512a963e7375dab9ad7f1abc0cacd41806c5c # v2.6.0
-      with:
-        languages: js
-        service: build-plugins
-        api_key: ${{secrets.DATADOG_API_KEY}}
-        site: datadoghq.com
+      - name: Configure Datadog Test Optimization
+        uses: datadog/test-visibility-github-action@f76512a963e7375dab9ad7f1abc0cacd41806c5c # v2.6.0
+        with:
+          languages: js
+          service: build-plugins
+          api_key: ${{secrets.DATADOG_API_KEY}}
+          site: datadoghq.com
 
-    - run: yarn install
+      - run: yarn install
 
-    - name: Build all plugins
-      if: steps.cache-build.outputs.cache-hit != 'true'
-      run: yarn build:all # We need the full build because one of the test verifies that we do produce the *.d.ts files.
+      - name: Build all plugins
+        if: steps.cache-build.outputs.cache-hit != 'true'
+        run: yarn build:all # We need the full build because one of the test verifies that we do produce the *.d.ts files.
 
-    - run: yarn test:unit --silent
-      env:
-        NODE_OPTIONS: -r ${{env.DD_TRACE_PACKAGE}}
-        DD_TAGS: type:unit
-        DD_ENV: ci
+      - run: yarn test:unit --silent
+        env:
+          NODE_OPTIONS: -r ${{env.DD_TRACE_PACKAGE}}
+          DD_TAGS: type:unit
+          DD_ENV: ci
 
   e2e:
     timeout-minutes: 30
@@ -57,72 +60,74 @@ jobs:
       FORCE_COLOR: true
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Install Node
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version-file: 'package.json'
+      - name: Install Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: "package.json"
 
-    - name: Cache build:all
-      id: cache-build
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-      with:
-        path: packages/published/**/dist
-        key: node18-cache-build-${{ hashFiles('packages/core/**', 'packages/factory/**', 'packages/plugins/**', 'packages/published/**', 'packages/tools/src/rollupConfig.mjs', 'yarn.lock') }}
+      - name: Cache build:all
+        id: cache-build
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: packages/published/**/dist
+          key: node18-cache-build-${{ hashFiles('packages/core/**', 'packages/factory/**',
+            'packages/plugins/**', 'packages/published/**',
+            'packages/tools/src/rollupConfig.mjs', 'yarn.lock') }}
 
-    - name: Cache playwright binaries
-      id: cache-playwright-binaries
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-      with:
-        path: |
-          ~/.cache/ms-playwright
-          ~/Library/Caches/ms-playwright
-          %USERPROFILE%\AppData\Local\ms-playwright
-        key: cache-playwright-binaries-${{ hashFiles('yarn.lock') }}
+      - name: Cache playwright binaries
+        id: cache-playwright-binaries
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+            %USERPROFILE%\AppData\Local\ms-playwright
+          key: cache-playwright-binaries-${{ hashFiles('yarn.lock') }}
 
-    - name: Configure Datadog Test Optimization
-      uses: datadog/test-visibility-github-action@f76512a963e7375dab9ad7f1abc0cacd41806c5c # v2.6.0
-      with:
-        languages: js
-        service: build-plugins
-        api_key: ${{secrets.DATADOG_API_KEY}}
-        site: datadoghq.com
+      - name: Configure Datadog Test Optimization
+        uses: datadog/test-visibility-github-action@f76512a963e7375dab9ad7f1abc0cacd41806c5c # v2.6.0
+        with:
+          languages: js
+          service: build-plugins
+          api_key: ${{secrets.DATADOG_API_KEY}}
+          site: datadoghq.com
 
-    - run: yarn install
+      - run: yarn install
 
-    - name: Install playwright
-      run: yarn workspace @dd/tests playwright install --with-deps
+      - name: Install playwright
+        run: yarn workspace @dd/tests playwright install --with-deps
 
-    - name: Build all plugins
-      if: steps.cache-build.outputs.cache-hit != 'true'
-      run: yarn build:all-no-types
+      - name: Build all plugins
+        if: steps.cache-build.outputs.cache-hit != 'true'
+        run: yarn build:all-no-types
 
-    - run: yarn test:e2e
-      env:
-        NODE_OPTIONS: -r ${{env.DD_TRACE_PACKAGE}}
-        DD_TAGS: type:e2e
-        DD_ENV: ci
+      - run: yarn test:e2e
+        env:
+          NODE_OPTIONS: -r ${{env.DD_TRACE_PACKAGE}}
+          DD_TAGS: type:e2e
+          DD_ENV: ci
 
-    - name: Save playwright cache
-      if: always() && steps.cache-playwright-binaries.outputs.cache-hit != 'true'
-      id: save-playwright-cache
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-      with:
-        path: |
-          ~/.cache/ms-playwright
-          ~/Library/Caches/ms-playwright
-          %USERPROFILE%\AppData\Local\ms-playwright
-        key: cache-playwright-binaries-${{ hashFiles('yarn.lock') }}
+      - name: Save playwright cache
+        if: always() && steps.cache-playwright-binaries.outputs.cache-hit != 'true'
+        id: save-playwright-cache
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+            %USERPROFILE%\AppData\Local\ms-playwright
+          key: cache-playwright-binaries-${{ hashFiles('yarn.lock') }}
 
-    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      if: ${{ failure() }}
-      with:
-        name: playwright
-        path: |
-          packages/tests/playwright-report
-          packages/tests/test-results
-        retention-days: 3
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ failure() }}
+        with:
+          name: playwright
+          path: |
+            packages/tests/playwright-report
+            packages/tests/test-results
+          retention-days: 3
 
   lint:
     name: Linting
@@ -131,51 +136,57 @@ jobs:
       FORCE_COLOR: true
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Install Node
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version-file: 'package.json'
+      - name: Install Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: "package.json"
 
-    - name: Cache build:rollup
-      id: cache-build-rollup
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-      with:
-        path: packages/published/rollup-plugin/dist-basic
-        key: node18-cache-build-rollup-${{ hashFiles('packages/core/**', 'packages/factory/**', 'packages/plugins/**', 'packages/published/**', 'packages/tools/src/rollupConfig.mjs', 'yarn.lock') }}
+      - name: Cache build:rollup
+        id: cache-build-rollup
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: packages/published/rollup-plugin/dist-basic
+          key: node18-cache-build-rollup-${{ hashFiles('packages/core/**',
+            'packages/factory/**', 'packages/plugins/**',
+            'packages/published/**', 'packages/tools/src/rollupConfig.mjs',
+            'yarn.lock') }}
 
-    - name: Cache build:all
-      id: cache-build
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-      with:
-        path: packages/published/**/dist
-        key: node18-cache-build-${{ hashFiles('packages/core/**', 'packages/factory/**', 'packages/plugins/**', 'packages/published/**', 'packages/tools/src/rollupConfig.mjs', 'yarn.lock') }}
+      - name: Cache build:all
+        id: cache-build
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: packages/published/**/dist
+          key: node18-cache-build-${{ hashFiles('packages/core/**', 'packages/factory/**',
+            'packages/plugins/**', 'packages/published/**',
+            'packages/tools/src/rollupConfig.mjs', 'yarn.lock') }}
 
-    - run: yarn install
+      - run: yarn install
 
-    # Pre build the rollup plugin so it can be used in the following step.
-    - name: Build rollup's plugin
-      if: steps.cache-build-rollup.outputs.cache-hit != 'true'
-      run: yarn workspace @datadog/rollup-plugin run buildBasic
+      # Pre build the rollup plugin so it can be used in the following step.
+      - name: Build rollup's plugin
+        if: steps.cache-build-rollup.outputs.cache-hit != 'true'
+        run: yarn workspace @datadog/rollup-plugin run buildBasic
 
-    - name: Build all plugins
-      if: steps.cache-build.outputs.cache-hit != 'true'
-      run: yarn build:all-no-types
-      env:
-        ADD_BUILD_PLUGINS: 1
-        BUILD_PLUGINS_REPORTS: 1
-        DD_GITHUB_JOB_NAME: Linting # Needs to be the same as the job to have CI Vis link the spans.
-        DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      - name: Build all plugins
+        if: steps.cache-build.outputs.cache-hit != 'true'
+        run: yarn build:all-no-types
+        env:
+          ADD_BUILD_PLUGINS: 1
+          BUILD_PLUGINS_REPORTS: 1
+          DD_GITHUB_JOB_NAME: Linting # Needs to be the same as the job to have CI Vis link the spans.
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
 
-    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      if: steps.cache-build.outputs.cache-hit != 'true'
-      with:
-        name: build-reports
-        path: |
-          packages/published/*/dist/reports
-        retention-days: 1
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: steps.cache-build.outputs.cache-hit != 'true'
+        with:
+          name: build-reports
+          path: |
+            packages/published/*/dist/reports
+          retention-days: 1
 
-    - run: yarn cli integrity
+      - run: yarn cli integrity
 
-    - run: git diff --exit-code && git diff --cached --exit-code || (echo "Please run 'yarn cli integrity' and commit the result." && exit 1)
+      - run: git diff --exit-code && git diff --cached --exit-code || (echo "Please run
+          'yarn cli integrity' and commit the result." && exit 1)

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,19 +1,20 @@
 name: Publish packages on NPM
 on:
   release:
-    types: [released]
+    types: [ released ]
   workflow_dispatch:
     inputs:
       channel:
-        description: 'Publish channel (latest or dev)'
+        description: "Publish channel (latest or dev)"
         required: true
-        default: 'dev'
+        default: "dev"
         type: choice
         options:
           - latest
           - dev
       version:
-        description: 'Version to publish (leave empty to use current version in package.json)'
+        description: "Version to publish (leave empty to use current version in
+          package.json)"
         required: false
         type: string
 
@@ -24,118 +25,118 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      with:
-        fetch-depth: 0 # Full history needed for yarn version to find ancestor with master/main
-    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version: '24'
-        registry-url: 'https://registry.npmjs.org'
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0 # Full history needed for yarn version to find ancestor with master/main
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
 
-    - name: Validate and set channel
-      id: channel
-      run: |
-        # Defaults to 'latest' for release events, otherwise uses dispatch input (which defaults to 'dev').
-        CHANNEL="${{ github.event.inputs.channel || 'latest' }}"
+      - name: Validate and set channel
+        id: channel
+        run: |
+          # Defaults to 'latest' for release events, otherwise uses dispatch input (which defaults to 'dev').
+          CHANNEL="${{ github.event.inputs.channel || 'latest' }}"
 
-        # For release events, github.ref_name is the tag name, not the branch.
-        # Get the branch name from the release target_commitish or default branch.
-        if [ "${{ github.event_name }}" = "release" ]; then
-          BRANCH="${{ github.event.release.target_commitish }}"
-        else
-          BRANCH="${{ github.ref_name }}"
-        fi
+          # For release events, github.ref_name is the tag name, not the branch.
+          # Get the branch name from the release target_commitish or default branch.
+          if [ "${{ github.event_name }}" = "release" ]; then
+            BRANCH="${{ github.event.release.target_commitish }}"
+          else
+            BRANCH="${{ github.ref_name }}"
+          fi
 
-        # Restrict 'latest' channel to master branch only
-        if [ "$CHANNEL" = "latest" ] && [ "$BRANCH" != "master" ]; then
-          echo "Error: The 'latest' channel can only be published from the 'master' branch."
-          echo "Current branch: $BRANCH"
-          echo "Use the 'dev' channel for publishing from other branches."
-          exit 1
-        fi
-
-        echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
-        echo "branch=$BRANCH" >> $GITHUB_OUTPUT
-        echo "Publishing to channel: $CHANNEL from branch: $BRANCH"
-
-    - name: Validate and set version
-      id: version
-      run: |
-        VERSION="${{ github.event.inputs.version }}"
-        CHANNEL="${{ steps.channel.outputs.channel }}"
-        BRANCH="${{ steps.channel.outputs.branch }}"
-
-        # If version is provided, validate it
-        if [ -n "$VERSION" ]; then
-          echo "Using provided version: $VERSION"
-
-          # Restrict version override on master branch to non-latest channels only
-          if [ "$BRANCH" = "master" ] && [ "$CHANNEL" = "latest" ]; then
-            echo "Error: Cannot provide a custom version when publishing to 'latest' channel from the 'master' branch."
-            echo "For 'latest' channel on master, the version from package.json must be used."
+          # Restrict 'latest' channel to master branch only
+          if [ "$CHANNEL" = "latest" ] && [ "$BRANCH" != "master" ]; then
+            echo "Error: The 'latest' channel can only be published from the 'master' branch."
+            echo "Current branch: $BRANCH"
+            echo "Use the 'dev' channel for publishing from other branches."
             exit 1
           fi
 
-          # For dev channel, verify version ends with -dev.<number>
-          if [ "$CHANNEL" = "dev" ]; then
-            if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-dev\.[0-9]+$'; then
-              echo "Error: Dev channel versions must end with -dev.<number> (e.g., 1.0.0-dev.0)"
+          echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "Publishing to channel: $CHANNEL from branch: $BRANCH"
+
+      - name: Validate and set version
+        id: version
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          CHANNEL="${{ steps.channel.outputs.channel }}"
+          BRANCH="${{ steps.channel.outputs.branch }}"
+
+          # If version is provided, validate it
+          if [ -n "$VERSION" ]; then
+            echo "Using provided version: $VERSION"
+
+            # Restrict version override on master branch to non-latest channels only
+            if [ "$BRANCH" = "master" ] && [ "$CHANNEL" = "latest" ]; then
+              echo "Error: Cannot provide a custom version when publishing to 'latest' channel from the 'master' branch."
+              echo "For 'latest' channel on master, the version from package.json must be used."
               exit 1
             fi
+
+            # For dev channel, verify version ends with -dev.<number>
+            if [ "$CHANNEL" = "dev" ]; then
+              if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-dev\.[0-9]+$'; then
+                echo "Error: Dev channel versions must end with -dev.<number> (e.g., 1.0.0-dev.0)"
+                exit 1
+              fi
+            fi
+
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "has_version=true" >> $GITHUB_OUTPUT
+          else
+            echo "No version provided, will use current package.json version"
+            echo "has_version=false" >> $GITHUB_OUTPUT
           fi
 
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "has_version=true" >> $GITHUB_OUTPUT
-        else
-          echo "No version provided, will use current package.json version"
-          echo "has_version=false" >> $GITHUB_OUTPUT
-        fi
+      - run: yarn
 
-    - run: yarn
+      - name: Set version if provided
+        if: steps.version.outputs.has_version == 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          echo "Setting version to: $VERSION"
+          yarn version:all "$VERSION"
+      - run: yarn workspace @datadog/rollup-plugin buildBasic
+      - run: export BUILD_PLUGINS_ENV=production
 
-    - name: Set version if provided
-      if: steps.version.outputs.has_version == 'true'
-      run: |
-        VERSION="${{ steps.version.outputs.version }}"
-        echo "Setting version to: $VERSION"
-        yarn version:all "$VERSION"
-    - run: yarn workspace @datadog/rollup-plugin buildBasic
-    - run: export BUILD_PLUGINS_ENV=production
-
-    - name: Publish to NPM
-      run: |
-        CHANNEL="${{ steps.channel.outputs.channel }}"
-        if [ "$CHANNEL" = "dev" ]; then
-          echo "Publishing to dev channel with --tag dev"
-          yarn loop --no-private npm publish --tag dev
-        else
-          echo "Publishing to latest channel"
-          yarn loop --no-private npm publish
-        fi
-      env:
-        ADD_BUILD_PLUGINS: 1
-        DD_GITHUB_JOB_NAME: Publish to NPM # Needs to be the same as the job to have CI Vis link the spans.
-        DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
-    - name: Log version published
-      run: |
-        VERSION="$(yarn workspace @datadog/webpack-plugin info @datadog/webpack-plugin --json | jq -r '.children.Version')"
-        CHANNEL="${{ steps.channel.outputs.channel }}"
-        HEADERS=(
-          -H "Content-Type: application/json"
-          -H "X-Datadog-Origin: build-plugins"
-          -H "DD-API-KEY: $DATADOG_API_KEY"
-        )
-        DATA="{
-          \"ddsource\": \"github\",
-          \"service\": \"build-plugins\",
-          \"message\": \"Version published to $CHANNEL channel: $VERSION\",
-          \"status\": \"success\",
-          \"env\": \"production\",
-          \"team\": \"language-foundations\",
-          \"version\": \"$VERSION\",
-          \"channel\": \"$CHANNEL\"
-        }"
-        URL="https://http-intake.logs.datadoghq.com/api/v2/logs"
-        curl -X POST "${HEADERS[@]}" -d "$DATA" "$URL"
-      env:
-        DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      - name: Publish to NPM
+        run: |
+          CHANNEL="${{ steps.channel.outputs.channel }}"
+          if [ "$CHANNEL" = "dev" ]; then
+            echo "Publishing to dev channel with --tag dev"
+            yarn loop --no-private npm publish --tag dev
+          else
+            echo "Publishing to latest channel"
+            yarn loop --no-private npm publish
+          fi
+        env:
+          ADD_BUILD_PLUGINS: 1
+          DD_GITHUB_JOB_NAME: Publish to NPM # Needs to be the same as the job to have CI Vis link the spans.
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      - name: Log version published
+        run: |
+          VERSION="$(yarn workspace @datadog/webpack-plugin info @datadog/webpack-plugin --json | jq -r '.children.Version')"
+          CHANNEL="${{ steps.channel.outputs.channel }}"
+          HEADERS=(
+            -H "Content-Type: application/json"
+            -H "X-Datadog-Origin: build-plugins"
+            -H "DD-API-KEY: $DATADOG_API_KEY"
+          )
+          DATA="{
+            \"ddsource\": \"github\",
+            \"service\": \"build-plugins\",
+            \"message\": \"Version published to $CHANNEL channel: $VERSION\",
+            \"status\": \"success\",
+            \"env\": \"production\",
+            \"team\": \"language-foundations\",
+            \"version\": \"$VERSION\",
+            \"channel\": \"$CHANNEL\"
+          }"
+          URL="https://http-intake.logs.datadoghq.com/api/v2/logs"
+          curl -X POST "${HEADERS[@]}" -d "$DATA" "$URL"
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}


### PR DESCRIPTION
### What and why?

Running the Publish packages on NPM workflow currently shows GitHub’s warning that Node.js 20 actions are deprecated and should be upgraded. This PR updates the GitHub Actions used by the build-plugins workflows to their latest pinned versions to address that warning.

Keeping these actions current also reduces CI maintenance risk, picks up upstream fixes, and keeps the repository aligned with supported versions of the standard GitHub workflow actions. There are no application or package behavior changes.

Reviewer note: please enable “Hide whitespace” in the GitHub diff viewer. Most of the diff is YAML formatting churn, so the meaningful changes are much easier to review with whitespace ignored.

### How?

The CI, publish, and bump workflows were updated to use newer pinned SHAs for:

- `actions/checkout`
- `actions/setup-node`
- `actions/cache`
- `actions/cache/save`

The formatting changes would normally have been split into a separate commit or PR from the action version bumps, but editor auto-format-on-save made separating those changes awkward, so they are included together here.
