### PR TITLE
Update CODEOWNERS for apps plugin ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,9 @@
 
 # Plugin owners
 
+# High Code Apps
+packages/plugins/apps                                                 @DataDog/app-builder-high-code @yoannmoinet
+
 # Build Report
 packages/plugins/build-report                                         @yoannmoinet
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,6 @@
 
 # Plugin owners
 
-# High Code Apps
-packages/plugins/apps                                                 @DataDog/app-builder-high-code @yoannmoinet
-
 # Build Report
 packages/plugins/build-report                                         @yoannmoinet
 
@@ -44,7 +41,7 @@ packages/plugins/async-queue                                          @yoannmoin
 packages/plugins/output                                               @yoannmoinet
 
 # Apps
-packages/plugins/apps                                                 @yoannmoinet
+packages/plugins/apps                                                 @DataDog/app-builder-high-code @yoannmoinet
 
 # Live Debugger
 packages/plugins/live-debugger/                                       @DataDog/debugger @yoannmoinet


### PR DESCRIPTION
### What and why?

Since High Code Apps is a significant contributor and invested in the apps plugin, let's make them (us) the codeowners.

### How?

Adds High Code Apps as codeowners for the apps plugin.
