### PR TITLE
[APPS][Connections Part 11] Resolve static definitions through module graph

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,6 @@ Yarn provides "prefixed" scripts using the `<scope>:<action>` pattern. Scripts l
 ### Code Conventions
 
 - **No `any` or `as` casts**: Don't use `any` types or `as` type assertions as an escape hatch. Instead use patterns the repo already follows: import types directly from external packages (e.g. `import type { UserConfig } from 'vite'`), use `typeof`/`instanceof`/`in` guards for narrowing (see `wrapPlugins.ts`), derive types from constants with `(typeof MY_CONST)[number]`, or use constrained generics (`<T extends SomeType>`). If you think you need `any`, something is wrong.
-- **Named union members**: When defining a union of object-shaped types, give every union member its own explicit named type or interface, then compose the union from those names. Don't define object-shaped members inline inside the union declaration.
 - **No TypeScript suppression comments**: Don't use `@ts-ignore`, `@ts-expect-error`, or `@ts-nocheck` to suppress type errors. Fix the underlying type issue instead.
 - **No same-line comments**: Don't put comments on the same line as code. Put comments on the line above the code they describe so code and explanation stay visually separate.
 - **No inlined function-call arguments**: Don't pass a function call directly as an argument to another function call. Assign the inner call to a well-named local variable first, then pass that variable to the outer call.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ Yarn provides "prefixed" scripts using the `<scope>:<action>` pattern. Scripts l
 ### Code Conventions
 
 - **No `any` or `as` casts**: Don't use `any` types or `as` type assertions as an escape hatch. Instead use patterns the repo already follows: import types directly from external packages (e.g. `import type { UserConfig } from 'vite'`), use `typeof`/`instanceof`/`in` guards for narrowing (see `wrapPlugins.ts`), derive types from constants with `(typeof MY_CONST)[number]`, or use constrained generics (`<T extends SomeType>`). If you think you need `any`, something is wrong.
+- **Named union members**: When defining a union of object-shaped types, give every union member its own explicit named type or interface, then compose the union from those names. Don't define object-shaped members inline inside the union declaration.
 - **No TypeScript suppression comments**: Don't use `@ts-ignore`, `@ts-expect-error`, or `@ts-nocheck` to suppress type errors. Fix the underlying type issue instead.
 - **No same-line comments**: Don't put comments on the same line as code. Put comments on the line above the code they describe so code and explanation stay visually separate.
 - **No inlined function-call arguments**: Don't pass a function call directly as an argument to another function call. Assign the inner call to a well-named local variable first, then pass that variable to the outer call.

--- a/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.test.ts
@@ -73,6 +73,17 @@ function expectLocalDefinition(
     });
 }
 
+function expectUnsupportedDefinition(
+    result: StaticDefinition,
+    expected: Record<string, unknown>,
+): void {
+    expect(result).toMatchObject({
+        kind: 'unsupported',
+        message: expect.any(String),
+        ...expected,
+    });
+}
+
 describe('Backend Functions - static definition resolution', () => {
     test('Should resolve same-module identifier references to top-level static bindings', () => {
         const actions = createRecord(
@@ -314,13 +325,13 @@ describe('Backend Functions - static definition resolution', () => {
         );
         const modules = createModules([actions, index, one, two]);
 
-        expect(
-            resolveStaticDefinitionForIdentifier(
-                modules,
-                actions.id,
-                getReferenceIdentifier(actions, 'HTTP_ID'),
-            ),
-        ).toMatchObject({
+        const result = resolveStaticDefinitionForIdentifier(
+            modules,
+            actions.id,
+            getReferenceIdentifier(actions, 'HTTP_ID'),
+        );
+
+        expectUnsupportedDefinition(result, {
             kind: 'unsupported',
             moduleId: index.id,
             reason: 'ambiguous-star-export',
@@ -343,13 +354,13 @@ describe('Backend Functions - static definition resolution', () => {
         );
         const modules = createModules([actions, index, ids]);
 
-        expect(
-            resolveStaticDefinitionForIdentifier(
-                modules,
-                actions.id,
-                getReferenceIdentifier(actions, 'HTTP_ID'),
-            ),
-        ).toMatchObject({
+        const result = resolveStaticDefinitionForIdentifier(
+            modules,
+            actions.id,
+            getReferenceIdentifier(actions, 'HTTP_ID'),
+        );
+
+        expectUnsupportedDefinition(result, {
             kind: 'unsupported',
             moduleId: index.id,
             reason: 'missing-export',
@@ -373,16 +384,17 @@ describe('Backend Functions - static definition resolution', () => {
         );
         const modules = createModules([actions, index]);
 
-        expect(
-            resolveStaticDefinitionForIdentifier(
-                modules,
-                actions.id,
-                getReferenceIdentifier(actions, 'HTTP_ID'),
-            ),
-        ).toMatchObject({
+        const result = resolveStaticDefinitionForIdentifier(
+            modules,
+            actions.id,
+            getReferenceIdentifier(actions, 'HTTP_ID'),
+        );
+
+        expectUnsupportedDefinition(result, {
             kind: 'unsupported',
             moduleId: '/project/src/backend/ids.js',
             reason: 'missing-module-record',
+            requestKind: 'export',
             exportName: 'HTTP_ID',
         });
     });
@@ -404,13 +416,13 @@ describe('Backend Functions - static definition resolution', () => {
         );
         const modules = createModules([actions, one, two]);
 
-        expect(
-            resolveStaticDefinitionForIdentifier(
-                modules,
-                actions.id,
-                getReferenceIdentifier(actions, 'HTTP_ID'),
-            ),
-        ).toMatchObject({
+        const result = resolveStaticDefinitionForIdentifier(
+            modules,
+            actions.id,
+            getReferenceIdentifier(actions, 'HTTP_ID'),
+        );
+
+        expectUnsupportedDefinition(result, {
             kind: 'unsupported',
             moduleId: one.id,
             reason: 'cycle',
@@ -435,25 +447,25 @@ describe('Backend Functions - static definition resolution', () => {
         );
         const modules = createModules([actions, ids]);
 
-        expect(
-            resolveStaticDefinitionForIdentifier(
-                modules,
-                actions.id,
-                getReferenceIdentifier(actions, 'DEFAULT_ID'),
-            ),
-        ).toMatchObject({
+        const defaultImportResult = resolveStaticDefinitionForIdentifier(
+            modules,
+            actions.id,
+            getReferenceIdentifier(actions, 'DEFAULT_ID'),
+        );
+
+        expectUnsupportedDefinition(defaultImportResult, {
             kind: 'unsupported',
             moduleId: actions.id,
             reason: 'default-import',
             variableName: 'DEFAULT_ID',
         });
-        expect(
-            resolveStaticDefinitionForIdentifier(
-                modules,
-                actions.id,
-                getReferenceIdentifier(actions, 'namespaceIds'),
-            ),
-        ).toMatchObject({
+        const namespaceImportResult = resolveStaticDefinitionForIdentifier(
+            modules,
+            actions.id,
+            getReferenceIdentifier(actions, 'namespaceIds'),
+        );
+
+        expectUnsupportedDefinition(namespaceImportResult, {
             kind: 'unsupported',
             moduleId: actions.id,
             reason: 'namespace-import',
@@ -478,13 +490,13 @@ describe('Backend Functions - static definition resolution', () => {
         );
         const modules = createModules([actions, index, ids]);
 
-        expect(
-            resolveStaticDefinitionForIdentifier(
-                modules,
-                actions.id,
-                getReferenceIdentifier(actions, 'HTTP_ID'),
-            ),
-        ).toMatchObject({
+        const result = resolveStaticDefinitionForIdentifier(
+            modules,
+            actions.id,
+            getReferenceIdentifier(actions, 'HTTP_ID'),
+        );
+
+        expectUnsupportedDefinition(result, {
             kind: 'unsupported',
             moduleId: index.id,
             reason: 'default-export',
@@ -513,31 +525,31 @@ describe('Backend Functions - static definition resolution', () => {
         );
         const modules = createModules([actions, ids]);
 
-        expect(
-            resolveStaticDefinitionForIdentifier(
-                modules,
-                actions.id,
-                getReferenceIdentifier(actions, 'MUTABLE_ID'),
-            ),
-        ).toMatchObject({
+        const mutableResult = resolveStaticDefinitionForIdentifier(
+            modules,
+            actions.id,
+            getReferenceIdentifier(actions, 'MUTABLE_ID'),
+        );
+
+        expectUnsupportedDefinition(mutableResult, {
             kind: 'unsupported',
             moduleId: ids.id,
             reason: 'mutable-binding',
             variableName: 'MUTABLE_ID',
-            detail: 'let',
+            declarationKind: 'let',
         });
-        expect(
-            resolveStaticDefinitionForIdentifier(
-                modules,
-                actions.id,
-                getReferenceIdentifier(actions, 'getId'),
-            ),
-        ).toMatchObject({
+        const unsupportedBindingResult = resolveStaticDefinitionForIdentifier(
+            modules,
+            actions.id,
+            getReferenceIdentifier(actions, 'getId'),
+        );
+
+        expectUnsupportedDefinition(unsupportedBindingResult, {
             kind: 'unsupported',
             moduleId: ids.id,
             reason: 'unsupported-binding',
             variableName: 'getId',
-            detail: 'FunctionDeclaration binding',
+            bindingReason: 'FunctionDeclaration binding',
         });
     });
 
@@ -548,13 +560,13 @@ describe('Backend Functions - static definition resolution', () => {
         );
         const modules = createModules([actions]);
 
-        expect(
-            resolveStaticDefinitionForIdentifier(
-                modules,
-                actions.id,
-                getDeclarationIdentifier(actions, 'HTTP_ID'),
-            ),
-        ).toMatchObject({
+        const result = resolveStaticDefinitionForIdentifier(
+            modules,
+            actions.id,
+            getDeclarationIdentifier(actions, 'HTTP_ID'),
+        );
+
+        expectUnsupportedDefinition(result, {
             kind: 'unsupported',
             moduleId: actions.id,
             reason: 'unresolved-identifier',

--- a/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.test.ts
@@ -1,0 +1,341 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import type * as eslintScope from 'eslint-scope';
+import { parseAst } from 'rollup/parseAst';
+
+import { createParsedModuleRecord, type ParsedModuleRecord } from './module-graph';
+import {
+    resolveStaticDefinitionForExport,
+    resolveStaticDefinitionForVariable,
+    type StaticDefinition,
+} from './static-definition-resolution';
+
+const buildRoot = '/project';
+
+function createRecord(
+    id: string,
+    code: string,
+    staticDependencies: string[] = [],
+): ParsedModuleRecord {
+    const record = createParsedModuleRecord(id, buildRoot, parseAst(code), staticDependencies);
+
+    if (!record) {
+        throw new Error(`Expected module record to be created for ${id}`);
+    }
+    return record;
+}
+
+function createModules(records: ParsedModuleRecord[]): Map<string, ParsedModuleRecord> {
+    return new Map(records.map((record) => [record.id, record]));
+}
+
+function getModuleVariable(record: ParsedModuleRecord, name: string): eslintScope.Variable {
+    const variable = record.scopeAnalysis.moduleScope.set.get(name);
+    if (!variable) {
+        throw new Error(`Expected ${record.id} to declare ${name}`);
+    }
+    return variable;
+}
+
+function expectLocalDefinition(
+    result: StaticDefinition,
+    moduleId: string,
+    variableName: string,
+): void {
+    expect(result).toMatchObject({
+        kind: 'local',
+        moduleId,
+        variable: { name: variableName },
+        binding: { kind: 'const' },
+    });
+}
+
+describe('Backend Functions - static definition resolution', () => {
+    test('Should resolve named import variables through source module exports', () => {
+        const ids = createRecord(
+            '/project/src/backend/ids.js',
+            "export const HTTP_ID = 'conn-http';",
+        );
+        const actions = createRecord(
+            '/project/src/backend/actions.backend.js',
+            "import { HTTP_ID as ACTIVE_ID } from './ids.js';",
+            [ids.id],
+        );
+        const modules = createModules([actions, ids]);
+
+        const result = resolveStaticDefinitionForVariable(
+            modules,
+            actions.id,
+            getModuleVariable(actions, 'ACTIVE_ID'),
+        );
+
+        expectLocalDefinition(result, ids.id, 'HTTP_ID');
+        expect(result.hops).toMatchObject([
+            { kind: 'import', moduleId: actions.id, localName: 'ACTIVE_ID' },
+            { kind: 'local-export', moduleId: ids.id, exportName: 'HTTP_ID' },
+        ]);
+    });
+
+    test('Should resolve local export aliases to top-level static bindings', () => {
+        const ids = createRecord(
+            '/project/src/backend/ids.js',
+            `
+                const HTTP_ID = 'conn-http';
+                export { HTTP_ID as ACTIVE_HTTP_ID };
+            `,
+        );
+        const modules = createModules([ids]);
+
+        const result = resolveStaticDefinitionForExport(modules, ids.id, 'ACTIVE_HTTP_ID');
+
+        expectLocalDefinition(result, ids.id, 'HTTP_ID');
+        expect(result.hops).toMatchObject([
+            { kind: 'local-export', moduleId: ids.id, exportName: 'ACTIVE_HTTP_ID' },
+        ]);
+    });
+
+    test('Should resolve named re-export aliases', () => {
+        const ids = createRecord(
+            '/project/src/backend/ids.js',
+            "export const HTTP_ID = 'conn-http';",
+        );
+        const index = createRecord(
+            '/project/src/backend/index.js',
+            "export { HTTP_ID as ACTIVE_HTTP_ID } from './ids.js';",
+            [ids.id],
+        );
+        const modules = createModules([index, ids]);
+
+        const result = resolveStaticDefinitionForExport(modules, index.id, 'ACTIVE_HTTP_ID');
+
+        expectLocalDefinition(result, ids.id, 'HTTP_ID');
+        expect(result.hops).toMatchObject([
+            { kind: 're-export', moduleId: index.id, exportName: 'ACTIVE_HTTP_ID' },
+            { kind: 'local-export', moduleId: ids.id, exportName: 'HTTP_ID' },
+        ]);
+    });
+
+    test('Should resolve local import and export relays', () => {
+        const ids = createRecord(
+            '/project/src/backend/ids.js',
+            "export const HTTP_ID = 'conn-http';",
+        );
+        const relay = createRecord(
+            '/project/src/backend/relay.js',
+            `
+                import { HTTP_ID } from './ids.js';
+                export { HTTP_ID as ACTIVE_HTTP_ID };
+            `,
+            [ids.id],
+        );
+        const modules = createModules([relay, ids]);
+
+        const result = resolveStaticDefinitionForExport(modules, relay.id, 'ACTIVE_HTTP_ID');
+
+        expectLocalDefinition(result, ids.id, 'HTTP_ID');
+        expect(result.hops).toMatchObject([
+            { kind: 'local-export', moduleId: relay.id, exportName: 'ACTIVE_HTTP_ID' },
+            { kind: 'import', moduleId: relay.id, localName: 'HTTP_ID' },
+            { kind: 'local-export', moduleId: ids.id, exportName: 'HTTP_ID' },
+        ]);
+    });
+
+    test('Should resolve unambiguous star exports', () => {
+        const ids = createRecord(
+            '/project/src/backend/ids.js',
+            "export const HTTP_ID = 'conn-http';",
+        );
+        const index = createRecord('/project/src/backend/index.js', "export * from './ids.js';", [
+            ids.id,
+        ]);
+        const modules = createModules([index, ids]);
+
+        const result = resolveStaticDefinitionForExport(modules, index.id, 'HTTP_ID');
+
+        expectLocalDefinition(result, ids.id, 'HTTP_ID');
+        expect(result.hops).toMatchObject([
+            { kind: 'star-export', moduleId: index.id, exportName: 'HTTP_ID' },
+            { kind: 'local-export', moduleId: ids.id, exportName: 'HTTP_ID' },
+        ]);
+    });
+
+    test('Should prefer explicit exports over star exports', () => {
+        const remoteIds = createRecord(
+            '/project/src/backend/remote-ids.js',
+            "export const HTTP_ID = 'conn-remote';",
+        );
+        const index = createRecord(
+            '/project/src/backend/index.js',
+            `
+                export const HTTP_ID = 'conn-local';
+                export * from './remote-ids.js';
+            `,
+            [remoteIds.id],
+        );
+        const modules = createModules([index, remoteIds]);
+
+        const result = resolveStaticDefinitionForExport(modules, index.id, 'HTTP_ID');
+
+        expectLocalDefinition(result, index.id, 'HTTP_ID');
+        expect(result.hops).toMatchObject([
+            { kind: 'local-export', moduleId: index.id, exportName: 'HTTP_ID' },
+        ]);
+    });
+
+    test('Should return unsupported for ambiguous star exports', () => {
+        const one = createRecord('/project/src/backend/one.js', "export const HTTP_ID = 'one';");
+        const two = createRecord('/project/src/backend/two.js', "export const HTTP_ID = 'two';");
+        const index = createRecord(
+            '/project/src/backend/index.js',
+            `
+                export * from './one.js';
+                export * from './two.js';
+            `,
+            [one.id, two.id],
+        );
+        const modules = createModules([index, one, two]);
+
+        expect(resolveStaticDefinitionForExport(modules, index.id, 'HTTP_ID')).toMatchObject({
+            kind: 'unsupported',
+            moduleId: index.id,
+            reason: 'ambiguous-star-export',
+            exportName: 'HTTP_ID',
+        });
+    });
+
+    test('Should return unsupported for missing exports', () => {
+        const ids = createRecord('/project/src/backend/ids.js', "export const OTHER_ID = 'other';");
+        const index = createRecord('/project/src/backend/index.js', "export * from './ids.js';", [
+            ids.id,
+        ]);
+        const modules = createModules([index, ids]);
+
+        expect(resolveStaticDefinitionForExport(modules, index.id, 'HTTP_ID')).toMatchObject({
+            kind: 'unsupported',
+            moduleId: index.id,
+            reason: 'missing-export',
+            exportName: 'HTTP_ID',
+        });
+    });
+
+    test('Should return unsupported for missing module records', () => {
+        const index = createRecord(
+            '/project/src/backend/index.js',
+            "export { HTTP_ID } from './ids.js';",
+            ['/project/src/backend/ids.js'],
+        );
+        const modules = createModules([index]);
+
+        expect(resolveStaticDefinitionForExport(modules, index.id, 'HTTP_ID')).toMatchObject({
+            kind: 'unsupported',
+            moduleId: '/project/src/backend/ids.js',
+            reason: 'missing-module-record',
+            exportName: 'HTTP_ID',
+        });
+    });
+
+    test('Should return unsupported for import and export cycles', () => {
+        const one = createRecord('/project/src/backend/one.js', "export * from './two.js';", [
+            '/project/src/backend/two.js',
+        ]);
+        const two = createRecord('/project/src/backend/two.js', "export * from './one.js';", [
+            one.id,
+        ]);
+        const modules = createModules([one, two]);
+
+        expect(resolveStaticDefinitionForExport(modules, one.id, 'HTTP_ID')).toMatchObject({
+            kind: 'unsupported',
+            moduleId: one.id,
+            reason: 'cycle',
+            exportName: 'HTTP_ID',
+        });
+    });
+
+    test('Should return unsupported for default and namespace imports', () => {
+        const ids = createRecord(
+            '/project/src/backend/ids.js',
+            "export const HTTP_ID = 'conn-http';",
+        );
+        const actions = createRecord(
+            '/project/src/backend/actions.backend.js',
+            `
+                import DEFAULT_ID from './ids.js';
+                import * as namespaceIds from './ids.js';
+            `,
+            [ids.id],
+        );
+        const modules = createModules([actions, ids]);
+
+        expect(
+            resolveStaticDefinitionForVariable(
+                modules,
+                actions.id,
+                getModuleVariable(actions, 'DEFAULT_ID'),
+            ),
+        ).toMatchObject({
+            kind: 'unsupported',
+            moduleId: actions.id,
+            reason: 'default-import',
+            variableName: 'DEFAULT_ID',
+        });
+        expect(
+            resolveStaticDefinitionForVariable(
+                modules,
+                actions.id,
+                getModuleVariable(actions, 'namespaceIds'),
+            ),
+        ).toMatchObject({
+            kind: 'unsupported',
+            moduleId: actions.id,
+            reason: 'namespace-import',
+            variableName: 'namespaceIds',
+        });
+    });
+
+    test('Should return unsupported for default re-exports', () => {
+        const ids = createRecord('/project/src/backend/ids.js', "export default 'conn-http';");
+        const index = createRecord(
+            '/project/src/backend/index.js',
+            "export { default as HTTP_ID } from './ids.js';",
+            [ids.id],
+        );
+        const modules = createModules([index, ids]);
+
+        expect(resolveStaticDefinitionForExport(modules, index.id, 'HTTP_ID')).toMatchObject({
+            kind: 'unsupported',
+            moduleId: index.id,
+            reason: 'default-export',
+            exportName: 'HTTP_ID',
+        });
+    });
+
+    test('Should return unsupported for mutable and otherwise unsupported bindings', () => {
+        const ids = createRecord(
+            '/project/src/backend/ids.js',
+            `
+                export let MUTABLE_ID = 'conn-mutable';
+                export function getId() {
+                    return 'conn-function';
+                }
+            `,
+        );
+        const modules = createModules([ids]);
+
+        expect(resolveStaticDefinitionForExport(modules, ids.id, 'MUTABLE_ID')).toMatchObject({
+            kind: 'unsupported',
+            moduleId: ids.id,
+            reason: 'mutable-binding',
+            variableName: 'MUTABLE_ID',
+            detail: 'let',
+        });
+        expect(resolveStaticDefinitionForExport(modules, ids.id, 'getId')).toMatchObject({
+            kind: 'unsupported',
+            moduleId: ids.id,
+            reason: 'unsupported-binding',
+            variableName: 'getId',
+            detail: 'FunctionDeclaration binding',
+        });
+    });
+});

--- a/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.test.ts
@@ -2,13 +2,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import type * as eslintScope from 'eslint-scope';
+import type { Identifier } from 'estree';
 import { parseAst } from 'rollup/parseAst';
 
 import { createParsedModuleRecord, type ParsedModuleRecord } from './module-graph';
 import {
-    resolveStaticDefinitionForExport,
-    resolveStaticDefinitionForVariable,
+    resolveStaticDefinitionForIdentifier,
     type StaticDefinition,
 } from './static-definition-resolution';
 
@@ -31,12 +30,34 @@ function createModules(records: ParsedModuleRecord[]): Map<string, ParsedModuleR
     return new Map(records.map((record) => [record.id, record]));
 }
 
-function getModuleVariable(record: ParsedModuleRecord, name: string): eslintScope.Variable {
-    const variable = record.scopeAnalysis.moduleScope.set.get(name);
-    if (!variable) {
-        throw new Error(`Expected ${record.id} to declare ${name}`);
+function getReferenceIdentifier(record: ParsedModuleRecord, name: string): Identifier {
+    for (const [identifier, reference] of record.scopeAnalysis.referencesByIdentifier) {
+        const isDefinitionIdentifier = reference.resolved?.defs.some(
+            (definition) => definition.name === identifier,
+        );
+        if (identifier.name === name && !isDefinitionIdentifier) {
+            return identifier;
+        }
     }
-    return variable;
+
+    throw new Error(`Expected ${record.id} to reference ${name}`);
+}
+
+function getDeclarationIdentifier(record: ParsedModuleRecord, name: string): Identifier {
+    for (const node of record.ast.body) {
+        const declaration = node.type === 'ExportNamedDeclaration' ? node.declaration : node;
+        if (declaration?.type !== 'VariableDeclaration') {
+            continue;
+        }
+
+        for (const declarator of declaration.declarations) {
+            if (declarator.id.type === 'Identifier' && declarator.id.name === name) {
+                return declarator.id;
+            }
+        }
+    }
+
+    throw new Error(`Expected ${record.id} to declare ${name}`);
 }
 
 function expectLocalDefinition(
@@ -53,22 +74,45 @@ function expectLocalDefinition(
 }
 
 describe('Backend Functions - static definition resolution', () => {
-    test('Should resolve named import variables through source module exports', () => {
+    test('Should resolve same-module identifier references to top-level static bindings', () => {
+        const actions = createRecord(
+            '/project/src/backend/actions.backend.js',
+            `
+                const HTTP_ID = 'conn-http';
+                request({ connectionId: HTTP_ID });
+            `,
+        );
+        const modules = createModules([actions]);
+
+        const result = resolveStaticDefinitionForIdentifier(
+            modules,
+            actions.id,
+            getReferenceIdentifier(actions, 'HTTP_ID'),
+        );
+
+        expectLocalDefinition(result, actions.id, 'HTTP_ID');
+        expect(result.hops).toEqual([]);
+    });
+
+    test('Should resolve named import identifiers through source module exports', () => {
         const ids = createRecord(
             '/project/src/backend/ids.js',
             "export const HTTP_ID = 'conn-http';",
         );
         const actions = createRecord(
             '/project/src/backend/actions.backend.js',
-            "import { HTTP_ID as ACTIVE_ID } from './ids.js';",
+            `
+                import { HTTP_ID as ACTIVE_ID } from './ids.js';
+                request({ connectionId: ACTIVE_ID });
+            `,
             [ids.id],
         );
         const modules = createModules([actions, ids]);
 
-        const result = resolveStaticDefinitionForVariable(
+        const result = resolveStaticDefinitionForIdentifier(
             modules,
             actions.id,
-            getModuleVariable(actions, 'ACTIVE_ID'),
+            getReferenceIdentifier(actions, 'ACTIVE_ID'),
         );
 
         expectLocalDefinition(result, ids.id, 'HTTP_ID');
@@ -86,12 +130,25 @@ describe('Backend Functions - static definition resolution', () => {
                 export { HTTP_ID as ACTIVE_HTTP_ID };
             `,
         );
-        const modules = createModules([ids]);
+        const actions = createRecord(
+            '/project/src/backend/actions.backend.js',
+            `
+                import { ACTIVE_HTTP_ID } from './ids.js';
+                request({ connectionId: ACTIVE_HTTP_ID });
+            `,
+            [ids.id],
+        );
+        const modules = createModules([actions, ids]);
 
-        const result = resolveStaticDefinitionForExport(modules, ids.id, 'ACTIVE_HTTP_ID');
+        const result = resolveStaticDefinitionForIdentifier(
+            modules,
+            actions.id,
+            getReferenceIdentifier(actions, 'ACTIVE_HTTP_ID'),
+        );
 
         expectLocalDefinition(result, ids.id, 'HTTP_ID');
         expect(result.hops).toMatchObject([
+            { kind: 'import', moduleId: actions.id, localName: 'ACTIVE_HTTP_ID' },
             { kind: 'local-export', moduleId: ids.id, exportName: 'ACTIVE_HTTP_ID' },
         ]);
     });
@@ -106,12 +163,25 @@ describe('Backend Functions - static definition resolution', () => {
             "export { HTTP_ID as ACTIVE_HTTP_ID } from './ids.js';",
             [ids.id],
         );
-        const modules = createModules([index, ids]);
+        const actions = createRecord(
+            '/project/src/backend/actions.backend.js',
+            `
+                import { ACTIVE_HTTP_ID } from './index.js';
+                request({ connectionId: ACTIVE_HTTP_ID });
+            `,
+            [index.id],
+        );
+        const modules = createModules([actions, index, ids]);
 
-        const result = resolveStaticDefinitionForExport(modules, index.id, 'ACTIVE_HTTP_ID');
+        const result = resolveStaticDefinitionForIdentifier(
+            modules,
+            actions.id,
+            getReferenceIdentifier(actions, 'ACTIVE_HTTP_ID'),
+        );
 
         expectLocalDefinition(result, ids.id, 'HTTP_ID');
         expect(result.hops).toMatchObject([
+            { kind: 'import', moduleId: actions.id, localName: 'ACTIVE_HTTP_ID' },
             { kind: 're-export', moduleId: index.id, exportName: 'ACTIVE_HTTP_ID' },
             { kind: 'local-export', moduleId: ids.id, exportName: 'HTTP_ID' },
         ]);
@@ -130,12 +200,25 @@ describe('Backend Functions - static definition resolution', () => {
             `,
             [ids.id],
         );
-        const modules = createModules([relay, ids]);
+        const actions = createRecord(
+            '/project/src/backend/actions.backend.js',
+            `
+                import { ACTIVE_HTTP_ID } from './relay.js';
+                request({ connectionId: ACTIVE_HTTP_ID });
+            `,
+            [relay.id],
+        );
+        const modules = createModules([actions, relay, ids]);
 
-        const result = resolveStaticDefinitionForExport(modules, relay.id, 'ACTIVE_HTTP_ID');
+        const result = resolveStaticDefinitionForIdentifier(
+            modules,
+            actions.id,
+            getReferenceIdentifier(actions, 'ACTIVE_HTTP_ID'),
+        );
 
         expectLocalDefinition(result, ids.id, 'HTTP_ID');
         expect(result.hops).toMatchObject([
+            { kind: 'import', moduleId: actions.id, localName: 'ACTIVE_HTTP_ID' },
             { kind: 'local-export', moduleId: relay.id, exportName: 'ACTIVE_HTTP_ID' },
             { kind: 'import', moduleId: relay.id, localName: 'HTTP_ID' },
             { kind: 'local-export', moduleId: ids.id, exportName: 'HTTP_ID' },
@@ -150,12 +233,25 @@ describe('Backend Functions - static definition resolution', () => {
         const index = createRecord('/project/src/backend/index.js', "export * from './ids.js';", [
             ids.id,
         ]);
-        const modules = createModules([index, ids]);
+        const actions = createRecord(
+            '/project/src/backend/actions.backend.js',
+            `
+                import { HTTP_ID } from './index.js';
+                request({ connectionId: HTTP_ID });
+            `,
+            [index.id],
+        );
+        const modules = createModules([actions, index, ids]);
 
-        const result = resolveStaticDefinitionForExport(modules, index.id, 'HTTP_ID');
+        const result = resolveStaticDefinitionForIdentifier(
+            modules,
+            actions.id,
+            getReferenceIdentifier(actions, 'HTTP_ID'),
+        );
 
         expectLocalDefinition(result, ids.id, 'HTTP_ID');
         expect(result.hops).toMatchObject([
+            { kind: 'import', moduleId: actions.id, localName: 'HTTP_ID' },
             { kind: 'star-export', moduleId: index.id, exportName: 'HTTP_ID' },
             { kind: 'local-export', moduleId: ids.id, exportName: 'HTTP_ID' },
         ]);
@@ -174,12 +270,25 @@ describe('Backend Functions - static definition resolution', () => {
             `,
             [remoteIds.id],
         );
-        const modules = createModules([index, remoteIds]);
+        const actions = createRecord(
+            '/project/src/backend/actions.backend.js',
+            `
+                import { HTTP_ID } from './index.js';
+                request({ connectionId: HTTP_ID });
+            `,
+            [index.id],
+        );
+        const modules = createModules([actions, index, remoteIds]);
 
-        const result = resolveStaticDefinitionForExport(modules, index.id, 'HTTP_ID');
+        const result = resolveStaticDefinitionForIdentifier(
+            modules,
+            actions.id,
+            getReferenceIdentifier(actions, 'HTTP_ID'),
+        );
 
         expectLocalDefinition(result, index.id, 'HTTP_ID');
         expect(result.hops).toMatchObject([
+            { kind: 'import', moduleId: actions.id, localName: 'HTTP_ID' },
             { kind: 'local-export', moduleId: index.id, exportName: 'HTTP_ID' },
         ]);
     });
@@ -195,9 +304,23 @@ describe('Backend Functions - static definition resolution', () => {
             `,
             [one.id, two.id],
         );
-        const modules = createModules([index, one, two]);
+        const actions = createRecord(
+            '/project/src/backend/actions.backend.js',
+            `
+                import { HTTP_ID } from './index.js';
+                request({ connectionId: HTTP_ID });
+            `,
+            [index.id],
+        );
+        const modules = createModules([actions, index, one, two]);
 
-        expect(resolveStaticDefinitionForExport(modules, index.id, 'HTTP_ID')).toMatchObject({
+        expect(
+            resolveStaticDefinitionForIdentifier(
+                modules,
+                actions.id,
+                getReferenceIdentifier(actions, 'HTTP_ID'),
+            ),
+        ).toMatchObject({
             kind: 'unsupported',
             moduleId: index.id,
             reason: 'ambiguous-star-export',
@@ -210,9 +333,23 @@ describe('Backend Functions - static definition resolution', () => {
         const index = createRecord('/project/src/backend/index.js', "export * from './ids.js';", [
             ids.id,
         ]);
-        const modules = createModules([index, ids]);
+        const actions = createRecord(
+            '/project/src/backend/actions.backend.js',
+            `
+                import { HTTP_ID } from './index.js';
+                request({ connectionId: HTTP_ID });
+            `,
+            [index.id],
+        );
+        const modules = createModules([actions, index, ids]);
 
-        expect(resolveStaticDefinitionForExport(modules, index.id, 'HTTP_ID')).toMatchObject({
+        expect(
+            resolveStaticDefinitionForIdentifier(
+                modules,
+                actions.id,
+                getReferenceIdentifier(actions, 'HTTP_ID'),
+            ),
+        ).toMatchObject({
             kind: 'unsupported',
             moduleId: index.id,
             reason: 'missing-export',
@@ -226,9 +363,23 @@ describe('Backend Functions - static definition resolution', () => {
             "export { HTTP_ID } from './ids.js';",
             ['/project/src/backend/ids.js'],
         );
-        const modules = createModules([index]);
+        const actions = createRecord(
+            '/project/src/backend/actions.backend.js',
+            `
+                import { HTTP_ID } from './index.js';
+                request({ connectionId: HTTP_ID });
+            `,
+            [index.id],
+        );
+        const modules = createModules([actions, index]);
 
-        expect(resolveStaticDefinitionForExport(modules, index.id, 'HTTP_ID')).toMatchObject({
+        expect(
+            resolveStaticDefinitionForIdentifier(
+                modules,
+                actions.id,
+                getReferenceIdentifier(actions, 'HTTP_ID'),
+            ),
+        ).toMatchObject({
             kind: 'unsupported',
             moduleId: '/project/src/backend/ids.js',
             reason: 'missing-module-record',
@@ -243,9 +394,23 @@ describe('Backend Functions - static definition resolution', () => {
         const two = createRecord('/project/src/backend/two.js', "export * from './one.js';", [
             one.id,
         ]);
-        const modules = createModules([one, two]);
+        const actions = createRecord(
+            '/project/src/backend/actions.backend.js',
+            `
+                import { HTTP_ID } from './one.js';
+                request({ connectionId: HTTP_ID });
+            `,
+            [one.id],
+        );
+        const modules = createModules([actions, one, two]);
 
-        expect(resolveStaticDefinitionForExport(modules, one.id, 'HTTP_ID')).toMatchObject({
+        expect(
+            resolveStaticDefinitionForIdentifier(
+                modules,
+                actions.id,
+                getReferenceIdentifier(actions, 'HTTP_ID'),
+            ),
+        ).toMatchObject({
             kind: 'unsupported',
             moduleId: one.id,
             reason: 'cycle',
@@ -263,16 +428,18 @@ describe('Backend Functions - static definition resolution', () => {
             `
                 import DEFAULT_ID from './ids.js';
                 import * as namespaceIds from './ids.js';
+                request({ connectionId: DEFAULT_ID });
+                request({ connectionId: namespaceIds.HTTP_ID });
             `,
             [ids.id],
         );
         const modules = createModules([actions, ids]);
 
         expect(
-            resolveStaticDefinitionForVariable(
+            resolveStaticDefinitionForIdentifier(
                 modules,
                 actions.id,
-                getModuleVariable(actions, 'DEFAULT_ID'),
+                getReferenceIdentifier(actions, 'DEFAULT_ID'),
             ),
         ).toMatchObject({
             kind: 'unsupported',
@@ -281,10 +448,10 @@ describe('Backend Functions - static definition resolution', () => {
             variableName: 'DEFAULT_ID',
         });
         expect(
-            resolveStaticDefinitionForVariable(
+            resolveStaticDefinitionForIdentifier(
                 modules,
                 actions.id,
-                getModuleVariable(actions, 'namespaceIds'),
+                getReferenceIdentifier(actions, 'namespaceIds'),
             ),
         ).toMatchObject({
             kind: 'unsupported',
@@ -301,9 +468,23 @@ describe('Backend Functions - static definition resolution', () => {
             "export { default as HTTP_ID } from './ids.js';",
             [ids.id],
         );
-        const modules = createModules([index, ids]);
+        const actions = createRecord(
+            '/project/src/backend/actions.backend.js',
+            `
+                import { HTTP_ID } from './index.js';
+                request({ connectionId: HTTP_ID });
+            `,
+            [index.id],
+        );
+        const modules = createModules([actions, index, ids]);
 
-        expect(resolveStaticDefinitionForExport(modules, index.id, 'HTTP_ID')).toMatchObject({
+        expect(
+            resolveStaticDefinitionForIdentifier(
+                modules,
+                actions.id,
+                getReferenceIdentifier(actions, 'HTTP_ID'),
+            ),
+        ).toMatchObject({
             kind: 'unsupported',
             moduleId: index.id,
             reason: 'default-export',
@@ -321,21 +502,63 @@ describe('Backend Functions - static definition resolution', () => {
                 }
             `,
         );
-        const modules = createModules([ids]);
+        const actions = createRecord(
+            '/project/src/backend/actions.backend.js',
+            `
+                import { MUTABLE_ID, getId } from './ids.js';
+                request({ connectionId: MUTABLE_ID });
+                request({ connectionId: getId });
+            `,
+            [ids.id],
+        );
+        const modules = createModules([actions, ids]);
 
-        expect(resolveStaticDefinitionForExport(modules, ids.id, 'MUTABLE_ID')).toMatchObject({
+        expect(
+            resolveStaticDefinitionForIdentifier(
+                modules,
+                actions.id,
+                getReferenceIdentifier(actions, 'MUTABLE_ID'),
+            ),
+        ).toMatchObject({
             kind: 'unsupported',
             moduleId: ids.id,
             reason: 'mutable-binding',
             variableName: 'MUTABLE_ID',
             detail: 'let',
         });
-        expect(resolveStaticDefinitionForExport(modules, ids.id, 'getId')).toMatchObject({
+        expect(
+            resolveStaticDefinitionForIdentifier(
+                modules,
+                actions.id,
+                getReferenceIdentifier(actions, 'getId'),
+            ),
+        ).toMatchObject({
             kind: 'unsupported',
             moduleId: ids.id,
             reason: 'unsupported-binding',
             variableName: 'getId',
             detail: 'FunctionDeclaration binding',
+        });
+    });
+
+    test('Should return unsupported for identifiers that are not references', () => {
+        const actions = createRecord(
+            '/project/src/backend/actions.backend.js',
+            "const HTTP_ID = 'conn-http';",
+        );
+        const modules = createModules([actions]);
+
+        expect(
+            resolveStaticDefinitionForIdentifier(
+                modules,
+                actions.id,
+                getDeclarationIdentifier(actions, 'HTTP_ID'),
+            ),
+        ).toMatchObject({
+            kind: 'unsupported',
+            moduleId: actions.id,
+            reason: 'unresolved-identifier',
+            variableName: 'HTTP_ID',
         });
     });
 });

--- a/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.test.ts
@@ -268,6 +268,46 @@ describe('Backend Functions - static definition resolution', () => {
         ]);
     });
 
+    test('Should ignore duplicate star export paths to the same binding', () => {
+        const ids = createRecord(
+            '/project/src/backend/ids.js',
+            "export const HTTP_ID = 'conn-http';",
+        );
+        const nested = createRecord('/project/src/backend/nested.js', "export * from './ids.js';", [
+            ids.id,
+        ]);
+        const index = createRecord(
+            '/project/src/backend/index.js',
+            `
+                export * from './ids.js';
+                export * from './nested.js';
+            `,
+            [ids.id, nested.id],
+        );
+        const actions = createRecord(
+            '/project/src/backend/actions.backend.js',
+            `
+                import { HTTP_ID } from './index.js';
+                request({ connectionId: HTTP_ID });
+            `,
+            [index.id],
+        );
+        const modules = createModules([actions, index, nested, ids]);
+
+        const result = resolveStaticDefinitionForIdentifier(
+            modules,
+            actions.id,
+            getReferenceIdentifier(actions, 'HTTP_ID'),
+        );
+
+        expectLocalDefinition(result, ids.id, 'HTTP_ID');
+        expect(result.hops).toMatchObject([
+            { kind: 'import', moduleId: actions.id, localName: 'HTTP_ID' },
+            { kind: 'star-export', moduleId: index.id, exportName: 'HTTP_ID' },
+            { kind: 'local-export', moduleId: ids.id, exportName: 'HTTP_ID' },
+        ]);
+    });
+
     test('Should prefer explicit exports over star exports', () => {
         const remoteIds = createRecord(
             '/project/src/backend/remote-ids.js',

--- a/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.test.ts
@@ -308,7 +308,7 @@ describe('Backend Functions - static definition resolution', () => {
         ]);
     });
 
-    test('Should prefer explicit exports over star exports', () => {
+    test('Should resolve explicit exports before checking star exports', () => {
         const remoteIds = createRecord(
             '/project/src/backend/remote-ids.js',
             "export const HTTP_ID = 'conn-remote';",

--- a/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.ts
@@ -168,15 +168,15 @@ export function resolveStaticDefinitionForIdentifier(
 ): StaticDefinition {
     const record = modules.get(moduleId);
     if (!record) {
-        return missingModuleRecordForVariable(moduleId, [], identifier.name);
+        return unsupportedMissingModuleRecordForVariable(moduleId, [], identifier.name);
     }
 
     const variable = resolveIdentifier(identifier, record.scopeAnalysis);
     if (!variable) {
-        return unresolvedIdentifier(moduleId, [], identifier.name);
+        return unsupportedUnresolvedIdentifier(moduleId, [], identifier.name);
     }
     if (isDefinitionIdentifier(identifier, variable)) {
-        return unresolvedIdentifier(moduleId, [], identifier.name);
+        return unsupportedUnresolvedIdentifier(moduleId, [], identifier.name);
     }
 
     return resolveVariable({ modules, visitedExports: new Set() }, moduleId, variable, []);
@@ -194,16 +194,16 @@ function resolveExport(
 ): StaticDefinition {
     const record = state.modules.get(moduleId);
     if (!record) {
-        return missingModuleRecordForExport(moduleId, hops, exportName);
+        return unsupportedMissingModuleRecordForExport(moduleId, hops, exportName);
     }
 
     if (exportName === 'default') {
-        return defaultExport(moduleId, hops, exportName);
+        return unsupportedDefaultExport(moduleId, hops, exportName);
     }
 
     const visitKey = `${moduleId}\0${exportName}`;
     if (state.visitedExports.has(visitKey)) {
-        return cycle(moduleId, hops, exportName);
+        return unsupportedCycle(moduleId, hops, exportName);
     }
 
     state.visitedExports.add(visitKey);
@@ -232,7 +232,7 @@ function resolveExplicitExport(
 
     if (binding.kind === 're-export') {
         if (binding.importedName === 'default') {
-            return defaultExport(record.id, hops, exportName);
+            return unsupportedDefaultExport(record.id, hops, exportName);
         }
 
         return resolveExport(state, binding.resolvedId, binding.importedName, [
@@ -286,12 +286,12 @@ function resolveStarExport(
         }
 
         if (candidate) {
-            return ambiguousStarExport(record.id, hops, exportName);
+            return unsupportedAmbiguousStarExport(record.id, hops, exportName);
         }
         candidate = result;
     }
 
-    return candidate ?? missingExport(record.id, hops, exportName);
+    return candidate ?? unsupportedMissingExport(record.id, hops, exportName);
 }
 
 function resolveVariable(
@@ -302,7 +302,7 @@ function resolveVariable(
 ): StaticDefinition {
     const record = state.modules.get(moduleId);
     if (!record) {
-        return missingModuleRecordForVariable(moduleId, hops, variable.name);
+        return unsupportedMissingModuleRecordForVariable(moduleId, hops, variable.name);
     }
 
     const importBinding = record.importsByVariable.get(variable);
@@ -312,7 +312,7 @@ function resolveVariable(
 
     const binding = record.topLevelBindingsByVariable.get(variable);
     if (!binding) {
-        return missingStaticBinding(record.id, hops, variable.name);
+        return unsupportedMissingStaticBinding(record.id, hops, variable.name);
     }
 
     if (binding.kind === 'const') {
@@ -320,7 +320,7 @@ function resolveVariable(
     }
 
     if (binding.kind === 'mutable') {
-        return mutableBinding(record.id, hops, variable.name, binding.declarationKind);
+        return unsupportedMutableBinding(record.id, hops, variable.name, binding.declarationKind);
     }
 
     return unsupportedBinding(record.id, hops, variable.name, binding.reason);
@@ -334,15 +334,15 @@ function resolveImportBinding(
     hops: StaticDefinitionHop[],
 ): StaticDefinition {
     if (binding.kind === 'default') {
-        return defaultImport(moduleId, hops, localName);
+        return unsupportedDefaultImport(moduleId, hops, localName);
     }
 
     if (binding.kind === 'namespace') {
-        return namespaceImport(moduleId, hops, localName);
+        return unsupportedNamespaceImport(moduleId, hops, localName);
     }
 
     if (binding.importedName === 'default') {
-        return defaultImport(moduleId, hops, localName);
+        return unsupportedDefaultImport(moduleId, hops, localName);
     }
 
     return resolveExport(state, binding.resolvedId, binding.importedName, [
@@ -357,7 +357,7 @@ function resolveImportBinding(
     ]);
 }
 
-function ambiguousStarExport(
+function unsupportedAmbiguousStarExport(
     moduleId: string,
     hops: StaticDefinitionHop[],
     exportName: string,
@@ -372,7 +372,7 @@ function ambiguousStarExport(
     };
 }
 
-function cycle(
+function unsupportedCycle(
     moduleId: string,
     hops: StaticDefinitionHop[],
     exportName: string,
@@ -387,7 +387,7 @@ function cycle(
     };
 }
 
-function defaultExport(
+function unsupportedDefaultExport(
     moduleId: string,
     hops: StaticDefinitionHop[],
     exportName: string,
@@ -402,7 +402,7 @@ function defaultExport(
     };
 }
 
-function defaultImport(
+function unsupportedDefaultImport(
     moduleId: string,
     hops: StaticDefinitionHop[],
     variableName: string,
@@ -417,7 +417,7 @@ function defaultImport(
     };
 }
 
-function missingExport(
+function unsupportedMissingExport(
     moduleId: string,
     hops: StaticDefinitionHop[],
     exportName: string,
@@ -432,7 +432,7 @@ function missingExport(
     };
 }
 
-function missingModuleRecordForExport(
+function unsupportedMissingModuleRecordForExport(
     moduleId: string,
     hops: StaticDefinitionHop[],
     exportName: string,
@@ -448,7 +448,7 @@ function missingModuleRecordForExport(
     };
 }
 
-function missingModuleRecordForVariable(
+function unsupportedMissingModuleRecordForVariable(
     moduleId: string,
     hops: StaticDefinitionHop[],
     variableName: string,
@@ -464,7 +464,7 @@ function missingModuleRecordForVariable(
     };
 }
 
-function missingStaticBinding(
+function unsupportedMissingStaticBinding(
     moduleId: string,
     hops: StaticDefinitionHop[],
     variableName: string,
@@ -479,7 +479,7 @@ function missingStaticBinding(
     };
 }
 
-function mutableBinding(
+function unsupportedMutableBinding(
     moduleId: string,
     hops: StaticDefinitionHop[],
     variableName: string,
@@ -496,7 +496,7 @@ function mutableBinding(
     };
 }
 
-function namespaceImport(
+function unsupportedNamespaceImport(
     moduleId: string,
     hops: StaticDefinitionHop[],
     variableName: string,
@@ -511,7 +511,7 @@ function namespaceImport(
     };
 }
 
-function unresolvedIdentifier(
+function unsupportedUnresolvedIdentifier(
     moduleId: string,
     hops: StaticDefinitionHop[],
     variableName: string,

--- a/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.ts
@@ -291,6 +291,10 @@ function resolveStarExport(
             return result;
         }
 
+        if (candidate && isSameLocalDefinition(candidate, result)) {
+            continue;
+        }
+
         if (candidate) {
             // Example: export * from './one.js'; export * from './two.js';
             return unsupportedAmbiguousStarExport(record.id, hops, exportName);
@@ -300,6 +304,10 @@ function resolveStarExport(
 
     // Example: export * from './ids.js'; when ids.js does not export HTTP_ID.
     return candidate ?? unsupportedMissingExport(record.id, hops, exportName);
+}
+
+function isSameLocalDefinition(left: LocalStaticDefinition, right: LocalStaticDefinition): boolean {
+    return left.moduleId === right.moduleId && left.variable === right.variable;
 }
 
 function resolveVariable(

--- a/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.ts
@@ -173,9 +173,11 @@ export function resolveStaticDefinitionForIdentifier(
 
     const variable = resolveIdentifier(identifier, record.scopeAnalysis);
     if (!variable) {
+        // Example: request({ connectionId: HTTP_ID }); when HTTP_ID is not in scope.
         return unsupportedUnresolvedIdentifier(moduleId, [], identifier.name);
     }
     if (isDefinitionIdentifier(identifier, variable)) {
+        // Example: const HTTP_ID = 'conn-http'; when HTTP_ID is the declaration itself.
         return unsupportedUnresolvedIdentifier(moduleId, [], identifier.name);
     }
 
@@ -198,11 +200,13 @@ function resolveExport(
     }
 
     if (exportName === 'default') {
+        // Example: export { default as HTTP_ID } from './ids.js';
         return unsupportedDefaultExport(moduleId, hops, exportName);
     }
 
     const visitKey = `${moduleId}\0${exportName}`;
     if (state.visitedExports.has(visitKey)) {
+        // Example: export * from './index.js'; when index.js eventually points back here.
         return unsupportedCycle(moduleId, hops, exportName);
     }
 
@@ -227,11 +231,13 @@ function resolveExplicitExport(
     hops: StaticDefinitionHop[],
 ): StaticDefinition {
     if (binding.kind === 'unsupported') {
+        // Example: export * as ids from './ids.js';
         return unsupportedExport(record.id, hops, exportName, binding.reason);
     }
 
     if (binding.kind === 're-export') {
         if (binding.importedName === 'default') {
+            // Example: export { default as HTTP_ID } from './ids.js';
             return unsupportedDefaultExport(record.id, hops, exportName);
         }
 
@@ -286,11 +292,13 @@ function resolveStarExport(
         }
 
         if (candidate) {
+            // Example: export * from './one.js'; export * from './two.js';
             return unsupportedAmbiguousStarExport(record.id, hops, exportName);
         }
         candidate = result;
     }
 
+    // Example: export * from './ids.js'; when ids.js does not export HTTP_ID.
     return candidate ?? unsupportedMissingExport(record.id, hops, exportName);
 }
 
@@ -320,9 +328,11 @@ function resolveVariable(
     }
 
     if (binding.kind === 'mutable') {
+        // Example: export let HTTP_ID = 'conn-http';
         return unsupportedMutableBinding(record.id, hops, variable.name, binding.declarationKind);
     }
 
+    // Example: export function getId() { return 'conn-http'; }
     return unsupportedBinding(record.id, hops, variable.name, binding.reason);
 }
 
@@ -334,14 +344,17 @@ function resolveImportBinding(
     hops: StaticDefinitionHop[],
 ): StaticDefinition {
     if (binding.kind === 'default') {
+        // Example: import HTTP_ID from './ids.js';
         return unsupportedDefaultImport(moduleId, hops, localName);
     }
 
     if (binding.kind === 'namespace') {
+        // Example: import * as ids from './ids.js';
         return unsupportedNamespaceImport(moduleId, hops, localName);
     }
 
     if (binding.importedName === 'default') {
+        // Example: import { default as HTTP_ID } from './ids.js';
         return unsupportedDefaultImport(moduleId, hops, localName);
     }
 

--- a/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.ts
@@ -310,6 +310,7 @@ function resolveVariable(
 ): StaticDefinition {
     const record = state.modules.get(moduleId);
     if (!record) {
+        // Example: resolving HTTP_ID after following an import to a module that was not collected.
         return unsupportedMissingModuleRecordForVariable(moduleId, hops, variable.name);
     }
 
@@ -320,6 +321,7 @@ function resolveVariable(
 
     const binding = record.topLevelBindingsByVariable.get(variable);
     if (!binding) {
+        // Example: export { HTTP_ID }; when HTTP_ID is not a recorded top-level binding.
         return unsupportedMissingStaticBinding(record.id, hops, variable.name);
     }
 

--- a/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.ts
@@ -1,0 +1,297 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import type * as eslintScope from 'eslint-scope';
+
+import type {
+    ConstStaticBinding,
+    ExportBinding,
+    ImportBinding,
+    ParsedModuleRecord,
+} from './module-graph';
+
+export type StaticDefinitionUnsupportedReason =
+    | 'ambiguous-star-export'
+    | 'cycle'
+    | 'default-export'
+    | 'default-import'
+    | 'missing-export'
+    | 'missing-module-record'
+    | 'missing-static-binding'
+    | 'mutable-binding'
+    | 'namespace-import'
+    | 'unsupported-binding'
+    | 'unsupported-export';
+
+export type StaticDefinition = LocalStaticDefinition | UnsupportedStaticDefinition;
+
+export interface LocalStaticDefinition {
+    kind: 'local';
+    moduleId: string;
+    variable: eslintScope.Variable;
+    binding: ConstStaticBinding;
+    hops: StaticDefinitionHop[];
+}
+
+export interface UnsupportedStaticDefinition {
+    kind: 'unsupported';
+    moduleId: string;
+    reason: StaticDefinitionUnsupportedReason;
+    exportName?: string;
+    variableName?: string;
+    detail?: string;
+    hops: StaticDefinitionHop[];
+}
+
+export type StaticDefinitionHop =
+    | {
+          kind: 'import';
+          moduleId: string;
+          localName: string;
+          exportName: string;
+          sourceModuleId: string;
+      }
+    | {
+          kind: 'local-export';
+          moduleId: string;
+          exportName: string;
+          localName: string;
+      }
+    | {
+          kind: 're-export';
+          moduleId: string;
+          exportName: string;
+          sourceModuleId: string;
+          sourceExportName: string;
+      }
+    | {
+          kind: 'star-export';
+          moduleId: string;
+          exportName: string;
+          sourceModuleId: string;
+      };
+
+interface ResolverState {
+    modules: ReadonlyMap<string, ParsedModuleRecord>;
+    visitedExports: Set<string>;
+}
+
+export function resolveStaticDefinitionForExport(
+    modules: ReadonlyMap<string, ParsedModuleRecord>,
+    moduleId: string,
+    exportName: string,
+): StaticDefinition {
+    return resolveExport({ modules, visitedExports: new Set() }, moduleId, exportName, []);
+}
+
+export function resolveStaticDefinitionForVariable(
+    modules: ReadonlyMap<string, ParsedModuleRecord>,
+    moduleId: string,
+    variable: eslintScope.Variable,
+): StaticDefinition {
+    return resolveVariable({ modules, visitedExports: new Set() }, moduleId, variable, []);
+}
+
+function resolveExport(
+    state: ResolverState,
+    moduleId: string,
+    exportName: string,
+    hops: StaticDefinitionHop[],
+): StaticDefinition {
+    const record = state.modules.get(moduleId);
+    if (!record) {
+        return unsupported(moduleId, 'missing-module-record', hops, { exportName });
+    }
+
+    if (exportName === 'default') {
+        return unsupported(moduleId, 'default-export', hops, { exportName });
+    }
+
+    const visitKey = `${moduleId}\0${exportName}`;
+    if (state.visitedExports.has(visitKey)) {
+        return unsupported(moduleId, 'cycle', hops, { exportName });
+    }
+
+    state.visitedExports.add(visitKey);
+    try {
+        const explicitExport = record.exportsByName.get(exportName);
+        if (explicitExport) {
+            return resolveExplicitExport(state, record, exportName, explicitExport, hops);
+        }
+
+        return resolveStarExport(state, record, exportName, hops);
+    } finally {
+        state.visitedExports.delete(visitKey);
+    }
+}
+
+function resolveExplicitExport(
+    state: ResolverState,
+    record: ParsedModuleRecord,
+    exportName: string,
+    binding: ExportBinding,
+    hops: StaticDefinitionHop[],
+): StaticDefinition {
+    if (binding.kind === 'unsupported') {
+        return unsupported(record.id, 'unsupported-export', hops, {
+            exportName,
+            detail: binding.reason,
+        });
+    }
+
+    if (binding.kind === 're-export') {
+        if (binding.importedName === 'default') {
+            return unsupported(record.id, 'default-export', hops, { exportName });
+        }
+
+        return resolveExport(state, binding.resolvedId, binding.importedName, [
+            ...hops,
+            {
+                kind: 're-export',
+                moduleId: record.id,
+                exportName,
+                sourceModuleId: binding.resolvedId,
+                sourceExportName: binding.importedName,
+            },
+        ]);
+    }
+
+    return resolveVariable(state, record.id, binding.variable, [
+        ...hops,
+        {
+            kind: 'local-export',
+            moduleId: record.id,
+            exportName,
+            localName: binding.variable.name,
+        },
+    ]);
+}
+
+function resolveStarExport(
+    state: ResolverState,
+    record: ParsedModuleRecord,
+    exportName: string,
+    hops: StaticDefinitionHop[],
+): StaticDefinition {
+    let candidate: LocalStaticDefinition | undefined;
+
+    for (const starExport of record.starExports) {
+        const result = resolveExport(state, starExport.resolvedId, exportName, [
+            ...hops,
+            {
+                kind: 'star-export',
+                moduleId: record.id,
+                exportName,
+                sourceModuleId: starExport.resolvedId,
+            },
+        ]);
+
+        if (result.kind === 'unsupported') {
+            if (result.reason === 'missing-export') {
+                continue;
+            }
+
+            return result;
+        }
+
+        if (candidate) {
+            return unsupported(record.id, 'ambiguous-star-export', hops, { exportName });
+        }
+        candidate = result;
+    }
+
+    return candidate ?? unsupported(record.id, 'missing-export', hops, { exportName });
+}
+
+function resolveVariable(
+    state: ResolverState,
+    moduleId: string,
+    variable: eslintScope.Variable,
+    hops: StaticDefinitionHop[],
+): StaticDefinition {
+    const record = state.modules.get(moduleId);
+    if (!record) {
+        return unsupported(moduleId, 'missing-module-record', hops, {
+            variableName: variable.name,
+        });
+    }
+
+    const importBinding = record.importsByVariable.get(variable);
+    if (importBinding) {
+        return resolveImportBinding(state, record.id, variable.name, importBinding, hops);
+    }
+
+    const binding = record.topLevelBindingsByVariable.get(variable);
+    if (!binding) {
+        return unsupported(record.id, 'missing-static-binding', hops, {
+            variableName: variable.name,
+        });
+    }
+
+    if (binding.kind === 'const') {
+        return { kind: 'local', moduleId: record.id, variable, binding, hops };
+    }
+
+    if (binding.kind === 'mutable') {
+        return unsupported(record.id, 'mutable-binding', hops, {
+            variableName: variable.name,
+            detail: binding.declarationKind,
+        });
+    }
+
+    return unsupported(record.id, 'unsupported-binding', hops, {
+        variableName: variable.name,
+        detail: binding.reason,
+    });
+}
+
+function resolveImportBinding(
+    state: ResolverState,
+    moduleId: string,
+    localName: string,
+    binding: ImportBinding,
+    hops: StaticDefinitionHop[],
+): StaticDefinition {
+    if (binding.kind === 'default') {
+        return unsupported(moduleId, 'default-import', hops, { variableName: localName });
+    }
+
+    if (binding.kind === 'namespace') {
+        return unsupported(moduleId, 'namespace-import', hops, { variableName: localName });
+    }
+
+    if (binding.importedName === 'default') {
+        return unsupported(moduleId, 'default-import', hops, { variableName: localName });
+    }
+
+    return resolveExport(state, binding.resolvedId, binding.importedName, [
+        ...hops,
+        {
+            kind: 'import',
+            moduleId,
+            localName,
+            exportName: binding.importedName,
+            sourceModuleId: binding.resolvedId,
+        },
+    ]);
+}
+
+function unsupported(
+    moduleId: string,
+    reason: StaticDefinitionUnsupportedReason,
+    hops: StaticDefinitionHop[],
+    context: {
+        exportName?: string;
+        variableName?: string;
+        detail?: string;
+    } = {},
+): UnsupportedStaticDefinition {
+    return {
+        kind: 'unsupported',
+        moduleId,
+        reason,
+        ...context,
+        hops,
+    };
+}

--- a/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.ts
@@ -9,23 +9,10 @@ import type {
     ConstStaticBinding,
     ExportBinding,
     ImportBinding,
+    MutableStaticBinding,
     ParsedModuleRecord,
 } from './module-graph';
 import { resolveIdentifier } from './module-scope';
-
-export type StaticDefinitionUnsupportedReason =
-    | 'ambiguous-star-export'
-    | 'cycle'
-    | 'default-export'
-    | 'default-import'
-    | 'missing-export'
-    | 'missing-module-record'
-    | 'missing-static-binding'
-    | 'mutable-binding'
-    | 'namespace-import'
-    | 'unresolved-identifier'
-    | 'unsupported-binding'
-    | 'unsupported-export';
 
 export type StaticDefinition = LocalStaticDefinition | UnsupportedStaticDefinition;
 
@@ -37,14 +24,100 @@ export interface LocalStaticDefinition {
     hops: StaticDefinitionHop[];
 }
 
-export interface UnsupportedStaticDefinition {
+export type UnsupportedStaticDefinition =
+    | AmbiguousStarExportStaticDefinition
+    | CycleStaticDefinition
+    | DefaultExportStaticDefinition
+    | DefaultImportStaticDefinition
+    | MissingExportStaticDefinition
+    | MissingModuleRecordForExportStaticDefinition
+    | MissingModuleRecordForVariableStaticDefinition
+    | MissingStaticBindingStaticDefinition
+    | MutableBindingStaticDefinition
+    | NamespaceImportStaticDefinition
+    | UnresolvedIdentifierStaticDefinition
+    | UnsupportedBindingStaticDefinition
+    | UnsupportedExportStaticDefinition;
+
+export type StaticDefinitionUnsupportedReason = UnsupportedStaticDefinition['reason'];
+
+interface UnsupportedStaticDefinitionBase {
     kind: 'unsupported';
     moduleId: string;
-    reason: StaticDefinitionUnsupportedReason;
-    exportName?: string;
-    variableName?: string;
-    detail?: string;
+    message: string;
     hops: StaticDefinitionHop[];
+}
+
+export interface AmbiguousStarExportStaticDefinition extends UnsupportedStaticDefinitionBase {
+    reason: 'ambiguous-star-export';
+    exportName: string;
+}
+
+export interface CycleStaticDefinition extends UnsupportedStaticDefinitionBase {
+    reason: 'cycle';
+    exportName: string;
+}
+
+export interface DefaultExportStaticDefinition extends UnsupportedStaticDefinitionBase {
+    reason: 'default-export';
+    exportName: string;
+}
+
+export interface DefaultImportStaticDefinition extends UnsupportedStaticDefinitionBase {
+    reason: 'default-import';
+    variableName: string;
+}
+
+export interface MissingExportStaticDefinition extends UnsupportedStaticDefinitionBase {
+    reason: 'missing-export';
+    exportName: string;
+}
+
+export interface MissingModuleRecordForExportStaticDefinition
+    extends UnsupportedStaticDefinitionBase {
+    reason: 'missing-module-record';
+    requestKind: 'export';
+    exportName: string;
+}
+
+export interface MissingModuleRecordForVariableStaticDefinition
+    extends UnsupportedStaticDefinitionBase {
+    reason: 'missing-module-record';
+    requestKind: 'variable';
+    variableName: string;
+}
+
+export interface MissingStaticBindingStaticDefinition extends UnsupportedStaticDefinitionBase {
+    reason: 'missing-static-binding';
+    variableName: string;
+}
+
+export interface MutableBindingStaticDefinition extends UnsupportedStaticDefinitionBase {
+    reason: 'mutable-binding';
+    variableName: string;
+    declarationKind: MutableStaticBinding['declarationKind'];
+}
+
+export interface NamespaceImportStaticDefinition extends UnsupportedStaticDefinitionBase {
+    reason: 'namespace-import';
+    variableName: string;
+}
+
+export interface UnresolvedIdentifierStaticDefinition extends UnsupportedStaticDefinitionBase {
+    reason: 'unresolved-identifier';
+    variableName: string;
+}
+
+export interface UnsupportedBindingStaticDefinition extends UnsupportedStaticDefinitionBase {
+    reason: 'unsupported-binding';
+    variableName: string;
+    bindingReason: string;
+}
+
+export interface UnsupportedExportStaticDefinition extends UnsupportedStaticDefinitionBase {
+    reason: 'unsupported-export';
+    exportName: string;
+    exportReason: string;
 }
 
 export type StaticDefinitionHop =
@@ -95,21 +168,15 @@ export function resolveStaticDefinitionForIdentifier(
 ): StaticDefinition {
     const record = modules.get(moduleId);
     if (!record) {
-        return unsupported(moduleId, 'missing-module-record', [], {
-            variableName: identifier.name,
-        });
+        return missingModuleRecordForVariable(moduleId, [], identifier.name);
     }
 
     const variable = resolveIdentifier(identifier, record.scopeAnalysis);
     if (!variable) {
-        return unsupported(moduleId, 'unresolved-identifier', [], {
-            variableName: identifier.name,
-        });
+        return unresolvedIdentifier(moduleId, [], identifier.name);
     }
     if (isDefinitionIdentifier(identifier, variable)) {
-        return unsupported(moduleId, 'unresolved-identifier', [], {
-            variableName: identifier.name,
-        });
+        return unresolvedIdentifier(moduleId, [], identifier.name);
     }
 
     return resolveVariable({ modules, visitedExports: new Set() }, moduleId, variable, []);
@@ -127,16 +194,16 @@ function resolveExport(
 ): StaticDefinition {
     const record = state.modules.get(moduleId);
     if (!record) {
-        return unsupported(moduleId, 'missing-module-record', hops, { exportName });
+        return missingModuleRecordForExport(moduleId, hops, exportName);
     }
 
     if (exportName === 'default') {
-        return unsupported(moduleId, 'default-export', hops, { exportName });
+        return defaultExport(moduleId, hops, exportName);
     }
 
     const visitKey = `${moduleId}\0${exportName}`;
     if (state.visitedExports.has(visitKey)) {
-        return unsupported(moduleId, 'cycle', hops, { exportName });
+        return cycle(moduleId, hops, exportName);
     }
 
     state.visitedExports.add(visitKey);
@@ -160,15 +227,12 @@ function resolveExplicitExport(
     hops: StaticDefinitionHop[],
 ): StaticDefinition {
     if (binding.kind === 'unsupported') {
-        return unsupported(record.id, 'unsupported-export', hops, {
-            exportName,
-            detail: binding.reason,
-        });
+        return unsupportedExport(record.id, hops, exportName, binding.reason);
     }
 
     if (binding.kind === 're-export') {
         if (binding.importedName === 'default') {
-            return unsupported(record.id, 'default-export', hops, { exportName });
+            return defaultExport(record.id, hops, exportName);
         }
 
         return resolveExport(state, binding.resolvedId, binding.importedName, [
@@ -222,12 +286,12 @@ function resolveStarExport(
         }
 
         if (candidate) {
-            return unsupported(record.id, 'ambiguous-star-export', hops, { exportName });
+            return ambiguousStarExport(record.id, hops, exportName);
         }
         candidate = result;
     }
 
-    return candidate ?? unsupported(record.id, 'missing-export', hops, { exportName });
+    return candidate ?? missingExport(record.id, hops, exportName);
 }
 
 function resolveVariable(
@@ -238,9 +302,7 @@ function resolveVariable(
 ): StaticDefinition {
     const record = state.modules.get(moduleId);
     if (!record) {
-        return unsupported(moduleId, 'missing-module-record', hops, {
-            variableName: variable.name,
-        });
+        return missingModuleRecordForVariable(moduleId, hops, variable.name);
     }
 
     const importBinding = record.importsByVariable.get(variable);
@@ -250,9 +312,7 @@ function resolveVariable(
 
     const binding = record.topLevelBindingsByVariable.get(variable);
     if (!binding) {
-        return unsupported(record.id, 'missing-static-binding', hops, {
-            variableName: variable.name,
-        });
+        return missingStaticBinding(record.id, hops, variable.name);
     }
 
     if (binding.kind === 'const') {
@@ -260,16 +320,10 @@ function resolveVariable(
     }
 
     if (binding.kind === 'mutable') {
-        return unsupported(record.id, 'mutable-binding', hops, {
-            variableName: variable.name,
-            detail: binding.declarationKind,
-        });
+        return mutableBinding(record.id, hops, variable.name, binding.declarationKind);
     }
 
-    return unsupported(record.id, 'unsupported-binding', hops, {
-        variableName: variable.name,
-        detail: binding.reason,
-    });
+    return unsupportedBinding(record.id, hops, variable.name, binding.reason);
 }
 
 function resolveImportBinding(
@@ -280,15 +334,15 @@ function resolveImportBinding(
     hops: StaticDefinitionHop[],
 ): StaticDefinition {
     if (binding.kind === 'default') {
-        return unsupported(moduleId, 'default-import', hops, { variableName: localName });
+        return defaultImport(moduleId, hops, localName);
     }
 
     if (binding.kind === 'namespace') {
-        return unsupported(moduleId, 'namespace-import', hops, { variableName: localName });
+        return namespaceImport(moduleId, hops, localName);
     }
 
     if (binding.importedName === 'default') {
-        return unsupported(moduleId, 'default-import', hops, { variableName: localName });
+        return defaultImport(moduleId, hops, localName);
     }
 
     return resolveExport(state, binding.resolvedId, binding.importedName, [
@@ -303,21 +357,205 @@ function resolveImportBinding(
     ]);
 }
 
-function unsupported(
+function ambiguousStarExport(
     moduleId: string,
-    reason: StaticDefinitionUnsupportedReason,
     hops: StaticDefinitionHop[],
-    context: {
-        exportName?: string;
-        variableName?: string;
-        detail?: string;
-    } = {},
-): UnsupportedStaticDefinition {
+    exportName: string,
+): AmbiguousStarExportStaticDefinition {
     return {
         kind: 'unsupported',
         moduleId,
-        reason,
-        ...context,
+        reason: 'ambiguous-star-export',
+        exportName,
+        message: `Module '${moduleId}' exposes ambiguous star exports for '${exportName}'.`,
+        hops,
+    };
+}
+
+function cycle(
+    moduleId: string,
+    hops: StaticDefinitionHop[],
+    exportName: string,
+): CycleStaticDefinition {
+    return {
+        kind: 'unsupported',
+        moduleId,
+        reason: 'cycle',
+        exportName,
+        message: `Resolving export '${exportName}' from module '${moduleId}' would cycle through the module graph.`,
+        hops,
+    };
+}
+
+function defaultExport(
+    moduleId: string,
+    hops: StaticDefinitionHop[],
+    exportName: string,
+): DefaultExportStaticDefinition {
+    return {
+        kind: 'unsupported',
+        moduleId,
+        reason: 'default-export',
+        exportName,
+        message: `Export '${exportName}' from module '${moduleId}' resolves through an unsupported default export.`,
+        hops,
+    };
+}
+
+function defaultImport(
+    moduleId: string,
+    hops: StaticDefinitionHop[],
+    variableName: string,
+): DefaultImportStaticDefinition {
+    return {
+        kind: 'unsupported',
+        moduleId,
+        reason: 'default-import',
+        variableName,
+        message: `Variable '${variableName}' in module '${moduleId}' is an unsupported default import.`,
+        hops,
+    };
+}
+
+function missingExport(
+    moduleId: string,
+    hops: StaticDefinitionHop[],
+    exportName: string,
+): MissingExportStaticDefinition {
+    return {
+        kind: 'unsupported',
+        moduleId,
+        reason: 'missing-export',
+        exportName,
+        message: `Module '${moduleId}' does not expose export '${exportName}'.`,
+        hops,
+    };
+}
+
+function missingModuleRecordForExport(
+    moduleId: string,
+    hops: StaticDefinitionHop[],
+    exportName: string,
+): MissingModuleRecordForExportStaticDefinition {
+    return {
+        kind: 'unsupported',
+        moduleId,
+        reason: 'missing-module-record',
+        requestKind: 'export',
+        exportName,
+        message: `Module '${moduleId}' was not collected while resolving export '${exportName}'.`,
+        hops,
+    };
+}
+
+function missingModuleRecordForVariable(
+    moduleId: string,
+    hops: StaticDefinitionHop[],
+    variableName: string,
+): MissingModuleRecordForVariableStaticDefinition {
+    return {
+        kind: 'unsupported',
+        moduleId,
+        reason: 'missing-module-record',
+        requestKind: 'variable',
+        variableName,
+        message: `Module '${moduleId}' was not collected while resolving variable '${variableName}'.`,
+        hops,
+    };
+}
+
+function missingStaticBinding(
+    moduleId: string,
+    hops: StaticDefinitionHop[],
+    variableName: string,
+): MissingStaticBindingStaticDefinition {
+    return {
+        kind: 'unsupported',
+        moduleId,
+        reason: 'missing-static-binding',
+        variableName,
+        message: `Variable '${variableName}' in module '${moduleId}' does not have a recorded top-level static binding.`,
+        hops,
+    };
+}
+
+function mutableBinding(
+    moduleId: string,
+    hops: StaticDefinitionHop[],
+    variableName: string,
+    declarationKind: MutableStaticBinding['declarationKind'],
+): MutableBindingStaticDefinition {
+    return {
+        kind: 'unsupported',
+        moduleId,
+        reason: 'mutable-binding',
+        variableName,
+        declarationKind,
+        message: `Variable '${variableName}' in module '${moduleId}' is declared with mutable '${declarationKind}'.`,
+        hops,
+    };
+}
+
+function namespaceImport(
+    moduleId: string,
+    hops: StaticDefinitionHop[],
+    variableName: string,
+): NamespaceImportStaticDefinition {
+    return {
+        kind: 'unsupported',
+        moduleId,
+        reason: 'namespace-import',
+        variableName,
+        message: `Variable '${variableName}' in module '${moduleId}' is an unsupported namespace import.`,
+        hops,
+    };
+}
+
+function unresolvedIdentifier(
+    moduleId: string,
+    hops: StaticDefinitionHop[],
+    variableName: string,
+): UnresolvedIdentifierStaticDefinition {
+    return {
+        kind: 'unsupported',
+        moduleId,
+        reason: 'unresolved-identifier',
+        variableName,
+        message: `Identifier '${variableName}' in module '${moduleId}' is not a resolvable reference.`,
+        hops,
+    };
+}
+
+function unsupportedBinding(
+    moduleId: string,
+    hops: StaticDefinitionHop[],
+    variableName: string,
+    bindingReason: string,
+): UnsupportedBindingStaticDefinition {
+    return {
+        kind: 'unsupported',
+        moduleId,
+        reason: 'unsupported-binding',
+        variableName,
+        bindingReason,
+        message: `Variable '${variableName}' in module '${moduleId}' has unsupported binding: ${bindingReason}.`,
+        hops,
+    };
+}
+
+function unsupportedExport(
+    moduleId: string,
+    hops: StaticDefinitionHop[],
+    exportName: string,
+    exportReason: string,
+): UnsupportedExportStaticDefinition {
+    return {
+        kind: 'unsupported',
+        moduleId,
+        reason: 'unsupported-export',
+        exportName,
+        exportReason,
+        message: `Export '${exportName}' from module '${moduleId}' is unsupported: ${exportReason}.`,
         hops,
     };
 }

--- a/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/static-definition-resolution.ts
@@ -3,6 +3,7 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import type * as eslintScope from 'eslint-scope';
+import type { Identifier } from 'estree';
 
 import type {
     ConstStaticBinding,
@@ -10,6 +11,7 @@ import type {
     ImportBinding,
     ParsedModuleRecord,
 } from './module-graph';
+import { resolveIdentifier } from './module-scope';
 
 export type StaticDefinitionUnsupportedReason =
     | 'ambiguous-star-export'
@@ -21,6 +23,7 @@ export type StaticDefinitionUnsupportedReason =
     | 'missing-static-binding'
     | 'mutable-binding'
     | 'namespace-import'
+    | 'unresolved-identifier'
     | 'unsupported-binding'
     | 'unsupported-export';
 
@@ -45,52 +48,75 @@ export interface UnsupportedStaticDefinition {
 }
 
 export type StaticDefinitionHop =
-    | {
-          kind: 'import';
-          moduleId: string;
-          localName: string;
-          exportName: string;
-          sourceModuleId: string;
-      }
-    | {
-          kind: 'local-export';
-          moduleId: string;
-          exportName: string;
-          localName: string;
-      }
-    | {
-          kind: 're-export';
-          moduleId: string;
-          exportName: string;
-          sourceModuleId: string;
-          sourceExportName: string;
-      }
-    | {
-          kind: 'star-export';
-          moduleId: string;
-          exportName: string;
-          sourceModuleId: string;
-      };
+    | ImportStaticDefinitionHop
+    | LocalExportStaticDefinitionHop
+    | ReExportStaticDefinitionHop
+    | StarExportStaticDefinitionHop;
+
+export interface ImportStaticDefinitionHop {
+    kind: 'import';
+    moduleId: string;
+    localName: string;
+    exportName: string;
+    sourceModuleId: string;
+}
+
+export interface LocalExportStaticDefinitionHop {
+    kind: 'local-export';
+    moduleId: string;
+    exportName: string;
+    localName: string;
+}
+
+export interface ReExportStaticDefinitionHop {
+    kind: 're-export';
+    moduleId: string;
+    exportName: string;
+    sourceModuleId: string;
+    sourceExportName: string;
+}
+
+export interface StarExportStaticDefinitionHop {
+    kind: 'star-export';
+    moduleId: string;
+    exportName: string;
+    sourceModuleId: string;
+}
 
 interface ResolverState {
     modules: ReadonlyMap<string, ParsedModuleRecord>;
     visitedExports: Set<string>;
 }
 
-export function resolveStaticDefinitionForExport(
+export function resolveStaticDefinitionForIdentifier(
     modules: ReadonlyMap<string, ParsedModuleRecord>,
     moduleId: string,
-    exportName: string,
+    identifier: Identifier,
 ): StaticDefinition {
-    return resolveExport({ modules, visitedExports: new Set() }, moduleId, exportName, []);
+    const record = modules.get(moduleId);
+    if (!record) {
+        return unsupported(moduleId, 'missing-module-record', [], {
+            variableName: identifier.name,
+        });
+    }
+
+    const variable = resolveIdentifier(identifier, record.scopeAnalysis);
+    if (!variable) {
+        return unsupported(moduleId, 'unresolved-identifier', [], {
+            variableName: identifier.name,
+        });
+    }
+    if (isDefinitionIdentifier(identifier, variable)) {
+        return unsupported(moduleId, 'unresolved-identifier', [], {
+            variableName: identifier.name,
+        });
+    }
+
+    return resolveVariable({ modules, visitedExports: new Set() }, moduleId, variable, []);
 }
 
-export function resolveStaticDefinitionForVariable(
-    modules: ReadonlyMap<string, ParsedModuleRecord>,
-    moduleId: string,
-    variable: eslintScope.Variable,
-): StaticDefinition {
-    return resolveVariable({ modules, visitedExports: new Set() }, moduleId, variable, []);
+function isDefinitionIdentifier(identifier: Identifier, variable: eslintScope.Variable): boolean {
+    return variable.defs.some((definition) => definition.name === identifier);
 }
 
 function resolveExport(


### PR DESCRIPTION
## Motivation

This is the next PR in the backend connection ID analysis stack. The previous PR enriches parsed backend module records with domain-neutral import, export, star export, and top-level binding facts. The imported connection ID integration needs a reusable way to resolve those facts through the backend module graph without embedding import/export traversal inside connection ID-specific code.

## Changes

Adds a domain-neutral static definition resolver for parsed backend module records. Given an ESTree identifier reference in a module, callers can resolve it to a concrete top-level const binding, or to a structured unsupported result with a stable reason code.

Example:

```ts
// actions.backend.ts
import { HTTP_CONNECTION_ID } from './connections';

request({
    connectionId: HTTP_CONNECTION_ID,
    inputs: {},
});

// connections.ts
const SOURCE_CONNECTION_ID = 'conn-http';
export const HTTP_CONNECTION_ID = SOURCE_CONNECTION_ID;
```

For the `HTTP_CONNECTION_ID` identifier in `actions.backend.ts`, the resolver follows the named import into `connections.ts` and returns the exported top-level const binding:

```ts
export const HTTP_CONNECTION_ID = SOURCE_CONNECTION_ID;
```

It does not evaluate the initializer into a string. That value-level evaluation is handled by the follow-up static string resolver PR.

The resolver is demand-driven: it follows named imports, local export aliases, named re-exports, local import/export relays, and unambiguous star exports for one requested symbol at a time.

Supported cases:

- Same-module identifier references to top-level const bindings
- Named imports through source module exports
- Local export aliases
- Named re-export aliases
- Local import/export relays
- Unambiguous star exports
- Explicit exports taking precedence over star exports

Unsupported cases return structured reason codes instead of throwing connection ID-specific errors.

Unsupported cases:

- Missing module records
- Missing exports
- Ambiguous star exports
- Import/export cycles
- Default imports
- Default exports and default re-exports
- Namespace imports
- Missing static bindings
- Mutable bindings
- Unsupported top-level declarations and binding patterns
- Unresolved identifiers and declaration identifiers

The result includes hop metadata so the follow-up connection ID PR can translate generic resolver failures into existing fail-closed diagnostics without recomputing graph traversal.

## QA Instructions

No manual QA needed. This is an internal AST-analysis helper with focused unit coverage and no manifest behavior changes in this PR.

## Blast Radius

This only affects the High Code Apps backend AST parsing internals in `@dd/apps-plugin`. The resolver is not wired into connection ID extraction or manifest output until the next stack PR, so customer-visible behavior should be unchanged.

## Documentation

-   [How to reliably make frontend production changes](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2286781319/Frontend+Production+Changesp)
-   [PR Description Guidelines](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/3120334387/PR+Checklist+and+Guidelines+for+Web+UI)
-   [Deploy steps](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/1457750032/)
