### PR TITLE
[APPS][Connections Part 10] Enrich parsed backend module records

### DIFF
--- a/packages/plugins/apps/src/backend/ast-parsing/module-graph.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/module-graph.test.ts
@@ -4,9 +4,35 @@
 
 import { parseAst } from 'rollup/parseAst';
 
-import { createParsedModuleRecord } from './module-graph';
+import {
+    createParsedModuleRecord,
+    type ExportBinding,
+    type ImportBinding,
+    type ParsedModuleRecord,
+    type StaticBinding,
+} from './module-graph';
 
 const buildRoot = '/project';
+
+function createRecord(code: string, staticDependencies: string[] = []): ParsedModuleRecord {
+    const record = createParsedModuleRecord(
+        '/project/src/backend/actions.backend.js',
+        buildRoot,
+        parseAst(code),
+        staticDependencies,
+    );
+
+    if (!record) {
+        throw new Error('Expected module record to be created');
+    }
+    return record;
+}
+
+function bindingsByVariableName<T>(bindings: Map<{ name: string }, T>): Record<string, T> {
+    return Object.fromEntries(
+        [...bindings.entries()].map(([variable, binding]) => [variable.name, binding]),
+    );
+}
 
 describe('Backend Functions - module graph records', () => {
     test('Should create graph records for app-local backend modules', () => {
@@ -127,5 +153,121 @@ describe('Backend Functions - module graph records', () => {
         );
 
         expect(record?.unsupportedDependencies).toEqual([]);
+    });
+
+    test('Should record import bindings by declared variable identity', () => {
+        const record = createRecord(
+            `
+                import { HTTP_ID as ACTIVE_ID } from './ids.js';
+                import DEFAULT_ID from './defaults.js';
+                import * as namespaceIds from './namespace.js';
+            `,
+            [
+                '/project/src/backend/ids.js',
+                '/project/src/backend/defaults.js',
+                '/project/src/backend/namespace.js',
+            ],
+        );
+
+        expect(bindingsByVariableName<ImportBinding>(record.importsByVariable)).toMatchObject({
+            ACTIVE_ID: {
+                kind: 'named',
+                importedName: 'HTTP_ID',
+                resolvedId: '/project/src/backend/ids.js',
+            },
+            DEFAULT_ID: {
+                kind: 'default',
+                resolvedId: '/project/src/backend/defaults.js',
+            },
+            namespaceIds: {
+                kind: 'namespace',
+                resolvedId: '/project/src/backend/namespace.js',
+            },
+        });
+    });
+
+    test('Should record local exports, re-exports, unsupported named exports, and star exports', () => {
+        const record = createRecord(
+            `
+                const LOCAL_ID = 'conn-local';
+                const { PATTERN_ID } = runtimeValues;
+
+                export const DIRECT_ID = 'conn-direct';
+                export { LOCAL_ID as ACTIVE_ID, PATTERN_ID };
+                export { REMOTE_ID as FORWARDED_ID, default as DEFAULT_ID } from './ids.js';
+                export * as namespaceIds from './namespace.js';
+                export * from './star.js';
+                export { LOCAL_ID as default };
+            `,
+            [
+                '/project/src/backend/ids.js',
+                '/project/src/backend/namespace.js',
+                '/project/src/backend/star.js',
+            ],
+        );
+        const exportsByName = Object.fromEntries(record.exportsByName) as Record<
+            string,
+            ExportBinding
+        >;
+
+        expect(exportsByName.ACTIVE_ID).toMatchObject({ kind: 'local' });
+        expect(exportsByName.DIRECT_ID).toMatchObject({ kind: 'local' });
+        expect(exportsByName.PATTERN_ID).toMatchObject({ kind: 'local' });
+        expect(exportsByName.FORWARDED_ID).toEqual({
+            kind: 're-export',
+            importedName: 'REMOTE_ID',
+            resolvedId: '/project/src/backend/ids.js',
+        });
+        expect(exportsByName.DEFAULT_ID).toEqual({
+            kind: 're-export',
+            importedName: 'default',
+            resolvedId: '/project/src/backend/ids.js',
+        });
+        expect(exportsByName.namespaceIds).toEqual({
+            kind: 'unsupported',
+            reason: 'namespace re-export',
+            resolvedId: '/project/src/backend/namespace.js',
+        });
+        expect(exportsByName.default).toEqual({
+            kind: 'unsupported',
+            reason: 'default export',
+        });
+        expect(record.starExports).toEqual([{ resolvedId: '/project/src/backend/star.js' }]);
+    });
+
+    test('Should record top-level static bindings by declared variable identity', () => {
+        const record = createRecord(`
+            const CONST_ID = 'conn-const';
+            let MUTABLE_ID = 'conn-mutable';
+            const { PATTERN_ID } = ids;
+            function getId() {
+                return 'conn-function';
+            }
+            export default function defaultGetId() {
+                return 'conn-default-function';
+            }
+            const CONNECTIONS = { HTTP: 'conn-http' };
+            CONNECTIONS.HTTP = 'conn-mutated';
+            const DELETED_CONNECTIONS = { HTTP: 'conn-http' };
+            delete DELETED_CONNECTIONS.HTTP;
+            const FOR_IN_CONNECTIONS = { HTTP: 'conn-http' };
+            for (FOR_IN_CONNECTIONS.HTTP in source) {}
+            const FOR_OF_CONNECTIONS = { HTTP: 'conn-http' };
+            for (FOR_OF_CONNECTIONS.HTTP of source) {}
+        `);
+
+        expect(
+            bindingsByVariableName<StaticBinding>(record.topLevelBindingsByVariable),
+        ).toMatchObject({
+            CONST_ID: { kind: 'const' },
+            MUTABLE_ID: { kind: 'mutable', declarationKind: 'let' },
+            PATTERN_ID: { kind: 'unsupported', reason: 'binding pattern' },
+            getId: { kind: 'unsupported', reason: 'FunctionDeclaration binding' },
+            defaultGetId: { kind: 'unsupported', reason: 'FunctionDeclaration binding' },
+            CONNECTIONS: { kind: 'unsupported', reason: 'mutated object binding' },
+            DELETED_CONNECTIONS: { kind: 'unsupported', reason: 'mutated object binding' },
+            FOR_IN_CONNECTIONS: { kind: 'unsupported', reason: 'mutated object binding' },
+            FOR_OF_CONNECTIONS: { kind: 'unsupported', reason: 'mutated object binding' },
+        });
     });
 });

--- a/packages/plugins/apps/src/backend/ast-parsing/module-graph.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/module-graph.ts
@@ -2,19 +2,57 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import type { BaseNode, ImportExpression, Program, SimpleCallExpression } from 'estree';
+import type * as eslintScope from 'eslint-scope';
+import type {
+    BaseNode,
+    ExportAllDeclaration,
+    ExportNamedDeclaration,
+    Expression,
+    Identifier,
+    ImportExpression,
+    Literal,
+    ModuleDeclaration,
+    Pattern,
+    Program,
+    SimpleCallExpression,
+    Super,
+    VariableDeclaration,
+} from 'estree';
 import path from 'path';
 
 import { BACKEND_CODE_EXTENSIONS } from '../../constants';
 
+import {
+    analyzeModuleScope,
+    getModuleVariable,
+    isImportVariable,
+    type ModuleScopeAnalysis,
+    resolveIdentifier,
+} from './module-scope';
 import { ensureProgram, isStringLiteral } from './type-guards';
 import { walkAst } from './walk-ast';
 
+/**
+ * Parsed app-local backend module plus reusable static facts about its module
+ * boundary and top-level declarations. These facts are intentionally
+ * domain-neutral: action-catalog and connection ID logic consume them later,
+ * but they are not encoded into the record itself.
+ */
 export interface ParsedModuleRecord {
     id: string;
     ast: Program;
+    scopeAnalysis: ModuleScopeAnalysis;
     staticDependencies: StaticModuleDependency[];
     unsupportedDependencies: ModuleDependency[];
+    importsByVariable: Map<eslintScope.Variable, ImportBinding>;
+    /**
+     * Export names that can be answered directly by this module. Bare
+     * `export *` edges stay in `starExports` because they must be probed by
+     * requested export name during resolution.
+     */
+    exportsByName: Map<string, ExportBinding>;
+    starExports: StarExport[];
+    topLevelBindingsByVariable: Map<eslintScope.Variable, StaticBinding>;
 }
 
 export interface StaticModuleDependency {
@@ -27,7 +65,80 @@ export interface ModuleDependency {
     kind: 'dynamic-import' | 'require';
 }
 
+/**
+ * Import binding keyed by the local eslint-scope variable, not the local text
+ * name, so later lookups remain safe when names are shadowed.
+ */
+export type ImportBinding = NamedImportBinding | DefaultImportBinding | NamespaceImportBinding;
+
+export interface NamedImportBinding {
+    kind: 'named';
+    importedName: string;
+    resolvedId: string;
+}
+
+export interface DefaultImportBinding {
+    kind: 'default';
+    resolvedId: string;
+}
+
+export interface NamespaceImportBinding {
+    kind: 'namespace';
+    resolvedId: string;
+}
+
+/**
+ * Export binding for names this module can answer without probing star
+ * exports. Unsupported records preserve the fact that an export name exists
+ * even when later static definition resolution will reject its form.
+ */
+export type ExportBinding = LocalExportBinding | ReExportBinding | UnsupportedExportBinding;
+
+export interface LocalExportBinding {
+    kind: 'local';
+    variable: eslintScope.Variable;
+}
+
+export interface ReExportBinding {
+    kind: 're-export';
+    importedName: string;
+    resolvedId: string;
+}
+
+export interface UnsupportedExportBinding {
+    kind: 'unsupported';
+    reason: string;
+    resolvedId?: string;
+}
+
+export interface StarExport {
+    resolvedId: string;
+}
+
+/**
+ * Top-level declaration summary. This records whether a local variable has a
+ * static expression later resolvers can inspect, without deciding whether that
+ * expression is meaningful for any particular domain.
+ */
+export type StaticBinding = ConstStaticBinding | MutableStaticBinding | UnsupportedStaticBinding;
+
+export interface ConstStaticBinding {
+    kind: 'const';
+    expression: Expression | null;
+}
+
+export interface MutableStaticBinding {
+    kind: 'mutable';
+    declarationKind: Exclude<VariableDeclaration['kind'], 'const'>;
+}
+
+export interface UnsupportedStaticBinding {
+    kind: 'unsupported';
+    reason: string;
+}
+
 type ImportCallExpression = SimpleCallExpression & { callee: { type: 'Import' } };
+type ModuleExportName = Identifier | Literal;
 
 const PACKAGE_MANAGER_DIRS = new Set(['node_modules', '.yarn']);
 
@@ -51,12 +162,19 @@ export function createParsedModuleRecord(
     }
 
     const program = ensureProgram(ast, moduleId);
+    const scopeAnalysis = analyzeModuleScope(program);
+    const staticModuleDependencies = collectStaticModuleDependencies(program, staticDependencies);
 
     return {
         id: moduleId,
         ast: program,
-        staticDependencies: collectStaticModuleDependencies(program, staticDependencies),
+        scopeAnalysis,
+        staticDependencies: staticModuleDependencies,
         unsupportedDependencies: collectUnsupportedModuleDependencies(program),
+        importsByVariable: collectImportBindings(program, scopeAnalysis, staticModuleDependencies),
+        exportsByName: collectExportBindings(program, scopeAnalysis, staticModuleDependencies),
+        starExports: collectStarExports(program, staticModuleDependencies),
+        topLevelBindingsByVariable: collectTopLevelBindings(program, scopeAnalysis),
     };
 }
 
@@ -86,6 +204,417 @@ function getStaticModuleSources(ast: Program): string[] {
 
         return [];
     });
+}
+
+function collectImportBindings(
+    ast: Program,
+    scopeAnalysis: ModuleScopeAnalysis,
+    staticDependencies: StaticModuleDependency[],
+): Map<eslintScope.Variable, ImportBinding> {
+    const importsByVariable = new Map<eslintScope.Variable, ImportBinding>();
+
+    for (const node of ast.body) {
+        if (node.type !== 'ImportDeclaration' || !isStringLiteral(node.source)) {
+            continue;
+        }
+
+        const resolvedId = getResolvedSource(staticDependencies, node.source.value);
+        for (const specifier of node.specifiers) {
+            const [variable] = scopeAnalysis.scopeManager.getDeclaredVariables(specifier);
+            if (!variable) {
+                continue;
+            }
+
+            if (specifier.type === 'ImportSpecifier') {
+                importsByVariable.set(variable, {
+                    kind: 'named',
+                    importedName: getModuleExportName(specifier.imported),
+                    resolvedId,
+                });
+                continue;
+            }
+
+            importsByVariable.set(variable, {
+                kind: specifier.type === 'ImportDefaultSpecifier' ? 'default' : 'namespace',
+                resolvedId,
+            });
+        }
+    }
+
+    return importsByVariable;
+}
+
+function collectExportBindings(
+    ast: Program,
+    scopeAnalysis: ModuleScopeAnalysis,
+    staticDependencies: StaticModuleDependency[],
+): Map<string, ExportBinding> {
+    const exportsByName = new Map<string, ExportBinding>();
+
+    for (const node of ast.body) {
+        if (node.type === 'ExportNamedDeclaration') {
+            collectNamedExportBindings(node, scopeAnalysis, staticDependencies, exportsByName);
+            continue;
+        }
+
+        if (node.type === 'ExportDefaultDeclaration') {
+            exportsByName.set('default', { kind: 'unsupported', reason: 'default export' });
+            continue;
+        }
+
+        if (node.type === 'ExportAllDeclaration') {
+            collectNamespaceExportBinding(node, staticDependencies, exportsByName);
+        }
+    }
+
+    return exportsByName;
+}
+
+function collectNamedExportBindings(
+    node: ExportNamedDeclaration,
+    scopeAnalysis: ModuleScopeAnalysis,
+    staticDependencies: StaticModuleDependency[],
+    exportsByName: Map<string, ExportBinding>,
+): void {
+    if (node.declaration) {
+        collectDeclarationExportBindings(node.declaration, scopeAnalysis, exportsByName);
+        return;
+    }
+
+    if (node.source && isStringLiteral(node.source)) {
+        const resolvedId = getResolvedSource(staticDependencies, node.source.value);
+        for (const specifier of node.specifiers) {
+            if (specifier.type !== 'ExportSpecifier') {
+                continue;
+            }
+            const exportedName = getModuleExportName(specifier.exported);
+            if (exportedName === 'default') {
+                exportsByName.set(exportedName, {
+                    kind: 'unsupported',
+                    reason: 'default re-export',
+                    resolvedId,
+                });
+                continue;
+            }
+            exportsByName.set(exportedName, {
+                kind: 're-export',
+                importedName: getModuleExportName(specifier.local),
+                resolvedId,
+            });
+        }
+        return;
+    }
+
+    for (const specifier of node.specifiers) {
+        if (specifier.type !== 'ExportSpecifier') {
+            continue;
+        }
+        const exportedName = getModuleExportName(specifier.exported);
+        if (exportedName === 'default') {
+            exportsByName.set(exportedName, {
+                kind: 'unsupported',
+                reason: 'default export',
+            });
+            continue;
+        }
+        const variable = getModuleVariable(getModuleExportName(specifier.local), scopeAnalysis);
+        exportsByName.set(
+            exportedName,
+            variable
+                ? { kind: 'local', variable }
+                : { kind: 'unsupported', reason: 'unresolved local export' },
+        );
+    }
+}
+
+function collectDeclarationExportBindings(
+    declaration: ExportNamedDeclaration['declaration'],
+    scopeAnalysis: ModuleScopeAnalysis,
+    exportsByName: Map<string, ExportBinding>,
+): void {
+    if (!declaration) {
+        return;
+    }
+
+    if (declaration.type === 'VariableDeclaration') {
+        for (const declarator of declaration.declarations) {
+            const variables = scopeAnalysis.scopeManager.getDeclaredVariables(declarator);
+            if (declarator.id.type !== 'Identifier') {
+                for (const variable of variables) {
+                    exportsByName.set(variable.name, {
+                        kind: 'unsupported',
+                        reason: 'binding pattern export',
+                    });
+                }
+                continue;
+            }
+
+            const [variable] = variables;
+            if (variable) {
+                exportsByName.set(declarator.id.name, { kind: 'local', variable });
+            }
+        }
+        return;
+    }
+
+    if (
+        (declaration.type === 'FunctionDeclaration' || declaration.type === 'ClassDeclaration') &&
+        declaration.id
+    ) {
+        const [variable] = scopeAnalysis.scopeManager.getDeclaredVariables(declaration);
+        if (variable) {
+            exportsByName.set(declaration.id.name, { kind: 'local', variable });
+        }
+    }
+}
+
+function collectNamespaceExportBinding(
+    node: ExportAllDeclaration,
+    staticDependencies: StaticModuleDependency[],
+    exportsByName: Map<string, ExportBinding>,
+): void {
+    const exported = getExportAllExportedName(node);
+    if (!exported || !isStringLiteral(node.source)) {
+        return;
+    }
+
+    exportsByName.set(exported, {
+        kind: 'unsupported',
+        reason: 'namespace re-export',
+        resolvedId: getResolvedSource(staticDependencies, node.source.value),
+    });
+}
+
+function collectStarExports(
+    ast: Program,
+    staticDependencies: StaticModuleDependency[],
+): StarExport[] {
+    return ast.body.flatMap((node) => {
+        if (
+            node.type !== 'ExportAllDeclaration' ||
+            getExportAllExportedName(node) ||
+            !isStringLiteral(node.source)
+        ) {
+            return [];
+        }
+
+        return [{ resolvedId: getResolvedSource(staticDependencies, node.source.value) }];
+    });
+}
+
+function collectTopLevelBindings(
+    ast: Program,
+    scopeAnalysis: ModuleScopeAnalysis,
+): Map<eslintScope.Variable, StaticBinding> {
+    const bindings = new Map<eslintScope.Variable, StaticBinding>();
+
+    for (const node of ast.body) {
+        collectTopLevelNodeBindings(node, scopeAnalysis, bindings);
+    }
+
+    markReassignedTopLevelBindings(ast, scopeAnalysis, bindings);
+    return bindings;
+}
+
+function collectTopLevelNodeBindings(
+    node: ModuleDeclaration | Program['body'][number],
+    scopeAnalysis: ModuleScopeAnalysis,
+    bindings: Map<eslintScope.Variable, StaticBinding>,
+): void {
+    if (node.type === 'VariableDeclaration') {
+        collectVariableDeclarationBindings(node, scopeAnalysis, bindings);
+        return;
+    }
+
+    if (
+        node.type === 'ExportNamedDeclaration' &&
+        node.declaration?.type === 'VariableDeclaration'
+    ) {
+        collectVariableDeclarationBindings(node.declaration, scopeAnalysis, bindings);
+        return;
+    }
+
+    const declaration =
+        node.type === 'ExportNamedDeclaration' || node.type === 'ExportDefaultDeclaration'
+            ? node.declaration
+            : node;
+    if (
+        declaration &&
+        (declaration.type === 'FunctionDeclaration' || declaration.type === 'ClassDeclaration') &&
+        declaration.id
+    ) {
+        const [variable] = scopeAnalysis.scopeManager.getDeclaredVariables(declaration);
+        if (variable) {
+            bindings.set(variable, {
+                kind: 'unsupported',
+                reason: `${declaration.type} binding`,
+            });
+        }
+    }
+}
+
+function collectVariableDeclarationBindings(
+    declaration: VariableDeclaration,
+    scopeAnalysis: ModuleScopeAnalysis,
+    bindings: Map<eslintScope.Variable, StaticBinding>,
+): void {
+    for (const declarator of declaration.declarations) {
+        const variables = scopeAnalysis.scopeManager.getDeclaredVariables(declarator);
+        if (declarator.id.type !== 'Identifier') {
+            for (const variable of variables) {
+                bindings.set(variable, { kind: 'unsupported', reason: 'binding pattern' });
+            }
+            continue;
+        }
+
+        const [variable] = variables;
+        if (!variable) {
+            continue;
+        }
+        if (declaration.kind === 'const') {
+            bindings.set(variable, { kind: 'const', expression: declarator.init ?? null });
+        } else {
+            bindings.set(variable, {
+                kind: 'mutable',
+                declarationKind: declaration.kind,
+            });
+        }
+    }
+}
+
+function markReassignedTopLevelBindings(
+    ast: Program,
+    scopeAnalysis: ModuleScopeAnalysis,
+    bindings: Map<eslintScope.Variable, StaticBinding>,
+): void {
+    walkAst(
+        ast,
+        { scopeAnalysis, bindings },
+        {
+            AssignmentExpression(node, { state }) {
+                markAssignedPattern(node.left, state.scopeAnalysis, state.bindings);
+            },
+            UpdateExpression(node, { state }) {
+                markAssignedPattern(node.argument, state.scopeAnalysis, state.bindings);
+            },
+            UnaryExpression(node, { state }) {
+                if (node.operator === 'delete') {
+                    markAssignedPattern(node.argument, state.scopeAnalysis, state.bindings);
+                }
+            },
+            ForInStatement(node, { state }) {
+                markForIterationTarget(node.left, state.scopeAnalysis, state.bindings);
+            },
+            ForOfStatement(node, { state }) {
+                markForIterationTarget(node.left, state.scopeAnalysis, state.bindings);
+            },
+        },
+    );
+}
+
+function markForIterationTarget(
+    left: Pattern | VariableDeclaration,
+    scopeAnalysis: ModuleScopeAnalysis,
+    bindings: Map<eslintScope.Variable, StaticBinding>,
+): void {
+    if (left.type !== 'VariableDeclaration') {
+        markAssignedPattern(left, scopeAnalysis, bindings);
+    }
+}
+
+function markAssignedPattern(
+    pattern: Pattern | Expression,
+    scopeAnalysis: ModuleScopeAnalysis,
+    bindings: Map<eslintScope.Variable, StaticBinding>,
+): void {
+    if (pattern.type === 'Identifier') {
+        markAssignedVariable(pattern, scopeAnalysis, bindings, 'reassigned binding');
+        return;
+    }
+
+    if (pattern.type === 'MemberExpression') {
+        const root = getMemberExpressionRoot(pattern);
+        if (root) {
+            markAssignedVariable(root, scopeAnalysis, bindings, 'mutated object binding');
+        }
+        return;
+    }
+
+    if (pattern.type === 'ObjectPattern') {
+        for (const property of pattern.properties) {
+            markAssignedPattern(
+                property.type === 'RestElement' ? property.argument : property.value,
+                scopeAnalysis,
+                bindings,
+            );
+        }
+        return;
+    }
+
+    if (pattern.type === 'ArrayPattern') {
+        for (const element of pattern.elements) {
+            if (element) {
+                markAssignedPattern(element, scopeAnalysis, bindings);
+            }
+        }
+        return;
+    }
+
+    if (pattern.type === 'RestElement') {
+        markAssignedPattern(pattern.argument, scopeAnalysis, bindings);
+        return;
+    }
+
+    if (pattern.type === 'AssignmentPattern') {
+        markAssignedPattern(pattern.left, scopeAnalysis, bindings);
+    }
+}
+
+function markAssignedVariable(
+    identifier: Identifier,
+    scopeAnalysis: ModuleScopeAnalysis,
+    bindings: Map<eslintScope.Variable, StaticBinding>,
+    reason: string,
+): void {
+    const variable = resolveIdentifier(identifier, scopeAnalysis);
+    if (!variable || isImportVariable(variable) || !bindings.has(variable)) {
+        return;
+    }
+
+    const binding = bindings.get(variable);
+    if (binding?.kind === 'mutable') {
+        return;
+    }
+    bindings.set(variable, { kind: 'unsupported', reason });
+}
+
+function getMemberExpressionRoot(node: Expression | Super): Identifier | undefined {
+    if (node.type === 'Identifier') {
+        return node;
+    }
+    if (node.type === 'MemberExpression') {
+        return getMemberExpressionRoot(node.object);
+    }
+    return undefined;
+}
+
+function getModuleExportName(node: ModuleExportName): string {
+    if (node.type === 'Identifier') {
+        return node.name;
+    }
+    return String(node.value);
+}
+
+function getExportAllExportedName(node: ExportAllDeclaration): string | undefined {
+    const exported = (node as ExportAllDeclaration & { exported?: ModuleExportName | null })
+        .exported;
+    return exported ? getModuleExportName(exported) : undefined;
+}
+
+function getResolvedSource(staticDependencies: StaticModuleDependency[], source: string): string {
+    return (
+        staticDependencies.find((dependency) => dependency.source === source)?.resolvedId ?? source
+    );
 }
 
 /**

--- a/packages/plugins/apps/src/backend/ast-parsing/walk-module-graph.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/walk-module-graph.test.ts
@@ -5,6 +5,7 @@
 import { parseAst } from 'rollup/parseAst';
 
 import type { ModuleDependency, ParsedModuleRecord, StaticModuleDependency } from './module-graph';
+import { analyzeModuleScope } from './module-scope';
 import { ensureProgram } from './type-guards';
 import { walkModuleGraph } from './walk-module-graph';
 
@@ -15,11 +16,18 @@ function createRecord(
     staticDependencies: string[] = [],
     unsupportedDependencies: ModuleDependency[] = [],
 ): ParsedModuleRecord {
+    const ast = ensureProgram(parseAst('export const value = true;'), id);
+
     return {
         id,
-        ast: ensureProgram(parseAst('export const value = true;'), id),
+        ast,
+        scopeAnalysis: analyzeModuleScope(ast),
         staticDependencies: staticDependencies.map(toStaticDependency),
         unsupportedDependencies,
+        importsByVariable: new Map(),
+        exportsByName: new Map(),
+        starExports: [],
+        topLevelBindingsByVariable: new Map(),
     };
 }
 


### PR DESCRIPTION
## Motivation

This is the second slice split out of the previous all-in-one module graph PR and is stacked on #373. Once scope analysis is reusable, `ParsedModuleRecord` can keep the static import/export/top-level binding facts needed by later resolver work without mixing in action-catalog or connection ID behavior.

## Changes

`ParsedModuleRecord` now captures the static ES module facts that later graph traversal can consume:

```ts
export interface ParsedModuleRecord {
    id: string;
    ast: Program;
    scopeAnalysis: ModuleScopeAnalysis;
    staticDependencies: StaticModuleDependency[];
    unsupportedDependencies: ModuleDependency[];
    importsByVariable: Map<eslintScope.Variable, ImportBinding>;
    exportsByName: Map<string, ExportBinding>;
    starExports: StarExport[];
    topLevelBindingsByVariable: Map<eslintScope.Variable, StaticBinding>;
}
```

For example, given a backend module like this:

```ts
import { HTTP_ID as ACTIVE_ID } from './ids.js';
import * as shared from './shared.js';

const LOCAL_ID = 'conn-local';
const CONNECTIONS = { HTTP: 'conn-http' };

export { LOCAL_ID as EXPORTED_LOCAL_ID };
export { REMOTE_ID as EXPORTED_REMOTE_ID } from './remote.js';
export * as namespaceIds from './namespace.js';
export * from './star.js';
```

The associated record stores data shaped like this:

```ts
{
    staticDependencies: [
        { source: './ids.js', resolvedId: '/project/src/backend/ids.js' },
        { source: './shared.js', resolvedId: '/project/src/backend/shared.js' },
        { source: './remote.js', resolvedId: '/project/src/backend/remote.js' },
        { source: './namespace.js', resolvedId: '/project/src/backend/namespace.js' },
        { source: './star.js', resolvedId: '/project/src/backend/star.js' },
    ],
    importsByVariable: Map([
        [ACTIVE_ID_VARIABLE, {
            kind: 'named',
            importedName: 'HTTP_ID',
            resolvedId: '/project/src/backend/ids.js',
        }],
        [shared_VARIABLE, {
            kind: 'namespace',
            resolvedId: '/project/src/backend/shared.js',
        }],
    ]),
    exportsByName: Map([
        ['EXPORTED_LOCAL_ID', { kind: 'local', variable: LOCAL_ID_VARIABLE }],
        ['EXPORTED_REMOTE_ID', {
            kind: 're-export',
            importedName: 'REMOTE_ID',
            resolvedId: '/project/src/backend/remote.js',
        }],
        ['namespaceIds', {
            kind: 'unsupported',
            reason: 'namespace re-export',
            resolvedId: '/project/src/backend/namespace.js',
        }],
    ]),
    starExports: [
        { resolvedId: '/project/src/backend/star.js' },
    ],
    topLevelBindingsByVariable: Map([
        [LOCAL_ID_VARIABLE, { kind: 'const', expression: STRING_LITERAL_NODE }],
        [CONNECTIONS_VARIABLE, { kind: 'const', expression: OBJECT_EXPRESSION_NODE }],
    ]),
}
```

Unsupported export and binding records intentionally preserve the fact that a symbol exists even when the first resolver cannot statically evaluate that form. That lets follow-up resolver code distinguish “missing export” from “export exists, but this form is unsupported.”

## QA Instructions

No manual QA; this is internal AST parsing metadata for the apps plugin backend module graph and is covered by CI.

## Blast Radius

This affects backend apps module graph parsing. It adds static metadata to `ParsedModuleRecord` and updates existing module graph test builders, but it does not change runtime app behavior or customer-facing UI.

## Documentation

-   [How to reliably make frontend production changes](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2286781319/Frontend+Production+Changesp)
-   [PR Description Guidelines](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/3120334387/PR+Checklist+and+Guidelines+for+Web+UI)
-   [Deploy steps](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/1457750032/)
