### PR TITLE
[APPS] Fix dev backend query API origin

### DIFF
--- a/packages/plugins/apps/src/vite/dev-server.test.ts
+++ b/packages/plugins/apps/src/vite/dev-server.test.ts
@@ -2,7 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import { createDevServerMiddleware } from '@dd/apps-plugin/vite/dev-server';
+import { createDevServerMiddleware, getQueryApiOrigin } from '@dd/apps-plugin/vite/dev-server';
 import { getMockLogger } from '@dd/tests/_jest/helpers/mocks';
 import { EventEmitter } from 'events';
 import type { IncomingMessage, ServerResponse } from 'http';
@@ -13,7 +13,7 @@ import type { BackendFunction } from '../backend/types';
 
 const mockViteBuild = jest.fn();
 
-const DD_SITE = 'datadoghq.com';
+const DD_API_ORIGIN = 'https://api.datadoghq.com';
 
 const mockFunctions: BackendFunction[] = [
     {
@@ -95,6 +95,24 @@ describe('Dev Server Middleware', () => {
         nock.cleanAll();
     });
 
+    describe('getQueryApiOrigin', () => {
+        test('Should normalize Datadog sites to their API origin', () => {
+            expect(getQueryApiOrigin('datadoghq.com')).toBe('https://api.datadoghq.com');
+            expect(getQueryApiOrigin('datad0g.com')).toBe('https://api.datad0g.com');
+            expect(getQueryApiOrigin('us5.datadoghq.com')).toBe('https://api.us5.datadoghq.com');
+        });
+
+        test('Should preserve explicit API origins', () => {
+            expect(getQueryApiOrigin('api.datadoghq.com')).toBe('https://api.datadoghq.com');
+            expect(getQueryApiOrigin('api.datad0g.com')).toBe('https://api.datad0g.com');
+        });
+
+        test('Should normalize app origins to API origins', () => {
+            expect(getQueryApiOrigin('app.datadoghq.com')).toBe('https://api.datadoghq.com');
+            expect(getQueryApiOrigin('app.datad0g.com')).toBe('https://api.datad0g.com');
+        });
+    });
+
     describe('createDevServerMiddleware routing', () => {
         const middleware = createDevServerMiddleware(
             mockViteBuild,
@@ -149,7 +167,7 @@ describe('Dev Server Middleware', () => {
             mockViteBuild.mockResolvedValue(mockBuildResult('// bundled code'));
 
             // Mock the Datadog API via nock.
-            const apiScope = nock(`https://${DD_SITE}`)
+            const apiScope = nock(DD_API_ORIGIN)
                 .post('/api/v2/app-builder/queries/preview-async')
                 .reply(200, { data: { id: 'receipt-123' } })
                 .get('/api/v2/app-builder/queries/execution-long-polling/receipt-123')
@@ -300,7 +318,7 @@ describe('Dev Server Middleware', () => {
         test('Should return 500 when Datadog API fails', async () => {
             mockViteBuild.mockResolvedValue(mockBuildResult('// code'));
 
-            nock(`https://${DD_SITE}`)
+            nock(DD_API_ORIGIN)
                 .post('/api/v2/app-builder/queries/preview-async')
                 .reply(403, 'Forbidden');
 
@@ -334,7 +352,7 @@ describe('Dev Server Middleware', () => {
                 };
             };
             let capturedBody: PreviewAsyncBody | undefined;
-            const apiScope = nock(`https://${DD_SITE}`, {
+            const apiScope = nock(DD_API_ORIGIN, {
                 reqheaders: {
                     'DD-API-KEY': 'test-api-key',
                     'DD-APPLICATION-KEY': 'test-app-key',
@@ -399,7 +417,7 @@ describe('Dev Server Middleware', () => {
                 };
             };
             let capturedBody: PreviewAsyncBody | undefined;
-            const apiScope = nock(`https://${DD_SITE}`)
+            const apiScope = nock(DD_API_ORIGIN)
                 .post('/api/v2/app-builder/queries/preview-async', (body) => {
                     capturedBody = body as PreviewAsyncBody;
                     return true;
@@ -429,7 +447,7 @@ describe('Dev Server Middleware', () => {
         test('Should handle errors array from long-polling endpoint', async () => {
             mockViteBuild.mockResolvedValue(mockBuildResult('// code'));
 
-            nock(`https://${DD_SITE}`)
+            nock(DD_API_ORIGIN)
                 .post('/api/v2/app-builder/queries/preview-async')
                 .reply(200, { data: { id: 'receipt-err' } })
                 .get('/api/v2/app-builder/queries/execution-long-polling/receipt-err')
@@ -455,7 +473,7 @@ describe('Dev Server Middleware', () => {
         test('Should retry when long-poll returns done: false', async () => {
             mockViteBuild.mockResolvedValue(mockBuildResult('// code'));
 
-            const apiScope = nock(`https://${DD_SITE}`)
+            const apiScope = nock(DD_API_ORIGIN)
                 .post('/api/v2/app-builder/queries/preview-async')
                 .reply(200, { data: { id: 'receipt-retry' } })
                 .get('/api/v2/app-builder/queries/execution-long-polling/receipt-retry')

--- a/packages/plugins/apps/src/vite/dev-server.test.ts
+++ b/packages/plugins/apps/src/vite/dev-server.test.ts
@@ -2,7 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import { createDevServerMiddleware, getQueryApiOrigin } from '@dd/apps-plugin/vite/dev-server';
+import { createDevServerMiddleware } from '@dd/apps-plugin/vite/dev-server';
 import { getMockLogger } from '@dd/tests/_jest/helpers/mocks';
 import { EventEmitter } from 'events';
 import type { IncomingMessage, ServerResponse } from 'http';
@@ -93,24 +93,6 @@ function mockBuildResult(code: string) {
 describe('Dev Server Middleware', () => {
     afterEach(() => {
         nock.cleanAll();
-    });
-
-    describe('getQueryApiOrigin', () => {
-        test('Should normalize Datadog sites to their API origin', () => {
-            expect(getQueryApiOrigin('datadoghq.com')).toBe('https://api.datadoghq.com');
-            expect(getQueryApiOrigin('datad0g.com')).toBe('https://api.datad0g.com');
-            expect(getQueryApiOrigin('us5.datadoghq.com')).toBe('https://api.us5.datadoghq.com');
-        });
-
-        test('Should preserve explicit API origins', () => {
-            expect(getQueryApiOrigin('api.datadoghq.com')).toBe('https://api.datadoghq.com');
-            expect(getQueryApiOrigin('api.datad0g.com')).toBe('https://api.datad0g.com');
-        });
-
-        test('Should normalize app origins to API origins', () => {
-            expect(getQueryApiOrigin('app.datadoghq.com')).toBe('https://api.datadoghq.com');
-            expect(getQueryApiOrigin('app.datad0g.com')).toBe('https://api.datad0g.com');
-        });
     });
 
     describe('createDevServerMiddleware routing', () => {

--- a/packages/plugins/apps/src/vite/dev-server.ts
+++ b/packages/plugins/apps/src/vite/dev-server.ts
@@ -28,6 +28,18 @@ type AuthConfig = Required<AuthOptionsWithDefaults>;
  */
 type BackendOutputs = { data: unknown };
 
+export function getQueryApiOrigin(site: string): string {
+    if (site.startsWith('api.')) {
+        return `https://${site}`;
+    }
+
+    if (site.startsWith('app.')) {
+        return `https://api.${site.slice('app.'.length)}`;
+    }
+
+    return `https://api.${site}`;
+}
+
 /**
  * Format a BackendFunction for display in log/error messages.
  */
@@ -118,7 +130,7 @@ async function executeScriptViaDatadog(
     auth: AuthConfig,
     log: Logger,
 ): Promise<BackendOutputs> {
-    const endpoint = `https://${auth.site}/api/v2/app-builder/queries/preview-async`;
+    const endpoint = `${getQueryApiOrigin(auth.site)}/api/v2/app-builder/queries/preview-async`;
     const displayName = formatRef(func);
 
     log.debug(`Calling Datadog API: ${endpoint}`);
@@ -179,7 +191,7 @@ async function pollQueryExecution(
     auth: AuthConfig,
     log: Logger,
 ): Promise<BackendOutputs> {
-    const endpoint = `https://${auth.site}/api/v2/app-builder/queries/execution-long-polling/${receiptId}`;
+    const endpoint = `${getQueryApiOrigin(auth.site)}/api/v2/app-builder/queries/execution-long-polling/${receiptId}`;
     const maxRetries = 10;
 
     /*

--- a/packages/plugins/apps/src/vite/dev-server.ts
+++ b/packages/plugins/apps/src/vite/dev-server.ts
@@ -28,18 +28,6 @@ type AuthConfig = Required<AuthOptionsWithDefaults>;
  */
 type BackendOutputs = { data: unknown };
 
-export function getQueryApiOrigin(site: string): string {
-    if (site.startsWith('api.')) {
-        return `https://${site}`;
-    }
-
-    if (site.startsWith('app.')) {
-        return `https://api.${site.slice('app.'.length)}`;
-    }
-
-    return `https://api.${site}`;
-}
-
 /**
  * Format a BackendFunction for display in log/error messages.
  */
@@ -130,7 +118,7 @@ async function executeScriptViaDatadog(
     auth: AuthConfig,
     log: Logger,
 ): Promise<BackendOutputs> {
-    const endpoint = `${getQueryApiOrigin(auth.site)}/api/v2/app-builder/queries/preview-async`;
+    const endpoint = `https://api.${auth.site}/api/v2/app-builder/queries/preview-async`;
     const displayName = formatRef(func);
 
     log.debug(`Calling Datadog API: ${endpoint}`);
@@ -191,7 +179,7 @@ async function pollQueryExecution(
     auth: AuthConfig,
     log: Logger,
 ): Promise<BackendOutputs> {
-    const endpoint = `${getQueryApiOrigin(auth.site)}/api/v2/app-builder/queries/execution-long-polling/${receiptId}`;
+    const endpoint = `https://api.${auth.site}/api/v2/app-builder/queries/execution-long-polling/${receiptId}`;
     const maxRetries = 10;
 
     /*


### PR DESCRIPTION
## Motivation

High-code app local backend functions are executed by the Vite dev-server middleware through App Builder's `preview-async` API. `dd-auth --actions-api` gives the child process a canonical `DD_SITE` value such as `datadoghq.com`, and this PR also needs to support staging auth like:

```sh
dd-auth --actions-api --domain dd.datad0g.com -- npm run dev
```

That staging form sets `DD_SITE=datad0g.com`. The site value is correct, but the dev-server query API must be called through the API origin, e.g. `https://api.datad0g.com`, not the bare site origin.

## Changes

Update the apps dev-server middleware to call the app-builder query APIs through `https://api.${site}`. This applies to both the initial `preview-async` request and the follow-up long-poll request used by `/__dd/executeAction`.

This intentionally keeps the PR small: there is no new site-normalization helper and no changed auth type. The dev server derives the API origin at the point where it makes the App Builder query request. Asset upload already uses `https://api.${site}` and is unchanged.

## QA Instructions
- Verified upload and dev server work correct with and without the `--domain dd.datad0g.com` param set:
- `dd-auth --actions-api --domain dd.datad0g.com -- npm run dev`
- `dd-auth --actions-api -- npm run dev`
- `DD_APPS_UPLOAD_ASSETS=1 dd-auth --actions-api --domain dd.datad0g.com -- npm run build`
- `DD_APPS_UPLOAD_ASSETS=1 dd-auth --actions-api -- npm run build`

## Blast Radius

This changes only the API origin used by high-code app local dev-server backend function execution through Datadog's app-builder query APIs. Build-time asset upload and app URL construction are unchanged.

## Documentation

-   [How to reliably make frontend production changes](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2286781319/Frontend+Production+Changesp)
-   [PR Description Guidelines](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/3120334387/PR+Checklist+and+Guidelines+for+Web+UI)
-   [Deploy steps](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/1457750032/)