### PR TITLE
Constrain auth.site to the documented Datadog sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The Datadog site to use APIs from, and which Datadog site telemetry metrics and 
 - `'ap1.datadoghq.com'`
 - `'ap2.datadoghq.com'`
 
-An unsupported value (passed via configuration or the `DATADOG_SITE` / `DD_SITE` environment variable) will throw at plugin initialization with a link back to the site list.
+An unsupported value (passed via configuration or the `DATADOG_SITE` / `DD_SITE` environment variable) will throw at plugin initialization.
 
 > [!NOTE]
 > The `DATADOG_SITE` environment variable takes priority over this configuration.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Follow the specific documentation for each bundler:
     auth?: {
         apiKey?: string;
         appKey?: string;
-        site?: Sites;
+        site?: Site;
     };
     customPlugins?: (arg: GetPluginsArg) => UnpluginPlugin[];
     enableGit?: boolean;

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Follow the specific documentation for each bundler:
     auth?: {
         apiKey?: string;
         appKey?: string;
-        site?: string;
+        site?: Sites;
     };
     customPlugins?: (arg: GetPluginsArg) => UnpluginPlugin[];
     enableGit?: boolean;
@@ -159,11 +159,18 @@ In order to interact with Datadog, you have to use [your own Application Key](ht
 
 > default `'datadoghq.com'`
 
-The Datadog site to use APIs from.
+The Datadog site to use APIs from, and which Datadog site telemetry metrics and error tracking sourcemaps are sent to. Must be one of the [documented Datadog sites](https://docs.datadoghq.com/getting_started/site/):
 
-Possible values are `'datadoghq.com'`, `'datadoghq.eu'`, `'us3.datadoghq.com'`, `'us5.datadoghq.com'`, `'ap1.datadoghq.com'`, etc.
+- `'datadoghq.com'`
+- `'us3.datadoghq.com'`
+- `'us5.datadoghq.com'`
+- `'datadoghq.eu'`
+- `'ddog-gov.com'`
+- `'us2.ddog-gov.com'`
+- `'ap1.datadoghq.com'`
+- `'ap2.datadoghq.com'`
 
-This configuration controls which Datadog site telemetry metrics and error tracking sourcemaps are sent to.
+An unsupported value (passed via configuration or the `DATADOG_SITE` / `DD_SITE` environment variable) will throw at plugin initialization with a link back to the site list.
 
 > [!NOTE]
 > The `DATADOG_SITE` environment variable takes priority over this configuration.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -22,6 +22,9 @@ export const SITES = [
     'ap2.datadoghq.com',
     'datad0g.com',
 ] as const;
+
+export const DEFAULT_SITE = SITES[0];
+
 export const ENV_VAR_REQUESTED_BUNDLERS = 'PLAYWRIGHT_REQUESTED_BUNDLERS';
 
 export const HOST_NAME = 'datadog-build-plugins';

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -8,6 +8,20 @@ export const INJECTED_FILE_RX = new RegExp(INJECTED_FILE);
 export const ALL_ENVS = ['development', 'production', 'test'] as const;
 export const ALL_BUNDLERS = ['webpack', 'vite', 'esbuild', 'rollup', 'rspack', 'rolldown', 'farm'];
 export const SUPPORTED_BUNDLERS = ['webpack', 'vite', 'esbuild', 'rollup', 'rspack'] as const;
+
+// source of truth: site parameter column of the site list in
+// https://docs.datadoghq.com/getting_started/site/
+export const SITES = [
+    'datadoghq.com',
+    'us3.datadoghq.com',
+    'us5.datadoghq.com',
+    'datadoghq.eu',
+    'ddog-gov.com',
+    'us2.ddog-gov.com',
+    'ap1.datadoghq.com',
+    'ap2.datadoghq.com',
+    'datad0g.com',
+] as const;
 export const ENV_VAR_REQUESTED_BUNDLERS = 'PLAYWRIGHT_REQUESTED_BUNDLERS';
 
 export const HOST_NAME = 'datadog-build-plugins';

--- a/packages/core/src/helpers/request.test.ts
+++ b/packages/core/src/helpers/request.test.ts
@@ -2,13 +2,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+import { DEFAULT_SITE } from '@dd/core/constants';
 import type { RequestOpts } from '@dd/core/types';
 import {
     SOURCEMAPS_API_PATH,
     SOURCEMAPS_API_SUBDOMAIN,
     getIntakeUrl,
 } from '@dd/error-tracking-plugin/sourcemaps/sender';
-import { DEFAULT_SITE } from '@dd/tests/_jest/helpers/mocks';
 import nock from 'nock';
 import { Readable } from 'stream';
 import { createGzip } from 'zlib';

--- a/packages/core/src/helpers/request.test.ts
+++ b/packages/core/src/helpers/request.test.ts
@@ -8,13 +8,13 @@ import {
     SOURCEMAPS_API_SUBDOMAIN,
     getIntakeUrl,
 } from '@dd/error-tracking-plugin/sourcemaps/sender';
-import { FAKE_SITE } from '@dd/tests/_jest/helpers/mocks';
+import { DEFAULT_SITE } from '@dd/tests/_jest/helpers/mocks';
 import nock from 'nock';
 import { Readable } from 'stream';
 import { createGzip } from 'zlib';
 
 const API_PATH = `/${SOURCEMAPS_API_PATH}`;
-const API_URL = `https://${SOURCEMAPS_API_SUBDOMAIN}.${FAKE_SITE}`;
+const API_URL = `https://${SOURCEMAPS_API_SUBDOMAIN}.${DEFAULT_SITE}`;
 
 describe('Request Helpers', () => {
     describe('doRequest', () => {
@@ -34,7 +34,7 @@ describe('Request Helpers', () => {
         });
 
         const requestOpts: RequestOpts = {
-            url: getIntakeUrl(FAKE_SITE),
+            url: getIntakeUrl(DEFAULT_SITE),
             method: 'POST',
             type: 'json',
             getData: getDataMock,
@@ -199,7 +199,7 @@ describe('Request Helpers', () => {
             });
 
             expect(fetchMock).toHaveBeenCalledWith(
-                getIntakeUrl(FAKE_SITE),
+                getIntakeUrl(DEFAULT_SITE),
                 expect.objectContaining({
                     headers: expect.objectContaining({
                         // Coming from the requestOpts.auth.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -25,7 +25,7 @@ import type * as rum from '@dd/rum-plugin';
 import type { BodyInit } from 'undici-types';
 import type { UnpluginOptions } from 'unplugin';
 
-import type { ALL_ENVS, SUPPORTED_BUNDLERS } from './constants';
+import type { ALL_ENVS, SITES, SUPPORTED_BUNDLERS } from './constants';
 
 export type Assign<A, B> = Omit<A, keyof B> & B;
 export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
@@ -244,10 +244,11 @@ export type GetWrappedPlugins = (arg: GetPluginsArg) => (PluginOptions | CustomP
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'none';
 
+export type Sites = (typeof SITES)[number];
 export type AuthOptions = {
     apiKey?: string;
     appKey?: string;
-    site?: string;
+    site?: Sites;
 };
 
 export type AuthOptionsWithDefaults = WithRequired<AuthOptions, 'site'>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -244,11 +244,11 @@ export type GetWrappedPlugins = (arg: GetPluginsArg) => (PluginOptions | CustomP
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'none';
 
-export type Sites = (typeof SITES)[number];
+export type Site = (typeof SITES)[number];
 export type AuthOptions = {
     apiKey?: string;
     appKey?: string;
-    site?: Sites;
+    site?: Site;
 };
 
 export type AuthOptionsWithDefaults = WithRequired<AuthOptions, 'site'>;

--- a/packages/factory/src/validate.ts
+++ b/packages/factory/src/validate.ts
@@ -2,33 +2,35 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import { SITES } from '@dd/core/constants';
+import { DEFAULT_SITE, SITES } from '@dd/core/constants';
 import { getDDEnvValue } from '@dd/core/helpers/env';
 import type {
     AuthOptionsWithDefaults,
     BuildMetadata,
     Options,
     OptionsWithDefaults,
-    Sites,
+    Site,
 } from '@dd/core/types';
 
 const SITES_DOC_URL = 'https://docs.datadoghq.com/getting_started/site/';
 
-const isSite = (value: string): value is Sites => (SITES as readonly string[]).includes(value);
+const isSite = (value: string): value is Site => SITES.some((s) => s === value);
 
-const validateAuth = (authSite: string | undefined, envSite: string | undefined): string[] => {
-    const errors: string[] = [];
-    if (authSite !== undefined && !isSite(authSite)) {
-        errors.push(
-            `auth.site "${authSite}" is not a supported Datadog site. See the site parameters in ${SITES_DOC_URL}.`,
-        );
+const resolveSite = (
+    value: string | undefined,
+    source: string,
+    errors: string[],
+): Site | undefined => {
+    if (value === undefined) {
+        return undefined;
     }
-    if (envSite !== undefined && !isSite(envSite)) {
-        errors.push(
-            `DATADOG_SITE/DD_SITE "${envSite}" is not a supported Datadog site. See the site parameters in ${SITES_DOC_URL}.`,
-        );
+    if (isSite(value)) {
+        return value;
     }
-    return errors;
+    errors.push(
+        `${source} "${value}" is not a supported Datadog site. See the site parameters in ${SITES_DOC_URL}.`,
+    );
+    return undefined;
 };
 
 const validateMetadata = (metadata: BuildMetadata | undefined): string[] => {
@@ -47,22 +49,20 @@ const validateMetadata = (metadata: BuildMetadata | undefined): string[] => {
 };
 
 export const validateOptions = (options: Options = {}): OptionsWithDefaults => {
-    const envSite = getDDEnvValue('SITE');
-    const errors: string[] = [
-        ...validateMetadata(options.metadata),
-        ...validateAuth(options.auth?.site, envSite),
-    ];
+    const errors: string[] = validateMetadata(options.metadata);
+    // DATADOG_SITE env var takes precedence over configuration; only validate
+    // auth.site when no env var is set, so a stale auth.site can't block a
+    // build that has already opted into an env override.
+    const envRaw = getDDEnvValue('SITE');
+    const envSite = resolveSite(envRaw, 'DATADOG_SITE/DD_SITE', errors);
+
+    const auth: AuthOptionsWithDefaults = {
+        site: envSite ?? resolveSite(options.auth?.site, 'auth.site', errors) ?? DEFAULT_SITE,
+    };
 
     if (errors.length) {
         throw new Error(`Invalid Datadog plugin configuration:\n  - ${errors.join('\n  - ')}`);
     }
-
-    // DATADOG_SITE env var takes precedence over configuration.
-    // envSite is re-checked with isSite so TS narrows it from string to Sites.
-    const validatedEnvSite = envSite !== undefined && isSite(envSite) ? envSite : undefined;
-    const auth: AuthOptionsWithDefaults = {
-        site: validatedEnvSite ?? options.auth?.site ?? 'datadoghq.com',
-    };
 
     // Prevent these from being accidentally logged.
     Object.defineProperty(auth, 'apiKey', {

--- a/packages/factory/src/validate.ts
+++ b/packages/factory/src/validate.ts
@@ -2,13 +2,34 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+import { SITES } from '@dd/core/constants';
 import { getDDEnvValue } from '@dd/core/helpers/env';
 import type {
     AuthOptionsWithDefaults,
     BuildMetadata,
     Options,
     OptionsWithDefaults,
+    Sites,
 } from '@dd/core/types';
+
+const SITES_DOC_URL = 'https://docs.datadoghq.com/getting_started/site/';
+
+const isSite = (value: string): value is Sites => (SITES as readonly string[]).includes(value);
+
+const validateAuth = (authSite: string | undefined, envSite: string | undefined): string[] => {
+    const errors: string[] = [];
+    if (authSite !== undefined && !isSite(authSite)) {
+        errors.push(
+            `auth.site "${authSite}" is not a supported Datadog site. See the site parameters in ${SITES_DOC_URL}.`,
+        );
+    }
+    if (envSite !== undefined && !isSite(envSite)) {
+        errors.push(
+            `DATADOG_SITE/DD_SITE "${envSite}" is not a supported Datadog site. See the site parameters in ${SITES_DOC_URL}.`,
+        );
+    }
+    return errors;
+};
 
 const validateMetadata = (metadata: BuildMetadata | undefined): string[] => {
     const errors: string[] = [];
@@ -26,15 +47,21 @@ const validateMetadata = (metadata: BuildMetadata | undefined): string[] => {
 };
 
 export const validateOptions = (options: Options = {}): OptionsWithDefaults => {
-    const errors: string[] = [...validateMetadata(options.metadata)];
+    const envSite = getDDEnvValue('SITE');
+    const errors: string[] = [
+        ...validateMetadata(options.metadata),
+        ...validateAuth(options.auth?.site, envSite),
+    ];
 
     if (errors.length) {
         throw new Error(`Invalid Datadog plugin configuration:\n  - ${errors.join('\n  - ')}`);
     }
 
+    // DATADOG_SITE env var takes precedence over configuration.
+    // envSite is re-checked with isSite so TS narrows it from string to Sites.
+    const validatedEnvSite = envSite !== undefined && isSite(envSite) ? envSite : undefined;
     const auth: AuthOptionsWithDefaults = {
-        // DATADOG_SITE env var takes precedence over configuration
-        site: getDDEnvValue('SITE') || options.auth?.site || 'datadoghq.com',
+        site: validatedEnvSite ?? options.auth?.site ?? 'datadoghq.com',
     };
 
     // Prevent these from being accidentally logged.

--- a/packages/plugins/apps/src/index.test.ts
+++ b/packages/plugins/apps/src/index.test.ts
@@ -7,11 +7,11 @@ import * as assets from '@dd/apps-plugin/assets';
 import * as identifier from '@dd/apps-plugin/identifier';
 import * as uploader from '@dd/apps-plugin/upload';
 import { getPlugins } from '@dd/apps-plugin';
+import { DEFAULT_SITE } from '@dd/core/constants';
 import * as fsHelpers from '@dd/core/helpers/fs';
 import { InjectPosition } from '@dd/core/types';
 import type { PluginOptions } from '@dd/core/types';
 import {
-    DEFAULT_SITE,
     getGetPluginsArg,
     getMockBundler,
     getRepositoryDataMock,

--- a/packages/plugins/apps/src/index.test.ts
+++ b/packages/plugins/apps/src/index.test.ts
@@ -11,6 +11,7 @@ import * as fsHelpers from '@dd/core/helpers/fs';
 import { InjectPosition } from '@dd/core/types';
 import type { PluginOptions } from '@dd/core/types';
 import {
+    DEFAULT_SITE,
     getGetPluginsArg,
     getMockBundler,
     getRepositoryDataMock,
@@ -216,7 +217,7 @@ describe('Apps Plugin - getPlugins', () => {
                 dryRun: true,
                 identifier: 'repo:app',
                 name: 'test-app',
-                site: 'example.com',
+                site: DEFAULT_SITE,
                 version: 'FAKE_VERSION',
             },
             expect.anything(),
@@ -441,7 +442,7 @@ describe('Apps Plugin - getPlugins', () => {
     });
 
     test('Should upload assets with vite bundler', async () => {
-        const intakeHost = 'https://api.example.com';
+        const intakeHost = `https://api.${DEFAULT_SITE}`;
         const uploadScope = nock(intakeHost).post(`/${APPS_API_PATH}/app-id/upload`).reply(200, {
             version_id: 'v123',
             application_id: 'app123',

--- a/packages/plugins/apps/src/vite/dev-server.test.ts
+++ b/packages/plugins/apps/src/vite/dev-server.test.ts
@@ -3,6 +3,7 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import { createDevServerMiddleware } from '@dd/apps-plugin/vite/dev-server';
+import type { AuthOptionsWithDefaults } from '@dd/core/types';
 import { getMockLogger } from '@dd/tests/_jest/helpers/mocks';
 import { EventEmitter } from 'events';
 import type { IncomingMessage, ServerResponse } from 'http';
@@ -31,7 +32,7 @@ const mockFunctions: BackendFunction[] = [
     },
 ];
 
-const mockAuth = {
+const mockAuth: AuthOptionsWithDefaults = {
     apiKey: 'test-api-key',
     appKey: 'test-app-key',
     site: 'datadoghq.com',

--- a/packages/plugins/metrics/src/index.test.ts
+++ b/packages/plugins/metrics/src/index.test.ts
@@ -4,7 +4,7 @@
 
 import type { Options, Metric } from '@dd/core/types';
 import { getPlugins } from '@dd/metrics-plugin';
-import { FAKE_SITE, getGetPluginsArg, hardProjectEntries } from '@dd/tests/_jest/helpers/mocks';
+import { DEFAULT_SITE, getGetPluginsArg, hardProjectEntries } from '@dd/tests/_jest/helpers/mocks';
 import { BUNDLERS, runBundlers } from '@dd/tests/_jest/helpers/runBundlers';
 import type { Bundler } from '@dd/tests/_jest/helpers/types';
 import nock from 'nock';
@@ -29,7 +29,7 @@ const getPluginConfig = (
     store: Record<string, Metric[]> = {},
 ) => {
     const pluginConfig: Options = {
-        auth: { site: FAKE_SITE },
+        auth: { site: DEFAULT_SITE },
         metrics: {
             filters: [],
             ...overrides,
@@ -81,7 +81,7 @@ describe('Metrics Universal Plugin', () => {
     ];
 
     beforeAll(() => {
-        nock(new RegExp(`${FAKE_SITE.replace('.', '\\.')}`))
+        nock(new RegExp(`${DEFAULT_SITE.replace('.', '\\.')}`))
             .persist()
             // Intercept metrics submissions.
             .post(new RegExp(`${METRICS_API_PATH.replace('/', '\\/')}`))

--- a/packages/plugins/metrics/src/index.test.ts
+++ b/packages/plugins/metrics/src/index.test.ts
@@ -2,9 +2,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+import { DEFAULT_SITE } from '@dd/core/constants';
 import type { Options, Metric } from '@dd/core/types';
 import { getPlugins } from '@dd/metrics-plugin';
-import { DEFAULT_SITE, getGetPluginsArg, hardProjectEntries } from '@dd/tests/_jest/helpers/mocks';
+import { getGetPluginsArg, hardProjectEntries } from '@dd/tests/_jest/helpers/mocks';
 import { BUNDLERS, runBundlers } from '@dd/tests/_jest/helpers/runBundlers';
 import type { Bundler } from '@dd/tests/_jest/helpers/types';
 import nock from 'nock';

--- a/packages/tests/src/_jest/helpers/mocks.ts
+++ b/packages/tests/src/_jest/helpers/mocks.ts
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+import { DEFAULT_SITE } from '@dd/core/constants';
 import {
     checkFile,
     getFile,
@@ -25,7 +26,6 @@ import type {
     Options,
     OptionsWithDefaults,
     RepositoryData,
-    Sites,
     TimeLogger,
     TimingsReport,
 } from '@dd/core/types';
@@ -48,8 +48,6 @@ import type { PathLike, Stats } from 'fs';
 import path from 'path';
 
 import { getTempWorkingDir } from './env';
-
-export const DEFAULT_SITE: Sites = 'datadoghq.com';
 
 export const easyProjectEntry = './easy_project/main.js';
 export const easyProjectWithCSSEntry = './easy_project_with_css/main.js';

--- a/packages/tests/src/_jest/helpers/mocks.ts
+++ b/packages/tests/src/_jest/helpers/mocks.ts
@@ -13,6 +13,7 @@ import {
 import { getAbsolutePath } from '@dd/core/helpers/paths';
 import { getUniqueId } from '@dd/core/helpers/strings';
 import type {
+    AuthOptionsWithDefaults,
     BuildReport,
     FileReport,
     GetPluginsArg,
@@ -24,6 +25,7 @@ import type {
     Options,
     OptionsWithDefaults,
     RepositoryData,
+    Sites,
     TimeLogger,
     TimingsReport,
 } from '@dd/core/types';
@@ -47,7 +49,7 @@ import path from 'path';
 
 import { getTempWorkingDir } from './env';
 
-export const FAKE_SITE = 'example.com';
+export const DEFAULT_SITE: Sites = 'datadoghq.com';
 
 export const easyProjectEntry = './easy_project/main.js';
 export const easyProjectWithCSSEntry = './easy_project_with_css/main.js';
@@ -56,7 +58,11 @@ export const hardProjectEntries = {
     app2: './hard_project/main2.js',
 };
 
-export const defaultAuth = { apiKey: '123', appKey: '123', site: FAKE_SITE };
+export const defaultAuth: AuthOptionsWithDefaults = {
+    apiKey: '123',
+    appKey: '123',
+    site: DEFAULT_SITE,
+};
 export const defaultPluginOptions: OptionsWithDefaults = {
     auth: defaultAuth,
     enableGit: true,

--- a/packages/tools/src/commands/integrity/readme.ts
+++ b/packages/tools/src/commands/integrity/readme.ts
@@ -355,7 +355,7 @@ export const updateReadmes = async (plugins: Workspace[], bundlers: Workspace[])
                 auth?: {
                     apiKey?: string;
                     appKey?: string;
-                    site?: string;
+                    site?: Sites;
                 };
                 customPlugins?: (arg: GetPluginsArg) => UnpluginPlugin[];
                 enableGit?: boolean;

--- a/packages/tools/src/commands/integrity/readme.ts
+++ b/packages/tools/src/commands/integrity/readme.ts
@@ -355,7 +355,7 @@ export const updateReadmes = async (plugins: Workspace[], bundlers: Workspace[])
                 auth?: {
                     apiKey?: string;
                     appKey?: string;
-                    site?: Sites;
+                    site?: Site;
                 };
                 customPlugins?: (arg: GetPluginsArg) => UnpluginPlugin[];
                 enableGit?: boolean;

--- a/packages/tools/src/rollupConfig.test.ts
+++ b/packages/tools/src/rollupConfig.test.ts
@@ -19,7 +19,7 @@ import { METRICS_API_PATH } from '@dd/metrics-plugin/common/sender';
 import { BUNDLER_VERSIONS, KNOWN_ERRORS } from '@dd/tests/_jest/helpers/constants';
 import { getOutDir, prepareWorkingDir } from '@dd/tests/_jest/helpers/env';
 import {
-    FAKE_SITE,
+    DEFAULT_SITE,
     easyProjectEntry,
     getFullPluginConfig,
     hardProjectEntries,
@@ -180,12 +180,12 @@ describe('Bundling', () => {
 
         // Mock network requests.
         // For sourcemaps submissions.
-        nock(`https://${SOURCEMAPS_API_SUBDOMAIN}.${FAKE_SITE}`)
+        nock(`https://${SOURCEMAPS_API_SUBDOMAIN}.${DEFAULT_SITE}`)
             .persist()
             .post(`/${SOURCEMAPS_API_PATH}`)
             .reply(200, {});
         // For metrics submissions.
-        nock(`https://api.${FAKE_SITE}`)
+        nock(`https://api.${DEFAULT_SITE}`)
             .persist()
             .post(`/${METRICS_API_PATH}?api_key=123`)
             .reply(200, {});

--- a/packages/tools/src/rollupConfig.test.ts
+++ b/packages/tools/src/rollupConfig.test.ts
@@ -7,7 +7,7 @@ import { datadogRollupPlugin } from '@datadog/rollup-plugin';
 import { datadogRspackPlugin } from '@datadog/rspack-plugin';
 import { datadogVitePlugin } from '@datadog/vite-plugin';
 import { datadogWebpackPlugin } from '@datadog/webpack-plugin';
-import { SUPPORTED_BUNDLERS } from '@dd/core/constants';
+import { SUPPORTED_BUNDLERS, DEFAULT_SITE } from '@dd/core/constants';
 import { rm } from '@dd/core/helpers/fs';
 import { formatDuration, getUniqueId } from '@dd/core/helpers/strings';
 import type { BundlerName } from '@dd/core/types';
@@ -19,7 +19,6 @@ import { METRICS_API_PATH } from '@dd/metrics-plugin/common/sender';
 import { BUNDLER_VERSIONS, KNOWN_ERRORS } from '@dd/tests/_jest/helpers/constants';
 import { getOutDir, prepareWorkingDir } from '@dd/tests/_jest/helpers/env';
 import {
-    DEFAULT_SITE,
     easyProjectEntry,
     getFullPluginConfig,
     hardProjectEntries,


### PR DESCRIPTION
### What and why?

<!-- A short description of what changes this PR introduces and why. -->

Previously `AuthOptions.site` was string, which let typos flow silently into Datadog intake URLs.

It was also a major source of bugs as sometimes Datadog API endpoints would inadvertently be specified as e.g. `https://${auth.site}/api/etc/etc` without the `api` subdomain, causing 403s when the APIs are run.

### How?

<!-- A brief description of implementation details of this PR. -->

- Introduces a SITES runtime tuple in packages/core/src/constants.ts as the
  single source of truth (matches the existing ALL_ENVS / SUPPORTED_BUNDLERS
  pattern).
- Derives the Sites type from SITES so type and runtime stay in lockstep.
- Validates auth.site and DATADOG_SITE / DD_SITE in validateOptions and
  throws a clear error pointing at
  https://docs.datadoghq.com/getting_started/site/ when an unsupported value
  is provided.
- Renames the test helper FAKE_SITE -> DEFAULT_SITE (now a real Sites value)
  and types defaultAuth as AuthOptionsWithDefaults so test fixtures match
  the tightened contract.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>



