### PR TITLE
[APPS][Connections Part 5] Move apps Vite behavior into getVitePlugin

### DIFF
--- a/packages/plugins/apps/src/index.test.ts
+++ b/packages/plugins/apps/src/index.test.ts
@@ -248,7 +248,7 @@ describe('Apps Plugin - getPlugins', () => {
         const args = getArgs();
         args.bundler = { build: viteBuild };
         const plugins = getPlugins(args);
-        const transform = plugins[0].transform as {
+        const transform = plugins[0].vite?.transform as {
             handler: (code: string, id: string) => unknown;
         };
         transform.handler.call(

--- a/packages/plugins/apps/src/index.ts
+++ b/packages/plugins/apps/src/index.ts
@@ -2,115 +2,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import { rm } from '@dd/core/helpers/fs';
 import type { GetPlugins } from '@dd/core/types';
-import { InjectPosition } from '@dd/core/types';
-import chalk from 'chalk';
-import fsp from 'fs/promises';
-import os from 'os';
-import path from 'path';
 
-import { createArchive } from './archive';
-import type { Asset } from './assets';
-import { collectAssets } from './assets';
-import { extractExportedFunctions } from './backend/ast-parsing/extract-backend-functions';
-import { extractConnectionIds } from './backend/ast-parsing/extract-connection-ids';
-import { encodeQueryName } from './backend/encodeQueryName';
-import { generateProxyModule } from './backend/proxy-codegen';
-import type { BackendFunction } from './backend/types';
-import { BACKEND_FILE_RE, CONFIG_KEY, PLUGIN_NAME } from './constants';
-import { resolveIdentifier } from './identifier';
-import type { AppsManifest, AppsOptions } from './types';
-import { uploadArchive } from './upload';
+import { CONFIG_KEY, PLUGIN_NAME } from './constants';
+import type { AppsOptions } from './types';
 import { validateOptions } from './validate';
 import { getVitePlugin } from './vite/index';
 
 export { CONFIG_KEY, PLUGIN_NAME };
-
-/**
- * Build BackendFunction entries from discovered export names and generate
- * the frontend proxy module that replaces the original backend code.
- */
-function buildProxyModule(
-    exportNames: string[],
-    id: string,
-    buildRoot: string,
-    allowedConnectionIds: string[],
-): { functions: BackendFunction[]; proxyCode: string } {
-    const relativePath = path.relative(buildRoot, id);
-    const refPath = relativePath.replace(BACKEND_FILE_RE, '');
-
-    const functions: BackendFunction[] = [];
-    const proxyExports: Array<{ exportName: string; queryName: string }> = [];
-
-    for (const exportName of exportNames) {
-        const func = {
-            relativePath: refPath,
-            name: exportName,
-            absolutePath: id,
-            allowedConnectionIds,
-        };
-        functions.push(func);
-        proxyExports.push({ exportName, queryName: encodeQueryName(func) });
-    }
-
-    return { functions, proxyCode: generateProxyModule(proxyExports) };
-}
-
-const yellow = chalk.yellow.bold;
-const red = chalk.red.bold;
-const MANIFEST_FILE_NAME = 'manifest.json';
-
-/**
- * Create a registry for tracking discovered backend functions.
- * Uses a Map keyed by entryPath so that re-transforms (e.g. during HMR)
- * replace stale entries for a file instead of appending duplicates.
- */
-function createBackendFunctionRegistry() {
-    const functionsByEntryPath = new Map<string, BackendFunction[]>();
-
-    return {
-        /** Replace all entries for a given file. Handles HMR re-transforms. */
-        setBackendFunctions(entryPath: string, functions: BackendFunction[]) {
-            functionsByEntryPath.set(entryPath, functions);
-        },
-        /** Get a flat array of all currently registered backend functions. */
-        getBackendFunctions(): BackendFunction[] {
-            return Array.from(functionsByEntryPath.values()).flat();
-        },
-    };
-}
-
-function buildManifest(backendFunctions: BackendFunction[]): AppsManifest {
-    const functions: AppsManifest['backend']['functions'] = {};
-    for (const func of backendFunctions) {
-        functions[encodeQueryName(func)] = {
-            allowedConnectionIds: [...func.allowedConnectionIds],
-        };
-    }
-    return { backend: { functions } };
-}
-
-async function writeManifestFile(backendFunctions: BackendFunction[]): Promise<{
-    manifestAsset: Asset;
-    cleanup: () => Promise<void>;
-}> {
-    const manifestDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'dd-apps-manifest-'));
-    const manifestPath = path.join(manifestDir, MANIFEST_FILE_NAME);
-    try {
-        await fsp.writeFile(manifestPath, JSON.stringify(buildManifest(backendFunctions), null, 2));
-    } catch (error) {
-        await rm(manifestDir);
-        throw error;
-    }
-    return {
-        manifestAsset: {
-            absolutePath: manifestPath,
-            relativePath: MANIFEST_FILE_NAME,
-        },
-        cleanup: () => rm(manifestDir),
-    };
-}
 
 export type types = {
     // Add the types you'd like to expose here.
@@ -119,7 +18,6 @@ export type types = {
 
 export const getPlugins: GetPlugins = ({ options, context, bundler }) => {
     const log = context.getLogger(PLUGIN_NAME);
-    let toThrow: Error | undefined;
     const validatedOptions = validateOptions(options);
     if (!validatedOptions.enable) {
         return [];
@@ -130,186 +28,16 @@ export const getPlugins: GetPlugins = ({ options, context, bundler }) => {
         return [];
     }
 
-    // Inject the runtime that `globalThis.DD_APPS_RUNTIME.executeBackendFunction`
-    // is read from. The generated proxy modules (emitted by the transform hook
-    // below) reference that global. NOTE: This file is built alongside the
-    // bundler plugin via the `toBuild` entry in @dd/apps-plugin's package.json.
-    //
-    // Position MIDDLE is used instead of BEFORE so Vite's dev server injects
-    // the runtime as a <script type="module"> via `transformIndexHtml` — BEFORE
-    // is served via Rollup's `banner()` output hook which only fires at build
-    // time, leaving the runtime undefined during `vite` (dev).
-    context.inject({
-        type: 'file',
-        position: InjectPosition.MIDDLE,
-        value: path.join(__dirname, './apps-runtime.mjs'),
-    });
-
-    const { setBackendFunctions, getBackendFunctions } = createBackendFunctionRegistry();
-
-    const handleUpload = async (backendOutputs: Map<string, string>) => {
-        const handleTimer = log.time('handle assets');
-        let archiveDir: string | undefined;
-        let cleanupManifest: (() => Promise<void>) | undefined;
-        try {
-            const identifierTimer = log.time('resolve identifier');
-
-            const { name, identifier } = resolveIdentifier(context.buildRoot, log, {
-                url: context.git?.remote,
-                name: validatedOptions.name,
-                identifier: validatedOptions.identifier,
-            });
-
-            if (!identifier || !name) {
-                throw new Error(`Missing apps identification.
-Either:
-  - pass an 'options.apps.identifier' and 'options.apps.name' to your plugin's configuration.
-  - have a 'name' and a 'repository' in your 'package.json'.
-  - have a valid remote url on your git project.
-`);
-            }
-            identifierTimer.end();
-
-            const relativeOutdir = path.relative(context.buildRoot, context.bundler.outDir);
-            const assetGlobs = [...validatedOptions.include, `${relativeOutdir}/**/*`];
-
-            const assets = await collectAssets(assetGlobs, context.buildRoot);
-
-            if (!assets.length) {
-                log.debug(`No assets to upload.`);
-                return;
-            }
-
-            // Exclude backend output files from frontend assets.
-            const backendPaths = new Set(backendOutputs.values());
-            const frontendOnly = assets.filter((a) => !backendPaths.has(a.absolutePath));
-
-            // Prefix all frontend assets with frontend/.
-            // Use POSIX joins — archive entries must use forward slashes.
-            const allAssets: Asset[] = frontendOnly.map((asset) => ({
-                ...asset,
-                relativePath: `frontend/${asset.relativePath}`,
-            }));
-
-            // Append backend assets from the outputs map populated during the build.
-            // Keys are encoded query names ({hash(path)}.{name}).
-            for (const [bundleName, absolutePath] of backendOutputs) {
-                allAssets.push({
-                    absolutePath,
-                    relativePath: `backend/${bundleName}.js`,
-                });
-            }
-
-            const backendFunctions = getBackendFunctions();
-            const { manifestAsset, cleanup } = await writeManifestFile(backendFunctions);
-            cleanupManifest = cleanup;
-            allAssets.push(manifestAsset);
-
-            const archiveTimer = log.time('archive assets');
-            const archive = await createArchive(allAssets);
-            archiveTimer.end();
-            // Store variable for later disposal of directory.
-            archiveDir = path.dirname(archive.archivePath);
-
-            const uploadTimer = log.time('upload assets');
-            const { errors: uploadErrors, warnings: uploadWarnings } = await uploadArchive(
-                archive,
-                {
-                    apiKey: context.auth.apiKey,
-                    appKey: context.auth.appKey,
-                    bundlerName: context.bundler.name,
-                    dryRun: validatedOptions.dryRun,
-                    identifier,
-                    name,
-                    site: context.auth.site,
-                    version: context.version,
-                },
-                log,
-            );
-            uploadTimer.end();
-
-            if (uploadWarnings.length > 0) {
-                log.warn(
-                    `${yellow('Warnings while uploading assets:')}\n    - ${uploadWarnings.join('\n    - ')}`,
-                );
-            }
-
-            if (uploadErrors.length > 0) {
-                const listOfErrors = uploadErrors
-                    .map((error) => error.cause || error.stack || error.message || error)
-                    .join('\n    - ');
-                throw new Error(`    - ${listOfErrors}`);
-            }
-        } catch (error: any) {
-            toThrow = error;
-            log.error(`${red('Failed to upload assets:')}\n${error?.message || error}`);
-        }
-
-        // Clean temporary directory
-        if (archiveDir) {
-            await rm(archiveDir);
-        }
-        if (cleanupManifest) {
-            await cleanupManifest();
-        }
-        handleTimer.end();
-
-        if (toThrow) {
-            // Break the build.
-            throw toThrow;
-        }
-    };
-
     // All build + upload logic is handled inside the Vite sub-plugin's closeBundle.
     // When backend functions exist, it builds them first, then uploads everything.
     return [
         {
             name: PLUGIN_NAME,
             enforce: 'post',
-            transform: {
-                filter: {
-                    id: {
-                        include: [BACKEND_FILE_RE],
-                        exclude: [/node_modules/, /[/\\]dist[/\\]/],
-                    },
-                },
-                // For each .backend.* file, parse its named exports, register
-                // them as backend functions, and replace the module with a
-                // frontend proxy that calls executeBackendFunction at runtime.
-                handler(code, id) {
-                    const ast = this.parse(code);
-                    const exportNames = extractExportedFunctions(ast, id);
-                    if (exportNames.length === 0) {
-                        log.warn(
-                            `Backend file ${id} has no exported functions. ` +
-                                `Did you forget to add a named export?`,
-                        );
-                        // Clear any previously registered functions for this file
-                        // so stale entries don't persist across HMR re-transforms.
-                        setBackendFunctions(id, []);
-                        return { code: '', map: null };
-                    }
-
-                    const allowedConnectionIds = extractConnectionIds(ast, id);
-                    const { functions, proxyCode } = buildProxyModule(
-                        exportNames,
-                        id,
-                        context.buildRoot,
-                        allowedConnectionIds,
-                    );
-                    setBackendFunctions(id, functions);
-                    log.debug(`Generated proxy for ${id} with ${functions.length} export(s)`);
-
-                    return { code: proxyCode, map: null };
-                },
-            },
             vite: getVitePlugin({
-                viteBuild: bundler.build,
-                buildRoot: context.buildRoot,
-                getBackendFunctions,
-                handleUpload,
-                log,
-                auth: context.auth,
+                bundler,
+                context,
+                options: validatedOptions,
             }),
         },
     ];

--- a/packages/plugins/apps/src/vite/handle-upload.ts
+++ b/packages/plugins/apps/src/vite/handle-upload.ts
@@ -1,0 +1,191 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import { rm } from '@dd/core/helpers/fs';
+import type { AuthOptionsWithDefaults, Logger } from '@dd/core/types';
+import chalk from 'chalk';
+import fsp from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import { createArchive } from '../archive';
+import type { Asset } from '../assets';
+import { collectAssets } from '../assets';
+import { encodeQueryName } from '../backend/encodeQueryName';
+import type { BackendFunction } from '../backend/types';
+import { resolveIdentifier } from '../identifier';
+import type { AppsManifest, AppsOptionsWithDefaults } from '../types';
+import { uploadArchive } from '../upload';
+
+const yellow = chalk.yellow.bold;
+const red = chalk.red.bold;
+const MANIFEST_FILE_NAME = 'manifest.json';
+
+export interface HandleUploadOptions {
+    backendOutputs: Map<string, string>;
+    backendFunctions: BackendFunction[];
+    buildRoot: string;
+    outDir: string;
+    bundlerName: string;
+    gitRemote?: string;
+    auth: AuthOptionsWithDefaults;
+    version: string;
+    options: AppsOptionsWithDefaults;
+    log: Logger;
+}
+
+function buildManifest(backendFunctions: BackendFunction[]): AppsManifest {
+    const functions: AppsManifest['backend']['functions'] = {};
+    for (const func of backendFunctions) {
+        functions[encodeQueryName(func)] = {
+            allowedConnectionIds: [...func.allowedConnectionIds],
+        };
+    }
+    return { backend: { functions } };
+}
+
+async function writeManifestFile(backendFunctions: BackendFunction[]): Promise<{
+    manifestAsset: Asset;
+    cleanup: () => Promise<void>;
+}> {
+    const manifestDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'dd-apps-manifest-'));
+    const manifestPath = path.join(manifestDir, MANIFEST_FILE_NAME);
+    try {
+        await fsp.writeFile(manifestPath, JSON.stringify(buildManifest(backendFunctions), null, 2));
+    } catch (error) {
+        await rm(manifestDir);
+        throw error;
+    }
+    return {
+        manifestAsset: {
+            absolutePath: manifestPath,
+            relativePath: MANIFEST_FILE_NAME,
+        },
+        cleanup: () => rm(manifestDir),
+    };
+}
+
+export const handleUpload = async ({
+    backendOutputs,
+    backendFunctions,
+    buildRoot,
+    outDir,
+    bundlerName,
+    gitRemote,
+    auth,
+    version,
+    options,
+    log,
+}: HandleUploadOptions) => {
+    const handleTimer = log.time('handle assets');
+    let archiveDir: string | undefined;
+    let cleanupManifest: (() => Promise<void>) | undefined;
+    let toThrow: Error | undefined;
+    try {
+        const identifierTimer = log.time('resolve identifier');
+
+        const { name, identifier } = resolveIdentifier(buildRoot, log, {
+            url: gitRemote,
+            name: options.name,
+            identifier: options.identifier,
+        });
+
+        if (!identifier || !name) {
+            throw new Error(`Missing apps identification.
+Either:
+  - pass an 'options.apps.identifier' and 'options.apps.name' to your plugin's configuration.
+  - have a 'name' and a 'repository' in your 'package.json'.
+  - have a valid remote url on your git project.
+`);
+        }
+        identifierTimer.end();
+
+        const relativeOutdir = path.relative(buildRoot, outDir);
+        const assetGlobs = [...options.include, `${relativeOutdir}/**/*`];
+
+        const assets = await collectAssets(assetGlobs, buildRoot);
+
+        if (!assets.length) {
+            log.debug(`No assets to upload.`);
+            return;
+        }
+
+        // Exclude backend output files from frontend assets.
+        const backendPaths = new Set(backendOutputs.values());
+        const frontendOnly = assets.filter((a) => !backendPaths.has(a.absolutePath));
+
+        // Prefix all frontend assets with frontend/.
+        // Use POSIX joins — archive entries must use forward slashes.
+        const allAssets: Asset[] = frontendOnly.map((asset) => ({
+            ...asset,
+            relativePath: `frontend/${asset.relativePath}`,
+        }));
+
+        // Append backend assets from the outputs map populated during the build.
+        // Keys are encoded query names ({hash(path)}.{name}).
+        for (const [bundleName, absolutePath] of backendOutputs) {
+            allAssets.push({
+                absolutePath,
+                relativePath: `backend/${bundleName}.js`,
+            });
+        }
+
+        const { manifestAsset, cleanup } = await writeManifestFile(backendFunctions);
+        cleanupManifest = cleanup;
+        allAssets.push(manifestAsset);
+
+        const archiveTimer = log.time('archive assets');
+        const archive = await createArchive(allAssets);
+        archiveTimer.end();
+        // Store variable for later disposal of directory.
+        archiveDir = path.dirname(archive.archivePath);
+
+        const uploadTimer = log.time('upload assets');
+        const { errors: uploadErrors, warnings: uploadWarnings } = await uploadArchive(
+            archive,
+            {
+                apiKey: auth.apiKey,
+                appKey: auth.appKey,
+                bundlerName,
+                dryRun: options.dryRun,
+                identifier,
+                name,
+                site: auth.site,
+                version,
+            },
+            log,
+        );
+        uploadTimer.end();
+
+        if (uploadWarnings.length > 0) {
+            log.warn(
+                `${yellow('Warnings while uploading assets:')}\n    - ${uploadWarnings.join('\n    - ')}`,
+            );
+        }
+
+        if (uploadErrors.length > 0) {
+            const listOfErrors = uploadErrors
+                .map((error) => error.cause || error.stack || error.message || error)
+                .join('\n    - ');
+            throw new Error(`    - ${listOfErrors}`);
+        }
+    } catch (error: any) {
+        toThrow = error;
+        log.error(`${red('Failed to upload assets:')}\n${error?.message || error}`);
+    }
+
+    // Clean temporary directory
+    if (archiveDir) {
+        await rm(archiveDir);
+    }
+    if (cleanupManifest) {
+        await cleanupManifest();
+    }
+    handleTimer.end();
+
+    if (toThrow) {
+        // Break the build.
+        throw toThrow;
+    }
+};

--- a/packages/plugins/apps/src/vite/handle-upload.ts
+++ b/packages/plugins/apps/src/vite/handle-upload.ts
@@ -3,7 +3,7 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import { rm } from '@dd/core/helpers/fs';
-import type { AuthOptionsWithDefaults, Logger } from '@dd/core/types';
+import type { GlobalContext } from '@dd/core/types';
 import chalk from 'chalk';
 import fsp from 'fs/promises';
 import os from 'os';
@@ -14,6 +14,7 @@ import type { Asset } from '../assets';
 import { collectAssets } from '../assets';
 import { encodeQueryName } from '../backend/encodeQueryName';
 import type { BackendFunction } from '../backend/types';
+import { PLUGIN_NAME } from '../constants';
 import { resolveIdentifier } from '../identifier';
 import type { AppsManifest, AppsOptionsWithDefaults } from '../types';
 import { uploadArchive } from '../upload';
@@ -25,14 +26,8 @@ const MANIFEST_FILE_NAME = 'manifest.json';
 export interface HandleUploadOptions {
     backendOutputs: Map<string, string>;
     backendFunctions: BackendFunction[];
-    buildRoot: string;
-    outDir: string;
-    bundlerName: string;
-    gitRemote?: string;
-    auth: AuthOptionsWithDefaults;
-    version: string;
+    context: GlobalContext;
     options: AppsOptionsWithDefaults;
-    log: Logger;
 }
 
 function buildManifest(backendFunctions: BackendFunction[]): AppsManifest {
@@ -69,15 +64,17 @@ async function writeManifestFile(backendFunctions: BackendFunction[]): Promise<{
 export const handleUpload = async ({
     backendOutputs,
     backendFunctions,
-    buildRoot,
-    outDir,
-    bundlerName,
-    gitRemote,
-    auth,
-    version,
+    context,
     options,
-    log,
 }: HandleUploadOptions) => {
+    const log = context.getLogger(PLUGIN_NAME);
+    const {
+        auth,
+        buildRoot,
+        bundler: { name: bundlerName, outDir },
+        git,
+        version,
+    } = context;
     const handleTimer = log.time('handle assets');
     let archiveDir: string | undefined;
     let cleanupManifest: (() => Promise<void>) | undefined;
@@ -86,7 +83,7 @@ export const handleUpload = async ({
         const identifierTimer = log.time('resolve identifier');
 
         const { name, identifier } = resolveIdentifier(buildRoot, log, {
-            url: gitRemote,
+            url: git?.remote,
             name: options.name,
             identifier: options.identifier,
         });

--- a/packages/plugins/apps/src/vite/index.test.ts
+++ b/packages/plugins/apps/src/vite/index.test.ts
@@ -2,13 +2,15 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+import * as assets from '@dd/apps-plugin/assets';
+import * as identifier from '@dd/apps-plugin/identifier';
 import { getVitePlugin } from '@dd/apps-plugin/vite/index';
-import { getMockLogger } from '@dd/tests/_jest/helpers/mocks';
+import { InjectPosition } from '@dd/core/types';
+import { getContextMock, getRepositoryDataMock } from '@dd/tests/_jest/helpers/mocks';
+import { parseAst } from 'rollup/parseAst';
 
 import { encodeQueryName } from '../backend/encodeQueryName';
 import type { BackendFunction } from '../backend/types';
-
-const log = getMockLogger();
 
 const functions: BackendFunction[] = [
     {
@@ -34,41 +36,80 @@ const mockViteBuild = jest.fn().mockResolvedValue({
         { type: 'chunk', isEntry: true, name: bundleName2, fileName: `${bundleName2}.js` },
     ],
 });
-const mockHandleUpload = jest.fn().mockResolvedValue(undefined);
+const mockInject = jest.fn();
 
 const defaultOptions = {
-    viteBuild: mockViteBuild,
-    buildRoot: '/build',
-    getBackendFunctions: () => functions,
-    handleUpload: mockHandleUpload,
-    log,
-    auth: { site: 'datadoghq.com' },
+    bundler: {
+        build: mockViteBuild,
+    },
+    context: getContextMock({
+        buildRoot: '/build',
+        bundler: {
+            name: 'vite',
+            version: 'FAKE_VERSION',
+            outDir: '/build/dist',
+        },
+        git: getRepositoryDataMock({ remote: 'git@github.com:org/repo.git' }),
+        inject: mockInject,
+        version: 'FAKE_VERSION',
+    }),
+    options: {
+        enable: true,
+        include: [],
+        dryRun: true,
+    },
 };
 
 describe('Backend Functions - getVitePlugin', () => {
     beforeEach(() => {
         jest.restoreAllMocks();
         mockViteBuild.mockClear();
-        mockHandleUpload.mockClear();
+        mockInject.mockClear();
+        jest.spyOn(identifier, 'resolveIdentifier').mockReturnValue({
+            identifier: 'repo:app',
+            name: 'test-app',
+        });
+        jest.spyOn(assets, 'collectAssets').mockResolvedValue([]);
     });
 
     test('Should return a vite plugin object with closeBundle', () => {
         const plugin = getVitePlugin(defaultOptions);
         expect(plugin).toBeDefined();
+        expect(plugin!.transform).toEqual(expect.any(Object));
         expect(plugin!.closeBundle).toEqual(expect.any(Function));
     });
 
     test('Should build backend functions and then upload in closeBundle', async () => {
         const plugin = getVitePlugin(defaultOptions);
+        const transform = plugin!.transform as {
+            handler: (code: string, id: string) => unknown;
+        };
+
+        transform.handler.call(
+            {
+                parse: parseAst,
+            },
+            `
+                export function myHandler() {}
+                export function otherFunc() {}
+            `,
+            '/build/src/backend/myHandler.backend.ts',
+        );
+
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         await (plugin as any).closeBundle();
 
         expect(mockViteBuild).toHaveBeenCalledTimes(2);
-        // handleUpload receives the backendOutputs map as an argument.
-        expect(mockHandleUpload).toHaveBeenCalledTimes(1);
-        const backendOutputs: Map<string, string> = mockHandleUpload.mock.calls[0][0];
-        expect(backendOutputs.size).toBe(2);
-        expect(backendOutputs.has(bundleName1)).toBe(true);
-        expect(backendOutputs.has(bundleName2)).toBe(true);
+        expect(assets.collectAssets).toHaveBeenCalledWith(['dist/**/*'], '/build');
+    });
+
+    test('Should inject the apps runtime', () => {
+        getVitePlugin(defaultOptions);
+
+        expect(mockInject).toHaveBeenCalledWith({
+            type: 'file',
+            position: InjectPosition.MIDDLE,
+            value: expect.stringMatching(/[/\\]apps-runtime\.mjs$/),
+        });
     });
 });

--- a/packages/plugins/apps/src/vite/index.ts
+++ b/packages/plugins/apps/src/vite/index.ts
@@ -166,14 +166,8 @@ export const getVitePlugin = ({
                 await handleUpload({
                     backendOutputs,
                     backendFunctions: getBackendFunctions(),
-                    buildRoot,
-                    outDir: context.bundler.outDir,
-                    bundlerName: context.bundler.name,
-                    gitRemote: context.git?.remote,
-                    auth,
-                    version: context.version,
+                    context,
                     options,
-                    log,
                 });
             } finally {
                 if (backendOutDir) {

--- a/packages/plugins/apps/src/vite/index.ts
+++ b/packages/plugins/apps/src/vite/index.ts
@@ -5,27 +5,20 @@
 import { rm } from '@dd/core/helpers/fs';
 import type { GlobalContext, PluginOptions } from '@dd/core/types';
 import { InjectPosition } from '@dd/core/types';
-import chalk from 'chalk';
-import fsp from 'fs/promises';
-import os from 'os';
 import path from 'path';
 import type { build } from 'vite';
 
-import { createArchive } from '../archive';
-import type { Asset } from '../assets';
-import { collectAssets } from '../assets';
 import { extractExportedFunctions } from '../backend/ast-parsing/extract-backend-functions';
 import { extractConnectionIds } from '../backend/ast-parsing/extract-connection-ids';
 import { encodeQueryName } from '../backend/encodeQueryName';
 import { generateProxyModule } from '../backend/proxy-codegen';
 import type { BackendFunction } from '../backend/types';
 import { BACKEND_FILE_RE, PLUGIN_NAME } from '../constants';
-import { resolveIdentifier } from '../identifier';
-import type { AppsManifest, AppsOptionsWithDefaults } from '../types';
-import { uploadArchive } from '../upload';
+import type { AppsOptionsWithDefaults } from '../types';
 
 import { buildBackendFunctions } from './build-backend-functions';
 import { createDevServerMiddleware } from './dev-server';
+import { handleUpload } from './handle-upload';
 
 export type ViteBundler = {
     build: typeof build;
@@ -87,41 +80,7 @@ function createBackendFunctionRegistry() {
     };
 }
 
-const yellow = chalk.yellow.bold;
-const red = chalk.red.bold;
 const APPS_RUNTIME_PATH = path.join(__dirname, './apps-runtime.mjs');
-const MANIFEST_FILE_NAME = 'manifest.json';
-
-function buildManifest(backendFunctions: BackendFunction[]): AppsManifest {
-    const functions: AppsManifest['backend']['functions'] = {};
-    for (const func of backendFunctions) {
-        functions[encodeQueryName(func)] = {
-            allowedConnectionIds: [...func.allowedConnectionIds],
-        };
-    }
-    return { backend: { functions } };
-}
-
-async function writeManifestFile(backendFunctions: BackendFunction[]): Promise<{
-    manifestAsset: Asset;
-    cleanup: () => Promise<void>;
-}> {
-    const manifestDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'dd-apps-manifest-'));
-    const manifestPath = path.join(manifestDir, MANIFEST_FILE_NAME);
-    try {
-        await fsp.writeFile(manifestPath, JSON.stringify(buildManifest(backendFunctions), null, 2));
-    } catch (error) {
-        await rm(manifestDir);
-        throw error;
-    }
-    return {
-        manifestAsset: {
-            absolutePath: manifestPath,
-            relativePath: MANIFEST_FILE_NAME,
-        },
-        cleanup: () => rm(manifestDir),
-    };
-}
 
 /**
  * Returns the Vite-specific plugin hooks for the apps plugin.
@@ -150,120 +109,6 @@ export const getVitePlugin = ({
     });
 
     const { setBackendFunctions, getBackendFunctions } = createBackendFunctionRegistry();
-
-    const handleUpload = async (backendOutputs: Map<string, string>) => {
-        const handleTimer = log.time('handle assets');
-        let archiveDir: string | undefined;
-        let cleanupManifest: (() => Promise<void>) | undefined;
-        let toThrow: Error | undefined;
-        try {
-            const identifierTimer = log.time('resolve identifier');
-
-            const { name, identifier } = resolveIdentifier(buildRoot, log, {
-                url: context.git?.remote,
-                name: options.name,
-                identifier: options.identifier,
-            });
-
-            if (!identifier || !name) {
-                throw new Error(`Missing apps identification.
-Either:
-  - pass an 'options.apps.identifier' and 'options.apps.name' to your plugin's configuration.
-  - have a 'name' and a 'repository' in your 'package.json'.
-  - have a valid remote url on your git project.
-`);
-            }
-            identifierTimer.end();
-
-            const relativeOutdir = path.relative(buildRoot, context.bundler.outDir);
-            const assetGlobs = [...options.include, `${relativeOutdir}/**/*`];
-
-            const assets = await collectAssets(assetGlobs, buildRoot);
-
-            if (!assets.length) {
-                log.debug(`No assets to upload.`);
-                return;
-            }
-
-            // Exclude backend output files from frontend assets.
-            const backendPaths = new Set(backendOutputs.values());
-            const frontendOnly = assets.filter((a) => !backendPaths.has(a.absolutePath));
-
-            // Prefix all frontend assets with frontend/.
-            // Use POSIX joins — archive entries must use forward slashes.
-            const allAssets: Asset[] = frontendOnly.map((asset) => ({
-                ...asset,
-                relativePath: `frontend/${asset.relativePath}`,
-            }));
-
-            // Append backend assets from the outputs map populated during the build.
-            // Keys are encoded query names ({hash(path)}.{name}).
-            for (const [bundleName, absolutePath] of backendOutputs) {
-                allAssets.push({
-                    absolutePath,
-                    relativePath: `backend/${bundleName}.js`,
-                });
-            }
-
-            const backendFunctions = getBackendFunctions();
-            const { manifestAsset, cleanup } = await writeManifestFile(backendFunctions);
-            cleanupManifest = cleanup;
-            allAssets.push(manifestAsset);
-
-            const archiveTimer = log.time('archive assets');
-            const archive = await createArchive(allAssets);
-            archiveTimer.end();
-            // Store variable for later disposal of directory.
-            archiveDir = path.dirname(archive.archivePath);
-
-            const uploadTimer = log.time('upload assets');
-            const { errors: uploadErrors, warnings: uploadWarnings } = await uploadArchive(
-                archive,
-                {
-                    apiKey: auth.apiKey,
-                    appKey: auth.appKey,
-                    bundlerName: context.bundler.name,
-                    dryRun: options.dryRun,
-                    identifier,
-                    name,
-                    site: auth.site,
-                    version: context.version,
-                },
-                log,
-            );
-            uploadTimer.end();
-
-            if (uploadWarnings.length > 0) {
-                log.warn(
-                    `${yellow('Warnings while uploading assets:')}\n    - ${uploadWarnings.join('\n    - ')}`,
-                );
-            }
-
-            if (uploadErrors.length > 0) {
-                const listOfErrors = uploadErrors
-                    .map((error) => error.cause || error.stack || error.message || error)
-                    .join('\n    - ');
-                throw new Error(`    - ${listOfErrors}`);
-            }
-        } catch (error: any) {
-            toThrow = error;
-            log.error(`${red('Failed to upload assets:')}\n${error?.message || error}`);
-        }
-
-        // Clean temporary directory
-        if (archiveDir) {
-            await rm(archiveDir);
-        }
-        if (cleanupManifest) {
-            await cleanupManifest();
-        }
-        handleTimer.end();
-
-        if (toThrow) {
-            // Break the build.
-            throw toThrow;
-        }
-    };
 
     return {
         transform: {
@@ -318,7 +163,18 @@ Either:
                 backendOutputs = result.outputs;
             }
             try {
-                await handleUpload(backendOutputs);
+                await handleUpload({
+                    backendOutputs,
+                    backendFunctions: getBackendFunctions(),
+                    buildRoot,
+                    outDir: context.bundler.outDir,
+                    bundlerName: context.bundler.name,
+                    gitRemote: context.git?.remote,
+                    auth,
+                    version: context.version,
+                    options,
+                    log,
+                });
             } finally {
                 if (backendOutDir) {
                     await rm(backendOutDir);

--- a/packages/plugins/apps/src/vite/index.ts
+++ b/packages/plugins/apps/src/vite/index.ts
@@ -3,25 +3,131 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import { rm } from '@dd/core/helpers/fs';
-import type { AuthOptionsWithDefaults, Logger, PluginOptions } from '@dd/core/types';
+import type { GlobalContext, PluginOptions } from '@dd/core/types';
+import { InjectPosition } from '@dd/core/types';
+import chalk from 'chalk';
+import fsp from 'fs/promises';
+import os from 'os';
+import path from 'path';
 import type { build } from 'vite';
 
+import { createArchive } from '../archive';
+import type { Asset } from '../assets';
+import { collectAssets } from '../assets';
+import { extractExportedFunctions } from '../backend/ast-parsing/extract-backend-functions';
+import { extractConnectionIds } from '../backend/ast-parsing/extract-connection-ids';
+import { encodeQueryName } from '../backend/encodeQueryName';
+import { generateProxyModule } from '../backend/proxy-codegen';
 import type { BackendFunction } from '../backend/types';
+import { BACKEND_FILE_RE, PLUGIN_NAME } from '../constants';
+import { resolveIdentifier } from '../identifier';
+import type { AppsManifest, AppsOptionsWithDefaults } from '../types';
+import { uploadArchive } from '../upload';
 
 import { buildBackendFunctions } from './build-backend-functions';
 import { createDevServerMiddleware } from './dev-server';
 
+export type ViteBundler = {
+    build: typeof build;
+};
+
 export interface VitePluginOptions {
-    viteBuild: typeof build;
-    buildRoot: string;
-    getBackendFunctions: () => BackendFunction[];
-    handleUpload: (backendOutputs: Map<string, string>) => Promise<void>;
-    log: Logger;
-    auth: AuthOptionsWithDefaults;
+    bundler: ViteBundler;
+    context: GlobalContext;
+    options: AppsOptionsWithDefaults;
+}
+
+/**
+ * Build BackendFunction entries from discovered export names and generate
+ * the frontend proxy module that replaces the original backend code.
+ */
+function buildProxyModule(
+    exportNames: string[],
+    id: string,
+    buildRoot: string,
+    allowedConnectionIds: string[],
+): { functions: BackendFunction[]; proxyCode: string } {
+    const relativePath = path.relative(buildRoot, id);
+    const refPath = relativePath.replace(BACKEND_FILE_RE, '');
+
+    const functions: BackendFunction[] = [];
+    const proxyExports: Array<{ exportName: string; queryName: string }> = [];
+
+    for (const exportName of exportNames) {
+        const func = {
+            relativePath: refPath,
+            name: exportName,
+            absolutePath: id,
+            allowedConnectionIds,
+        };
+        functions.push(func);
+        proxyExports.push({ exportName, queryName: encodeQueryName(func) });
+    }
+
+    return { functions, proxyCode: generateProxyModule(proxyExports) };
+}
+
+/**
+ * Create a registry for tracking discovered backend functions.
+ * Uses a Map keyed by entryPath so that re-transforms (e.g. during HMR)
+ * replace stale entries for a file instead of appending duplicates.
+ */
+function createBackendFunctionRegistry() {
+    const functionsByEntryPath = new Map<string, BackendFunction[]>();
+
+    return {
+        /** Replace all entries for a given file. Handles HMR re-transforms. */
+        setBackendFunctions(entryPath: string, functions: BackendFunction[]) {
+            functionsByEntryPath.set(entryPath, functions);
+        },
+        /** Get a flat array of all currently registered backend functions. */
+        getBackendFunctions(): BackendFunction[] {
+            return Array.from(functionsByEntryPath.values()).flat();
+        },
+    };
+}
+
+const yellow = chalk.yellow.bold;
+const red = chalk.red.bold;
+const APPS_RUNTIME_PATH = path.join(__dirname, './apps-runtime.mjs');
+const MANIFEST_FILE_NAME = 'manifest.json';
+
+function buildManifest(backendFunctions: BackendFunction[]): AppsManifest {
+    const functions: AppsManifest['backend']['functions'] = {};
+    for (const func of backendFunctions) {
+        functions[encodeQueryName(func)] = {
+            allowedConnectionIds: [...func.allowedConnectionIds],
+        };
+    }
+    return { backend: { functions } };
+}
+
+async function writeManifestFile(backendFunctions: BackendFunction[]): Promise<{
+    manifestAsset: Asset;
+    cleanup: () => Promise<void>;
+}> {
+    const manifestDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'dd-apps-manifest-'));
+    const manifestPath = path.join(manifestDir, MANIFEST_FILE_NAME);
+    try {
+        await fsp.writeFile(manifestPath, JSON.stringify(buildManifest(backendFunctions), null, 2));
+    } catch (error) {
+        await rm(manifestDir);
+        throw error;
+    }
+    return {
+        manifestAsset: {
+            absolutePath: manifestPath,
+            relativePath: MANIFEST_FILE_NAME,
+        },
+        cleanup: () => rm(manifestDir),
+    };
 }
 
 /**
  * Returns the Vite-specific plugin hooks for the apps plugin.
+ *
+ * Transform: discovers backend exports and connection allowlists, registers
+ * backend functions, and replaces each backend module with its frontend proxy.
  *
  * Production (closeBundle): builds backend functions (if any) then uploads
  * all assets sequentially.
@@ -30,33 +136,199 @@ export interface VitePluginOptions {
  * testing when auth credentials are available.
  */
 export const getVitePlugin = ({
-    viteBuild,
-    buildRoot,
-    getBackendFunctions,
-    handleUpload,
-    log,
-    auth,
-}: VitePluginOptions): PluginOptions['vite'] => ({
-    async closeBundle() {
-        let backendOutDir: string | undefined;
-        let backendOutputs = new Map<string, string>();
-        const functions = getBackendFunctions();
-        if (functions.length > 0) {
-            const result = await buildBackendFunctions(viteBuild, functions, buildRoot, log);
-            backendOutDir = result.outDir;
-            backendOutputs = result.outputs;
-        }
+    bundler,
+    context,
+    options,
+}: VitePluginOptions): PluginOptions['vite'] => {
+    const log = context.getLogger(PLUGIN_NAME);
+    const { auth, buildRoot } = context;
+
+    context.inject({
+        type: 'file',
+        position: InjectPosition.MIDDLE,
+        value: APPS_RUNTIME_PATH,
+    });
+
+    const { setBackendFunctions, getBackendFunctions } = createBackendFunctionRegistry();
+
+    const handleUpload = async (backendOutputs: Map<string, string>) => {
+        const handleTimer = log.time('handle assets');
+        let archiveDir: string | undefined;
+        let cleanupManifest: (() => Promise<void>) | undefined;
+        let toThrow: Error | undefined;
         try {
-            await handleUpload(backendOutputs);
-        } finally {
-            if (backendOutDir) {
-                await rm(backendOutDir);
+            const identifierTimer = log.time('resolve identifier');
+
+            const { name, identifier } = resolveIdentifier(buildRoot, log, {
+                url: context.git?.remote,
+                name: options.name,
+                identifier: options.identifier,
+            });
+
+            if (!identifier || !name) {
+                throw new Error(`Missing apps identification.
+Either:
+  - pass an 'options.apps.identifier' and 'options.apps.name' to your plugin's configuration.
+  - have a 'name' and a 'repository' in your 'package.json'.
+  - have a valid remote url on your git project.
+`);
             }
+            identifierTimer.end();
+
+            const relativeOutdir = path.relative(buildRoot, context.bundler.outDir);
+            const assetGlobs = [...options.include, `${relativeOutdir}/**/*`];
+
+            const assets = await collectAssets(assetGlobs, buildRoot);
+
+            if (!assets.length) {
+                log.debug(`No assets to upload.`);
+                return;
+            }
+
+            // Exclude backend output files from frontend assets.
+            const backendPaths = new Set(backendOutputs.values());
+            const frontendOnly = assets.filter((a) => !backendPaths.has(a.absolutePath));
+
+            // Prefix all frontend assets with frontend/.
+            // Use POSIX joins — archive entries must use forward slashes.
+            const allAssets: Asset[] = frontendOnly.map((asset) => ({
+                ...asset,
+                relativePath: `frontend/${asset.relativePath}`,
+            }));
+
+            // Append backend assets from the outputs map populated during the build.
+            // Keys are encoded query names ({hash(path)}.{name}).
+            for (const [bundleName, absolutePath] of backendOutputs) {
+                allAssets.push({
+                    absolutePath,
+                    relativePath: `backend/${bundleName}.js`,
+                });
+            }
+
+            const backendFunctions = getBackendFunctions();
+            const { manifestAsset, cleanup } = await writeManifestFile(backendFunctions);
+            cleanupManifest = cleanup;
+            allAssets.push(manifestAsset);
+
+            const archiveTimer = log.time('archive assets');
+            const archive = await createArchive(allAssets);
+            archiveTimer.end();
+            // Store variable for later disposal of directory.
+            archiveDir = path.dirname(archive.archivePath);
+
+            const uploadTimer = log.time('upload assets');
+            const { errors: uploadErrors, warnings: uploadWarnings } = await uploadArchive(
+                archive,
+                {
+                    apiKey: auth.apiKey,
+                    appKey: auth.appKey,
+                    bundlerName: context.bundler.name,
+                    dryRun: options.dryRun,
+                    identifier,
+                    name,
+                    site: auth.site,
+                    version: context.version,
+                },
+                log,
+            );
+            uploadTimer.end();
+
+            if (uploadWarnings.length > 0) {
+                log.warn(
+                    `${yellow('Warnings while uploading assets:')}\n    - ${uploadWarnings.join('\n    - ')}`,
+                );
+            }
+
+            if (uploadErrors.length > 0) {
+                const listOfErrors = uploadErrors
+                    .map((error) => error.cause || error.stack || error.message || error)
+                    .join('\n    - ');
+                throw new Error(`    - ${listOfErrors}`);
+            }
+        } catch (error: any) {
+            toThrow = error;
+            log.error(`${red('Failed to upload assets:')}\n${error?.message || error}`);
         }
-    },
-    configureServer(server) {
-        server.middlewares.use(
-            createDevServerMiddleware(viteBuild, getBackendFunctions, auth, buildRoot, log),
-        );
-    },
-});
+
+        // Clean temporary directory
+        if (archiveDir) {
+            await rm(archiveDir);
+        }
+        if (cleanupManifest) {
+            await cleanupManifest();
+        }
+        handleTimer.end();
+
+        if (toThrow) {
+            // Break the build.
+            throw toThrow;
+        }
+    };
+
+    return {
+        transform: {
+            filter: {
+                id: {
+                    include: [BACKEND_FILE_RE],
+                    exclude: [/node_modules/, /[/\\]dist[/\\]/],
+                },
+            },
+            // For each .backend.* file, parse its named exports, register
+            // them as backend functions, and replace the module with a
+            // frontend proxy that calls executeBackendFunction at runtime.
+            handler(code, id) {
+                const ast = this.parse(code);
+                const exportNames = extractExportedFunctions(ast, id);
+                if (exportNames.length === 0) {
+                    log.warn(
+                        `Backend file ${id} has no exported functions. ` +
+                            `Did you forget to add a named export?`,
+                    );
+                    // Clear any previously registered functions for this file
+                    // so stale entries don't persist across HMR re-transforms.
+                    setBackendFunctions(id, []);
+                    return { code: '', map: null };
+                }
+
+                const allowedConnectionIds = extractConnectionIds(ast, id);
+                const { functions, proxyCode } = buildProxyModule(
+                    exportNames,
+                    id,
+                    buildRoot,
+                    allowedConnectionIds,
+                );
+                setBackendFunctions(id, functions);
+                log.debug(`Generated proxy for ${id} with ${functions.length} export(s)`);
+
+                return { code: proxyCode, map: null };
+            },
+        },
+        async closeBundle() {
+            let backendOutDir: string | undefined;
+            let backendOutputs = new Map<string, string>();
+            const functions = getBackendFunctions();
+            if (functions.length > 0) {
+                const result = await buildBackendFunctions(
+                    bundler.build,
+                    functions,
+                    buildRoot,
+                    log,
+                );
+                backendOutDir = result.outDir;
+                backendOutputs = result.outputs;
+            }
+            try {
+                await handleUpload(backendOutputs);
+            } finally {
+                if (backendOutDir) {
+                    await rm(backendOutDir);
+                }
+            }
+        },
+        configureServer(server) {
+            server.middlewares.use(
+                createDevServerMiddleware(bundler.build, getBackendFunctions, auth, buildRoot, log),
+            );
+        },
+    };
+};


### PR DESCRIPTION
## Motivation

[build-plugins#353](https://github.com/DataDog/build-plugins/pull/353) needs to find action-catalog call sites that are reachable from a `*.backend.*` entry file, even when the calls are defined in imported helper modules instead of directly inside the backend entry file.

That graph traversal needs more of the Vite/Rollup plugin context available where backend transformation happens: module resolution, module loading, watch-file registration, and eventually TypeScript-to-JavaScript fallback transforms for local modules. Keeping backend transform ownership split between `packages/plugins/apps/src/index.ts` and `getVitePlugin` would force the graph PR to thread more Vite-specific state through the top-level apps plugin entrypoint.

This PR isolates that behavior-neutral ownership move first. The follow-up graph PR can then focus on the actual traversal and extraction behavior instead of mixing it with structural movement.

## Changes

Moves existing Vite-owned apps plugin behavior into `getVitePlugin` without changing the connection ID extraction boundary or upload behavior.

`getVitePlugin` now owns:
- backend `.backend.*` transform and proxy generation
- runtime injection at `InjectPosition.MIDDLE`
- backend function registry creation and replacement semantics
- backend build/upload sequencing during `closeBundle`
- dev-server middleware registration

The top-level apps plugin entrypoint now validates options, checks that the bundler is Vite, and delegates Vite-specific behavior to `getVitePlugin`. `getVitePlugin` receives the factory `context` directly so it can read Vite/build metadata and use the same ownership boundary that the module traversal PR will extend.

The upload/archive/manifest path was also extracted into a focused Vite helper module. That keeps `vite/index.ts` centered on Vite hook wiring while preserving the existing frontend/backend archive layout, root `manifest.json` shape, upload errors/warnings, and cleanup behavior.

This remains behavior-neutral: the transform still uses the current entry-only connection ID extraction path, so imported helper modules are not newly analyzed in this PR.

## QA Instructions

Automated:
- `yarn workspace @dd/apps-plugin typecheck`
- `yarn workspace @dd/tests test:unit packages/plugins/apps/src/index.test.ts packages/plugins/apps/src/vite/index.test.ts --runInBand`
- `yarn eslint packages/plugins/apps/src/index.ts packages/plugins/apps/src/vite/index.ts packages/plugins/apps/src/vite/handle-upload.ts packages/plugins/apps/src/index.test.ts packages/plugins/apps/src/vite/index.test.ts --quiet`
- `git diff --check`

## Blast Radius

Affects `@dd/apps-plugin` Vite hook organization only. This PR should preserve generated backend proxies, runtime injection position, backend function registry replacement semantics, upload archive layout, manifest shape, upload cleanup, and dev-server middleware behavior.

The review risk is mostly refactor risk around preserving existing hook timing and upload inputs. New module traversal behavior remains isolated to the child PR.

## Documentation

- [How to reliably make frontend production changes](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2286781319/Frontend+Production+Changesp)
- [PR Description Guidelines](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/3120334387/PR+Checklist+and+Guidelines+for+Web+UI)
- [Deploy steps](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/1457750032/)