### PR TITLE
[TEST] Validate master unit tests with upload fix

### DIFF
--- a/packages/tools/src/rollupConfig.test.ts
+++ b/packages/tools/src/rollupConfig.test.ts
@@ -58,6 +58,22 @@ jest.mock('@datadog/vite-plugin', () => ({
 jest.mock('@datadog/webpack-plugin', () => ({
     datadogWebpackPlugin: jest.fn(),
 }));
+jest.mock('@dd/core/helpers/fs', () => {
+    const actual = jest.requireActual<typeof import('@dd/core/helpers/fs')>('@dd/core/helpers/fs');
+    const nodeFs = jest.requireActual<typeof import('fs')>('fs');
+    const { File } = jest.requireActual<typeof import('buffer')>('buffer');
+
+    return {
+        ...actual,
+        getFile: jest.fn(
+            async (filepath: string, options: { contentType: string; filename: string }) => {
+                return new File([nodeFs.readFileSync(filepath)], options.filename, {
+                    type: options.contentType,
+                });
+            },
+        ),
+    };
+});
 
 const datadogEsbuildPluginMock = jest.mocked(datadogEsbuildPlugin);
 const datadogRollupPluginMock = jest.mocked(datadogRollupPlugin);


### PR DESCRIPTION
## Motivation\n\nValidate whether the rollupConfig unit-test failure is addressed on latest master by making the bundling test use memory-backed File objects for source-map uploads.\n\n## Changes\n\nThis branch is based on latest origin/master at e6b88631 and adds the test-only getFile mock in packages/tools/src/rollupConfig.test.ts. The mock preserves the real fs helper module while returning a memory-backed File for upload tests.\n\n## QA Instructions\n\nUse the PR CI results, especially the Unit tests job, to compare against the companion no-fix validation PR.\n\n## Blast Radius\n\nTest-only validation draft PR. No production code changes.\n\n## Documentation\n\nN/A