### PR TITLE
Document Claude code readability conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,8 @@ Yarn provides "prefixed" scripts using the `<scope>:<action>` pattern. Scripts l
 
 - **No `any` or `as` casts**: Don't use `any` types or `as` type assertions as an escape hatch. Instead use patterns the repo already follows: import types directly from external packages (e.g. `import type { UserConfig } from 'vite'`), use `typeof`/`instanceof`/`in` guards for narrowing (see `wrapPlugins.ts`), derive types from constants with `(typeof MY_CONST)[number]`, or use constrained generics (`<T extends SomeType>`). If you think you need `any`, something is wrong.
 - **No TypeScript suppression comments**: Don't use `@ts-ignore`, `@ts-expect-error`, or `@ts-nocheck` to suppress type errors. Fix the underlying type issue instead.
+- **No same-line comments**: Don't put comments on the same line as code. Put comments on the line above the code they describe so code and explanation stay visually separate.
+- **No inlined function-call arguments**: Don't pass a function call directly as an argument to another function call. Assign the inner call to a well-named local variable first, then pass that variable to the outer call.
 - **Use existing repo utilities**: Before writing new helpers, check what already exists:
   - HTTP requests: `@dd/core/helpers/request` (not raw `fetch`)
   - File operations: `@dd/core/helpers/fs` (not `fs/promises` directly)


### PR DESCRIPTION
## Motivation

Clarify the repository guidance for AI-assisted code edits so generated changes favor readable, reviewable code over compact expressions.

## Changes

Adds two Claude code style conventions:

- Comments should live on their own line above the code they describe, rather than beside code.
- Function calls should not be passed directly as arguments to other function calls; the inner result should be assigned to a named local first.

These rules make intermediate values easier to inspect, give comments room to explain intent, and reduce dense one-line expressions in future generated changes.

## QA Instructions

Documentation-only change. Review the updated `CLAUDE.md` guidance and confirm the conventions are clear.

## Blast Radius

No runtime impact. This only changes repository guidance for future Claude-generated edits.

## Documentation

-   [How to reliably make frontend production changes](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2286781319/Frontend+Production+Changesp)
-   [PR Description Guidelines](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/3120334387/PR+Checklist+and+Guidelines+for+Web+UI)
-   [Deploy steps](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/1457750032/)