### PR TITLE
[APPS][Connections Part 12] Use static definitions for imported connection IDs

### DIFF
--- a/packages/plugins/apps/src/backend/ast-parsing/connection-id-values.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/connection-id-values.ts
@@ -16,7 +16,13 @@ import type {
     VariableDeclaration,
 } from 'estree';
 
+import type { ParsedModuleRecord } from './module-graph';
 import { isImportVariable, type ModuleScopeAnalysis, resolveIdentifier } from './module-scope';
+import {
+    resolveStaticDefinitionForIdentifier,
+    type LocalStaticDefinition,
+    type UnsupportedStaticDefinition,
+} from './static-definition-resolution';
 
 const CONNECTION_ID_PROPERTY = 'connectionId';
 
@@ -105,6 +111,11 @@ export interface SameModuleConnectionIdBindings {
     byVariable: Map<eslintScope.Variable, StaticBinding>;
 }
 
+export interface ModuleGraphConnectionIdResolutionContext {
+    modules: ReadonlyMap<string, ParsedModuleRecord>;
+    moduleId: string;
+}
+
 /**
  * Shared state for one `connectionId` value resolution.
  *
@@ -114,8 +125,19 @@ export interface SameModuleConnectionIdBindings {
 interface ConnectionIdResolutionContext {
     bindings: SameModuleConnectionIdBindings;
     filePath: string;
+    moduleGraph?: ModuleGraphConnectionIdResolutionContext;
     scopeAnalysis: ModuleScopeAnalysis;
     seen: Set<eslintScope.Variable>;
+}
+
+interface ResolvedConnectionIdExpression {
+    expression: Expression;
+    context: ConnectionIdResolutionContext;
+}
+
+interface ResolvedObjectExpression {
+    expression: ObjectExpression;
+    context: ConnectionIdResolutionContext;
 }
 
 /**
@@ -177,6 +199,7 @@ export function extractConnectionIdFromActionCall(
     bindings: SameModuleConnectionIdBindings,
     scopeAnalysis: ModuleScopeAnalysis,
     filePath: string,
+    moduleGraph?: ModuleGraphConnectionIdResolutionContext,
 ): string | undefined {
     const [firstArg] = node.arguments;
     if (!firstArg || firstArg.type !== 'ObjectExpression') {
@@ -191,6 +214,7 @@ export function extractConnectionIdFromActionCall(
     return resolveConnectionIdValue(connectionIdProperty.value, {
         bindings,
         filePath,
+        moduleGraph,
         scopeAnalysis,
         seen: new Set(),
     });
@@ -324,6 +348,20 @@ function resolveIdentifierValue(
     identifier: Identifier,
     context: ConnectionIdResolutionContext,
 ): string {
+    if (context.moduleGraph) {
+        const definition = resolveStaticDefinitionForIdentifier(
+            context.moduleGraph.modules,
+            context.moduleGraph.moduleId,
+            identifier,
+        );
+
+        if (definition.kind === 'unsupported') {
+            throw unsupportedStaticDefinitionConnectionId(context.filePath, identifier, definition);
+        }
+
+        return resolveLocalStaticDefinitionValue(definition, context);
+    }
+
     const variable = resolveIdentifier(identifier, context.scopeAnalysis);
     if (!variable) {
         // The identifier has no declaration eslint-scope can point to:
@@ -404,6 +442,33 @@ function resolveIdentifierValue(
     }
 }
 
+function resolveLocalStaticDefinitionValue(
+    definition: LocalStaticDefinition,
+    context: ConnectionIdResolutionContext,
+): string {
+    if (!definition.binding.expression) {
+        throw unsupportedConnectionId(
+            definition.moduleId,
+            `uninitialized const connectionId binding ${definition.variable.name}`,
+        );
+    }
+    if (context.seen.has(definition.variable)) {
+        throw unsupportedConnectionId(
+            definition.moduleId,
+            `cyclic connectionId binding ${definition.variable.name}`,
+        );
+    }
+
+    const definitionContext = getModuleConnectionIdContext(context, definition.moduleId);
+
+    context.seen.add(definition.variable);
+    try {
+        return resolveConnectionIdValue(definition.binding.expression, definitionContext);
+    } finally {
+        context.seen.delete(definition.variable);
+    }
+}
+
 /**
  * Resolves an object member read from a top-level const object.
  *
@@ -434,7 +499,7 @@ function resolveObjectMemberValue(
     // the string literal can become the final connection ID immediately. For
     // `const CONNECTIONS = { HTTP: HTTP_CONNECTION_ID }`, the identifier can
     // resolve through its own const binding before producing the final string.
-    return resolveConnectionIdValue(value, context);
+    return resolveConnectionIdValue(value.expression, value.context);
 }
 
 /**
@@ -447,7 +512,7 @@ function resolveObjectMemberValue(
 function resolveObjectMemberExpression(
     node: MemberExpression,
     context: ConnectionIdResolutionContext,
-): Expression {
+): ResolvedConnectionIdExpression {
     if (node.optional) {
         throw unsupportedConnectionId(context.filePath, 'optional connectionId member reads');
     }
@@ -466,7 +531,14 @@ function resolveObjectMemberExpression(
     }
 
     const objectExpression = resolveObjectExpressionValue(node.object, context);
-    return resolveObjectPropertyExpression(objectExpression, node.property.name, context);
+    return {
+        expression: resolveObjectPropertyExpression(
+            objectExpression.expression,
+            node.property.name,
+            objectExpression.context,
+        ),
+        context: objectExpression.context,
+    };
 }
 
 /**
@@ -483,17 +555,50 @@ function resolveObjectMemberExpression(
 function resolveObjectExpressionValue(
     node: MemberExpression['object'] | Expression,
     context: ConnectionIdResolutionContext,
-): ObjectExpression {
+): ResolvedObjectExpression {
     if (node.type === 'ObjectExpression') {
-        return node;
+        return { expression: node, context };
     }
 
     if (node.type === 'MemberExpression') {
-        return resolveObjectExpressionValue(resolveObjectMemberExpression(node, context), context);
+        const value = resolveObjectMemberExpression(node, context);
+        return resolveObjectExpressionValue(value.expression, value.context);
     }
 
     if (node.type !== 'Identifier') {
         throw unsupportedConnectionId(context.filePath, 'non-object connectionId member values');
+    }
+
+    if (context.moduleGraph) {
+        const definition = resolveStaticDefinitionForIdentifier(
+            context.moduleGraph.modules,
+            context.moduleGraph.moduleId,
+            node,
+        );
+
+        if (definition.kind === 'unsupported') {
+            throw unsupportedStaticDefinitionConnectionId(context.filePath, node, definition);
+        }
+        if (!definition.binding.expression) {
+            throw unsupportedConnectionId(
+                definition.moduleId,
+                `uninitialized const connectionId object binding ${definition.variable.name}`,
+            );
+        }
+        if (context.seen.has(definition.variable)) {
+            throw unsupportedConnectionId(
+                definition.moduleId,
+                `cyclic connectionId object binding ${definition.variable.name}`,
+            );
+        }
+
+        const definitionContext = getModuleConnectionIdContext(context, definition.moduleId);
+        context.seen.add(definition.variable);
+        try {
+            return resolveObjectExpressionValue(definition.binding.expression, definitionContext);
+        } finally {
+            context.seen.delete(definition.variable);
+        }
     }
 
     const variable = resolveIdentifier(node, context.scopeAnalysis);
@@ -563,6 +668,39 @@ function resolveObjectExpressionValue(
     } finally {
         context.seen.delete(variable);
     }
+}
+
+function getModuleConnectionIdContext(
+    context: ConnectionIdResolutionContext,
+    moduleId: string,
+): ConnectionIdResolutionContext {
+    const moduleGraph = context.moduleGraph;
+    if (!moduleGraph) {
+        return context;
+    }
+
+    if (moduleGraph.moduleId === moduleId) {
+        return context;
+    }
+
+    const record = moduleGraph.modules.get(moduleId);
+    if (!record) {
+        throw unsupportedConnectionId(
+            context.filePath,
+            `missing module record while resolving connectionId binding ${moduleId}`,
+        );
+    }
+
+    return {
+        bindings: { byVariable: new Map() },
+        filePath: moduleId,
+        moduleGraph: {
+            modules: moduleGraph.modules,
+            moduleId,
+        },
+        scopeAnalysis: record.scopeAnalysis,
+        seen: context.seen,
+    };
 }
 
 /**
@@ -714,6 +852,17 @@ function getStaticPropertyKey(property: Property): string | undefined {
 function unsupportedActionCatalogCall(filePath: string, unsupported: string): Error {
     return new Error(
         `Unsupported action-catalog call in ${filePath}: ${unsupported} could hide a connectionId.`,
+    );
+}
+
+function unsupportedStaticDefinitionConnectionId(
+    filePath: string,
+    identifier: Identifier,
+    definition: UnsupportedStaticDefinition,
+): Error {
+    return unsupportedConnectionId(
+        filePath,
+        `unsupported static definition ${definition.reason} for ${identifier.name}: ${definition.message}`,
     );
 }
 

--- a/packages/plugins/apps/src/backend/ast-parsing/connection-id-values.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/connection-id-values.ts
@@ -9,15 +9,13 @@ import type {
     Literal,
     MemberExpression,
     ObjectExpression,
-    Program,
     Property,
     SimpleCallExpression,
     TemplateLiteral,
-    VariableDeclaration,
 } from 'estree';
 
 import type { ParsedModuleRecord } from './module-graph';
-import { isImportVariable, type ModuleScopeAnalysis, resolveIdentifier } from './module-scope';
+import type { ModuleScopeAnalysis } from './module-scope';
 import {
     resolveStaticDefinitionForIdentifier,
     type LocalStaticDefinition,
@@ -26,90 +24,7 @@ import {
 
 const CONNECTION_ID_PROPERTY = 'connectionId';
 
-type VariableKind = VariableDeclaration['kind'];
 type ConnectionIdProperty = Property & { value: Expression };
-
-/**
- * Describes what kind of same-file variable a connectionId expression points to.
- *
- * We record declarations before resolving values so later reads can be checked by
- * declaration identity, not by name. For example, the `ID` in
- * `request({ connectionId: ID })` must point to the same variable created by
- * `const ID = 'abc'`, not a shadowed function parameter also named `ID`.
- */
-type StaticBinding =
-    /**
-     * A top-level `const` declaration whose initializer can be followed during
-     * connection ID resolution.
-     *
-     * Example:
-     *
-     * ```ts
-     * const HTTP_CONNECTION_ID = 'conn-http';
-     * request({ connectionId: HTTP_CONNECTION_ID, inputs: {} });
-     * ```
-     */
-    | {
-          kind: 'const';
-          init: Expression | null;
-      }
-    /**
-     * A top-level `let` or `var` declaration. The binding is known, but the
-     * value can change before the action call executes, so reads fail closed.
-     *
-     * Example:
-     *
-     * ```ts
-     * let HTTP_CONNECTION_ID = 'conn-http';
-     * HTTP_CONNECTION_ID = getConnectionId();
-     * request({ connectionId: HTTP_CONNECTION_ID, inputs: {} });
-     * ```
-     */
-    | {
-          kind: 'mutable';
-          declarationKind: Exclude<VariableKind, 'const'>;
-      }
-    /**
-     * A declaration that creates variables through a binding pattern. Patterns
-     * can hide aliasing behavior, so reads from these bindings fail closed.
-     *
-     * Example:
-     *
-     * ```ts
-     * const { HTTP: HTTP_CONNECTION_ID } = CONNECTIONS;
-     * request({ connectionId: HTTP_CONNECTION_ID, inputs: {} });
-     * ```
-     */
-    | {
-          kind: 'unsupported-pattern';
-      };
-
-/**
- * Same-file declarations that may be used while resolving connection IDs.
- *
- * The map key is an `eslintScope.Variable`. In plain terms, that is
- * eslint-scope's object for one specific declaration in the source file. For
- * example, in `const HTTP = 'abc'`, eslint-scope creates one `Variable` for
- * that top-level `HTTP` declaration. If a function later declares another
- * `HTTP`, eslint-scope creates a different `Variable` for that inner
- * declaration. Using the `Variable` object as the key is what makes this
- * shadowing-safe; we are not matching by the text name `HTTP` alone.
- *
- * The map value is a `StaticBinding`, which is our smaller summary of whether
- * that declaration is safe to use as a connection ID source:
- *
- * - `const`: keep the initializer expression, such as the `'abc'` in
- *   `const HTTP = 'abc'`, so the resolver can read it later.
- * - `mutable`: remember that the declaration came from `let` or `var`, so
- *   `connectionId: HTTP` fails closed instead of trusting a value that can
- *   change.
- * - `unsupported-pattern`: remember that the declaration came from a binding
- *   pattern such as `const { HTTP } = CONNECTIONS`, which this resolver
- *   intentionally does not support.
- */
-export interface SameModuleConnectionIdBindings {
-    byVariable: Map<eslintScope.Variable, StaticBinding>;
-}
 
 export interface ModuleGraphConnectionIdResolutionContext {
     modules: ReadonlyMap<string, ParsedModuleRecord>;
@@ -123,9 +38,8 @@ export interface ModuleGraphConnectionIdResolutionContext {
  * infinite recursion for cycles such as `const A = B; const B = A;`.
  */
 interface ConnectionIdResolutionContext {
-    bindings: SameModuleConnectionIdBindings;
     filePath: string;
-    moduleGraph?: ModuleGraphConnectionIdResolutionContext;
+    moduleGraph: ModuleGraphConnectionIdResolutionContext;
     scopeAnalysis: ModuleScopeAnalysis;
     seen: Set<eslintScope.Variable>;
 }
@@ -138,45 +52,6 @@ interface ResolvedConnectionIdExpression {
 interface ResolvedObjectExpression {
     expression: ObjectExpression;
     context: ConnectionIdResolutionContext;
-}
-
-/**
- * Collects top-level variable declarations that same-module connection IDs may
- * reference.
- *
- * Supported declarations are deliberately narrow. A top-level `const` keeps its
- * initializer so `connectionId: HTTP_CONNECTION_ID` can resolve through
- * `const HTTP_CONNECTION_ID = 'abc'`. Top-level `let` and `var` declarations are
- * recorded as mutable so they fail closed if used. Destructured declarations are
- * recorded as unsupported because `const { HTTP } = CONNECTIONS` adds more
- * aliasing behavior than the resolver supports.
- */
-export function collectSameModuleConnectionIdBindings(
-    ast: Program,
-    scopeAnalysis: ModuleScopeAnalysis,
-): SameModuleConnectionIdBindings {
-    const byVariable = new Map<eslintScope.Variable, StaticBinding>();
-
-    for (const node of ast.body) {
-        // Top-level declarations such as:
-        //   const HTTP_CONNECTION_ID = 'abc';
-        //   const CONNECTIONS = { HTTP: 'abc' };
-        if (node.type === 'VariableDeclaration') {
-            collectVariableDeclarationBindings(node, scopeAnalysis, byVariable);
-            continue;
-        }
-
-        // Exported top-level declarations are still same-module values:
-        //   export const HTTP_CONNECTION_ID = 'abc';
-        if (
-            node.type === 'ExportNamedDeclaration' &&
-            node.declaration?.type === 'VariableDeclaration'
-        ) {
-            collectVariableDeclarationBindings(node.declaration, scopeAnalysis, byVariable);
-        }
-    }
-
-    return { byVariable };
 }
 
 /**
@@ -196,10 +71,9 @@ export function collectSameModuleConnectionIdBindings(
  */
 export function extractConnectionIdFromActionCall(
     node: SimpleCallExpression,
-    bindings: SameModuleConnectionIdBindings,
     scopeAnalysis: ModuleScopeAnalysis,
     filePath: string,
-    moduleGraph?: ModuleGraphConnectionIdResolutionContext,
+    moduleGraph: ModuleGraphConnectionIdResolutionContext,
 ): string | undefined {
     const [firstArg] = node.arguments;
     if (!firstArg || firstArg.type !== 'ObjectExpression') {
@@ -212,64 +86,11 @@ export function extractConnectionIdFromActionCall(
     }
 
     return resolveConnectionIdValue(connectionIdProperty.value, {
-        bindings,
         filePath,
         moduleGraph,
         scopeAnalysis,
         seen: new Set(),
     });
-}
-
-/**
- * Records variables created by one top-level declaration statement.
- *
- * For `const HTTP = 'abc'`, eslint-scope tells us which variable object belongs
- * to the `HTTP` declaration. We store that object with the initializer expression
- * `'abc'`. For `let HTTP = 'abc'`, we still store the variable, but mark it
- * mutable so reads fail closed later.
- */
-function collectVariableDeclarationBindings(
-    declaration: VariableDeclaration,
-    scopeAnalysis: ModuleScopeAnalysis,
-    byVariable: Map<eslintScope.Variable, StaticBinding>,
-): void {
-    for (const declarator of declaration.declarations) {
-        const variables = scopeAnalysis.scopeManager.getDeclaredVariables(declarator);
-
-        // Destructuring creates variables, but this resolver does not follow
-        // destructured aliases:
-        //   const { HTTP } = CONNECTIONS;
-        if (declarator.id.type !== 'Identifier') {
-            for (const variable of variables) {
-                byVariable.set(variable, { kind: 'unsupported-pattern' });
-            }
-            continue;
-        }
-
-        // For a simple declaration like `const HTTP = 'abc'`, eslint-scope
-        // should return the single Variable created for `HTTP`. The guard is
-        // defensive in case a parser/scope edge case gives us no declaration.
-        const [variable] = variables;
-        if (!variable) {
-            continue;
-        }
-
-        // Immutable top-level values can be followed later:
-        //   const HTTP_CONNECTION_ID = 'abc';
-        //   const CONNECTIONS = { HTTP: HTTP_CONNECTION_ID };
-        if (declaration.kind === 'const') {
-            byVariable.set(variable, { kind: 'const', init: declarator.init ?? null });
-        } else {
-            // Mutable values fail closed because the initializer may not be the
-            // value used at runtime:
-            //   let HTTP_CONNECTION_ID = 'abc';
-            //   HTTP_CONNECTION_ID = getConnectionId();
-            byVariable.set(variable, {
-                kind: 'mutable',
-                declarationKind: declaration.kind,
-            });
-        }
-    }
 }
 
 /**
@@ -348,98 +169,17 @@ function resolveIdentifierValue(
     identifier: Identifier,
     context: ConnectionIdResolutionContext,
 ): string {
-    if (context.moduleGraph) {
-        const definition = resolveStaticDefinitionForIdentifier(
-            context.moduleGraph.modules,
-            context.moduleGraph.moduleId,
-            identifier,
-        );
+    const definition = resolveStaticDefinitionForIdentifier(
+        context.moduleGraph.modules,
+        context.moduleGraph.moduleId,
+        identifier,
+    );
 
-        if (definition.kind === 'unsupported') {
-            throw unsupportedStaticDefinitionConnectionId(context.filePath, identifier, definition);
-        }
-
-        return resolveLocalStaticDefinitionValue(definition, context);
+    if (definition.kind === 'unsupported') {
+        throw unsupportedStaticDefinitionConnectionId(context.filePath, identifier, definition);
     }
 
-    const variable = resolveIdentifier(identifier, context.scopeAnalysis);
-    if (!variable) {
-        // The identifier has no declaration eslint-scope can point to:
-        //   request({ connectionId: HTTP_CONNECTION_ID });
-        // with no `HTTP_CONNECTION_ID` declared in this file.
-        throw unsupportedConnectionId(context.filePath, `unresolved identifier ${identifier.name}`);
-    }
-
-    if (isImportVariable(variable)) {
-        // Imported values require following another module, which is deferred to
-        // the module graph PR:
-        //   import { HTTP_CONNECTION_ID } from './connections';
-        throw unsupportedConnectionId(
-            context.filePath,
-            `imported connectionId binding ${identifier.name}`,
-        );
-    }
-
-    const binding = context.bindings.byVariable.get(variable);
-    if (!binding) {
-        // The declaration exists, but it is not a top-level same-module binding:
-        //   function run() {
-        //     const HTTP_CONNECTION_ID = 'abc';
-        //     request({ connectionId: HTTP_CONNECTION_ID });
-        //   }
-        throw unsupportedConnectionId(
-            context.filePath,
-            `non-top-level connectionId binding ${identifier.name}`,
-        );
-    }
-
-    switch (binding.kind) {
-        case 'mutable':
-            // `let` and `var` can change after their initializer:
-            //   let HTTP_CONNECTION_ID = 'abc';
-            //   HTTP_CONNECTION_ID = getConnectionId();
-            throw unsupportedConnectionId(
-                context.filePath,
-                `mutable ${binding.declarationKind} connectionId binding ${identifier.name}`,
-            );
-        case 'unsupported-pattern':
-            // Destructured aliases are deliberately out of scope:
-            //   const { HTTP: HTTP_CONNECTION_ID } = CONNECTIONS;
-            throw unsupportedConnectionId(
-                context.filePath,
-                `destructured connectionId binding ${identifier.name}`,
-            );
-        case 'const':
-            if (!binding.init) {
-                // This is invalid JavaScript for plain `const`, but keep the
-                // guard explicit for parser edge cases.
-                throw unsupportedConnectionId(
-                    context.filePath,
-                    `uninitialized const connectionId binding ${identifier.name}`,
-                );
-            }
-            if (context.seen.has(variable)) {
-                // Const chains can reference each other; stop cycles before
-                // recursion loops forever:
-                //   const A = B;
-                //   const B = A;
-                throw unsupportedConnectionId(
-                    context.filePath,
-                    `cyclic connectionId binding ${identifier.name}`,
-                );
-            }
-
-            // Follow supported const chains:
-            //   const HTTP = 'abc';
-            //   const ACTIVE_HTTP = HTTP;
-            //   request({ connectionId: ACTIVE_HTTP });
-            context.seen.add(variable);
-            try {
-                return resolveConnectionIdValue(binding.init, context);
-            } finally {
-                context.seen.delete(variable);
-            }
-    }
+    return resolveLocalStaticDefinitionValue(definition, context);
 }
 
 function resolveLocalStaticDefinitionValue(
@@ -569,104 +309,34 @@ function resolveObjectExpressionValue(
         throw unsupportedConnectionId(context.filePath, 'non-object connectionId member values');
     }
 
-    if (context.moduleGraph) {
-        const definition = resolveStaticDefinitionForIdentifier(
-            context.moduleGraph.modules,
-            context.moduleGraph.moduleId,
-            node,
-        );
+    const definition = resolveStaticDefinitionForIdentifier(
+        context.moduleGraph.modules,
+        context.moduleGraph.moduleId,
+        node,
+    );
 
-        if (definition.kind === 'unsupported') {
-            throw unsupportedStaticDefinitionConnectionId(context.filePath, node, definition);
-        }
-        if (!definition.binding.expression) {
-            throw unsupportedConnectionId(
-                definition.moduleId,
-                `uninitialized const connectionId object binding ${definition.variable.name}`,
-            );
-        }
-        if (context.seen.has(definition.variable)) {
-            throw unsupportedConnectionId(
-                definition.moduleId,
-                `cyclic connectionId object binding ${definition.variable.name}`,
-            );
-        }
-
-        const definitionContext = getModuleConnectionIdContext(context, definition.moduleId);
-        context.seen.add(definition.variable);
-        try {
-            return resolveObjectExpressionValue(definition.binding.expression, definitionContext);
-        } finally {
-            context.seen.delete(definition.variable);
-        }
+    if (definition.kind === 'unsupported') {
+        throw unsupportedStaticDefinitionConnectionId(context.filePath, node, definition);
     }
-
-    const variable = resolveIdentifier(node, context.scopeAnalysis);
-    if (!variable) {
-        throw unsupportedConnectionId(context.filePath, `unresolved object binding ${node.name}`);
-    }
-    // Imported maps require module graph analysis:
-    //   import { CONNECTIONS } from './connections';
-    //   request({ connectionId: CONNECTIONS.HTTP });
-    if (isImportVariable(variable)) {
+    if (!definition.binding.expression) {
         throw unsupportedConnectionId(
-            context.filePath,
-            `imported connectionId object binding ${node.name}`,
+            definition.moduleId,
+            `uninitialized const connectionId object binding ${definition.variable.name}`,
+        );
+    }
+    if (context.seen.has(definition.variable)) {
+        throw unsupportedConnectionId(
+            definition.moduleId,
+            `cyclic connectionId object binding ${definition.variable.name}`,
         );
     }
 
-    const binding = context.bindings.byVariable.get(variable);
-    if (!binding) {
-        throw unsupportedConnectionId(
-            context.filePath,
-            `non-top-level connectionId object binding ${node.name}`,
-        );
-    }
-    if (binding.kind === 'mutable') {
-        // A mutable map can change before the action call runs:
-        //   let CONNECTIONS = { HTTP: 'abc' };
-        //   CONNECTIONS = loadConnections();
-        throw unsupportedConnectionId(
-            context.filePath,
-            `mutable ${binding.declarationKind} connectionId object binding ${node.name}`,
-        );
-    }
-    if (binding.kind === 'unsupported-pattern') {
-        // Destructured maps are not expected here, but keep the failure explicit
-        // for consistency with direct identifier resolution.
-        throw unsupportedConnectionId(
-            context.filePath,
-            `destructured connectionId object binding ${node.name}`,
-        );
-    }
-    if (!binding.init) {
-        throw unsupportedConnectionId(
-            context.filePath,
-            `uninitialized const connectionId object binding ${node.name}`,
-        );
-    }
-
-    if (context.seen.has(variable)) {
-        // Const object aliases can reference each other; stop cycles before
-        // recursion loops forever:
-        //   const A = B;
-        //   const B = A;
-        throw unsupportedConnectionId(
-            context.filePath,
-            `cyclic connectionId object binding ${node.name}`,
-        );
-    }
-
-    context.seen.add(variable);
+    const definitionContext = getModuleConnectionIdContext(context, definition.moduleId);
+    context.seen.add(definition.variable);
     try {
-        const objectExpression = resolveObjectExpressionValue(binding.init, context);
-        // `CONNECTIONS.HTTP` only works when `CONNECTIONS` is visibly an object
-        // literal in this file, directly or through const aliases:
-        //   const CONNECTIONS = { HTTP: 'abc' };
-        //   const ACTIVE_CONNECTIONS = CONNECTIONS;
-        return objectExpression;
+        return resolveObjectExpressionValue(definition.binding.expression, definitionContext);
     } finally {
-        context.seen.delete(variable);
+        context.seen.delete(definition.variable);
     }
 }
 
@@ -675,10 +345,6 @@ function getModuleConnectionIdContext(
     moduleId: string,
 ): ConnectionIdResolutionContext {
     const moduleGraph = context.moduleGraph;
-    if (!moduleGraph) {
-        return context;
-    }
-
     if (moduleGraph.moduleId === moduleId) {
         return context;
     }
@@ -692,7 +358,6 @@ function getModuleConnectionIdContext(
     }
 
     return {
-        bindings: { byVariable: new Map() },
         filePath: moduleId,
         moduleGraph: {
             modules: moduleGraph.modules,

--- a/packages/plugins/apps/src/backend/ast-parsing/extract-connection-ids-from-module-graph.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/extract-connection-ids-from-module-graph.test.ts
@@ -10,6 +10,7 @@ import { createParsedModuleRecord, type ParsedModuleRecord } from './module-grap
 
 const buildRoot = '/project';
 const entryId = '/project/src/backend/actions.backend.js';
+const actionCatalogId = '/project/node_modules/@datadog/action-catalog/http/http.js';
 
 function parse(code: string): Program {
     return parseAst(code) as Program;
@@ -289,37 +290,374 @@ describe('Backend Functions - extractConnectionIdsFromModuleGraph', () => {
         expect(() => extract([entry])).toThrow(`uncollected local import ${missingId}`);
     });
 
-    test('Should keep imported connection ID values unsupported in reachable helpers', () => {
-        const helperId = '/project/src/backend/helpers/http.js';
-        const idsId = '/project/src/backend/helpers/ids.js';
-        const entry = createRecord(
-            entryId,
-            `
+    test.each([
+        {
+            description: 'string constants',
+            idsCode: "export const HTTP_CONNECTION_ID = 'conn-imported';",
+            helperValue: 'HTTP_CONNECTION_ID',
+            expected: 'conn-imported',
+        },
+        {
+            description: 'static template literals',
+            idsCode: 'export const HTTP_CONNECTION_ID = `conn-template`;',
+            helperValue: 'HTTP_CONNECTION_ID',
+            expected: 'conn-template',
+        },
+        {
+            description: 'const-to-const chains',
+            idsCode: `
+                const BASE_CONNECTION_ID = 'conn-chain';
+                export const HTTP_CONNECTION_ID = BASE_CONNECTION_ID;
+            `,
+            helperValue: 'HTTP_CONNECTION_ID',
+            expected: 'conn-chain',
+        },
+        {
+            description: 'object member reads',
+            idsCode: "export const CONNECTIONS = { HTTP: 'conn-object' };",
+            helperValue: 'CONNECTIONS.HTTP',
+            expected: 'conn-object',
+        },
+        {
+            description: 'nested object member reads',
+            idsCode: "export const CONNECTIONS = { HTTP: { PROD: 'conn-nested' } };",
+            helperValue: 'CONNECTIONS.HTTP.PROD',
+            expected: 'conn-nested',
+        },
+        {
+            description: 'object member values that reference constants',
+            idsCode: `
+                const HTTP_CONNECTION_ID = 'conn-object-chain';
+                export const CONNECTIONS = { HTTP: HTTP_CONNECTION_ID };
+            `,
+            helperValue: 'CONNECTIONS.HTTP',
+            expected: 'conn-object-chain',
+        },
+    ])(
+        'Should resolve imported connection ID $description',
+        ({ idsCode, helperValue, expected }) => {
+            const helperId = '/project/src/backend/helpers/http.js';
+            const idsId = '/project/src/backend/helpers/ids.js';
+            const entry = createRecord(
+                entryId,
+                `
                 import { getEcho } from './helpers/http.js';
 
                 export function run() {
                     return getEcho();
                 }
             `,
-            [helperId],
-        );
-        const helper = createRecord(
-            helperId,
-            `
+                [helperId],
+            );
+            const helper = createRecord(
+                helperId,
+                `
                 import { request } from '@datadog/action-catalog/http/http';
-                import { HTTP_CONNECTION_ID } from './ids.js';
+                import { CONNECTIONS, HTTP_CONNECTION_ID } from './ids.js';
 
                 export function getEcho() {
-                    return request({ connectionId: HTTP_CONNECTION_ID, inputs: {} });
+                    return request({ connectionId: ${helperValue}, inputs: {} });
                 }
             `,
-            [idsId],
-        );
+                [actionCatalogId, idsId],
+            );
+            const ids = createRecord(idsId, idsCode);
 
-        expect(() => extract([entry, helper])).toThrow(
-            'imported connectionId binding HTTP_CONNECTION_ID',
-        );
-    });
+            expect(extract([entry, helper, ids])).toEqual([expected]);
+        },
+    );
+
+    test.each([
+        {
+            description: 'local export aliases',
+            idsCode: `
+                const HTTP_CONNECTION_ID = 'conn-alias';
+                export { HTTP_CONNECTION_ID as ACTIVE_HTTP_CONNECTION_ID };
+            `,
+            indexCode: "export { ACTIVE_HTTP_CONNECTION_ID } from './ids.js';",
+            importName: 'ACTIVE_HTTP_CONNECTION_ID',
+            expected: 'conn-alias',
+        },
+        {
+            description: 'named re-export aliases',
+            idsCode: "export const HTTP_CONNECTION_ID = 'conn-re-export';",
+            indexCode:
+                "export { HTTP_CONNECTION_ID as ACTIVE_HTTP_CONNECTION_ID } from './ids.js';",
+            importName: 'ACTIVE_HTTP_CONNECTION_ID',
+            expected: 'conn-re-export',
+        },
+        {
+            description: 'local import/export relays',
+            idsCode: "export const HTTP_CONNECTION_ID = 'conn-relay';",
+            indexCode: `
+                import { HTTP_CONNECTION_ID } from './ids.js';
+                export { HTTP_CONNECTION_ID as ACTIVE_HTTP_CONNECTION_ID };
+            `,
+            importName: 'ACTIVE_HTTP_CONNECTION_ID',
+            expected: 'conn-relay',
+        },
+        {
+            description: 'unambiguous star exports',
+            idsCode: "export const HTTP_CONNECTION_ID = 'conn-star-export';",
+            indexCode: "export * from './ids.js';",
+            importName: 'HTTP_CONNECTION_ID',
+            expected: 'conn-star-export',
+        },
+    ])(
+        'Should resolve imported connection IDs through $description',
+        ({ idsCode, indexCode, importName, expected }) => {
+            const helperId = '/project/src/backend/helpers/http.js';
+            const indexId = '/project/src/backend/helpers/index.js';
+            const idsId = '/project/src/backend/helpers/ids.js';
+            const entry = createRecord(
+                entryId,
+                `
+                    import { getEcho } from './helpers/http.js';
+
+                    export function run() {
+                        return getEcho();
+                    }
+                `,
+                [helperId],
+            );
+            const helper = createRecord(
+                helperId,
+                `
+                    import { request } from '@datadog/action-catalog/http/http';
+                    import { ${importName} } from './index.js';
+
+                    export function getEcho() {
+                        return request({ connectionId: ${importName}, inputs: {} });
+                    }
+                `,
+                [actionCatalogId, indexId],
+            );
+            const index = createRecord(indexId, indexCode, [idsId]);
+            const ids = createRecord(idsId, idsCode);
+
+            expect(extract([entry, helper, index, ids])).toEqual([expected]);
+        },
+    );
+
+    test.each([
+        {
+            description: 'missing exports',
+            records: () => {
+                const helperId = '/project/src/backend/helpers/http.js';
+                const indexId = '/project/src/backend/helpers/index.js';
+                const idsId = '/project/src/backend/helpers/ids.js';
+                return [
+                    createRecord(entryId, "import { getEcho } from './helpers/http.js';", [
+                        helperId,
+                    ]),
+                    createRecord(
+                        helperId,
+                        `
+                            import { request } from '@datadog/action-catalog/http/http';
+                            import { HTTP_CONNECTION_ID } from './index.js';
+                            request({ connectionId: HTTP_CONNECTION_ID, inputs: {} });
+                        `,
+                        [actionCatalogId, indexId],
+                    ),
+                    createRecord(indexId, "export * from './ids.js';", [idsId]),
+                    createRecord(idsId, "export const OTHER_CONNECTION_ID = 'conn-other';"),
+                ];
+            },
+            expectedMessage: 'unsupported static definition missing-export',
+        },
+        {
+            description: 'ambiguous star exports',
+            records: () => {
+                const helperId = '/project/src/backend/helpers/http.js';
+                const indexId = '/project/src/backend/helpers/index.js';
+                const oneId = '/project/src/backend/helpers/one.js';
+                const twoId = '/project/src/backend/helpers/two.js';
+                return [
+                    createRecord(entryId, "import { getEcho } from './helpers/http.js';", [
+                        helperId,
+                    ]),
+                    createRecord(
+                        helperId,
+                        `
+                            import { request } from '@datadog/action-catalog/http/http';
+                            import { HTTP_CONNECTION_ID } from './index.js';
+                            request({ connectionId: HTTP_CONNECTION_ID, inputs: {} });
+                        `,
+                        [actionCatalogId, indexId],
+                    ),
+                    createRecord(
+                        indexId,
+                        `
+                            export * from './one.js';
+                            export * from './two.js';
+                        `,
+                        [oneId, twoId],
+                    ),
+                    createRecord(oneId, "export const HTTP_CONNECTION_ID = 'conn-one';"),
+                    createRecord(twoId, "export const HTTP_CONNECTION_ID = 'conn-two';"),
+                ];
+            },
+            expectedMessage: 'unsupported static definition ambiguous-star-export',
+        },
+        {
+            description: 'import/export cycles',
+            records: () => {
+                const helperId = '/project/src/backend/helpers/http.js';
+                const oneId = '/project/src/backend/helpers/one.js';
+                const twoId = '/project/src/backend/helpers/two.js';
+                return [
+                    createRecord(entryId, "import { getEcho } from './helpers/http.js';", [
+                        helperId,
+                    ]),
+                    createRecord(
+                        helperId,
+                        `
+                            import { request } from '@datadog/action-catalog/http/http';
+                            import { HTTP_CONNECTION_ID } from './one.js';
+                            request({ connectionId: HTTP_CONNECTION_ID, inputs: {} });
+                        `,
+                        [actionCatalogId, oneId],
+                    ),
+                    createRecord(oneId, "export * from './two.js';", [twoId]),
+                    createRecord(twoId, "export * from './one.js';", [oneId]),
+                ];
+            },
+            expectedMessage: 'unsupported static definition cycle',
+        },
+        {
+            description: 'default imports',
+            records: () => {
+                const helperId = '/project/src/backend/helpers/http.js';
+                const idsId = '/project/src/backend/helpers/ids.js';
+                return [
+                    createRecord(entryId, "import { getEcho } from './helpers/http.js';", [
+                        helperId,
+                    ]),
+                    createRecord(
+                        helperId,
+                        `
+                            import { request } from '@datadog/action-catalog/http/http';
+                            import HTTP_CONNECTION_ID from './ids.js';
+                            request({ connectionId: HTTP_CONNECTION_ID, inputs: {} });
+                        `,
+                        [actionCatalogId, idsId],
+                    ),
+                    createRecord(idsId, "export default 'conn-http';"),
+                ];
+            },
+            expectedMessage: 'unsupported static definition default-import',
+        },
+        {
+            description: 'namespace imports',
+            records: () => {
+                const helperId = '/project/src/backend/helpers/http.js';
+                const idsId = '/project/src/backend/helpers/ids.js';
+                return [
+                    createRecord(entryId, "import { getEcho } from './helpers/http.js';", [
+                        helperId,
+                    ]),
+                    createRecord(
+                        helperId,
+                        `
+                            import { request } from '@datadog/action-catalog/http/http';
+                            import * as ids from './ids.js';
+                            request({ connectionId: ids.HTTP_CONNECTION_ID, inputs: {} });
+                        `,
+                        [actionCatalogId, idsId],
+                    ),
+                    createRecord(idsId, "export const HTTP_CONNECTION_ID = 'conn-http';"),
+                ];
+            },
+            expectedMessage: 'unsupported static definition namespace-import',
+        },
+        {
+            description: 'mutable exports',
+            records: () => {
+                const helperId = '/project/src/backend/helpers/http.js';
+                const idsId = '/project/src/backend/helpers/ids.js';
+                return [
+                    createRecord(entryId, "import { getEcho } from './helpers/http.js';", [
+                        helperId,
+                    ]),
+                    createRecord(
+                        helperId,
+                        `
+                            import { request } from '@datadog/action-catalog/http/http';
+                            import { HTTP_CONNECTION_ID } from './ids.js';
+                            request({ connectionId: HTTP_CONNECTION_ID, inputs: {} });
+                        `,
+                        [actionCatalogId, idsId],
+                    ),
+                    createRecord(idsId, "export let HTTP_CONNECTION_ID = 'conn-http';"),
+                ];
+            },
+            expectedMessage: 'unsupported static definition mutable-binding',
+        },
+        {
+            description: 'reassigned exports',
+            records: () => {
+                const helperId = '/project/src/backend/helpers/http.js';
+                const idsId = '/project/src/backend/helpers/ids.js';
+                return [
+                    createRecord(entryId, "import { getEcho } from './helpers/http.js';", [
+                        helperId,
+                    ]),
+                    createRecord(
+                        helperId,
+                        `
+                            import { request } from '@datadog/action-catalog/http/http';
+                            import { HTTP_CONNECTION_ID } from './ids.js';
+                            request({ connectionId: HTTP_CONNECTION_ID, inputs: {} });
+                        `,
+                        [actionCatalogId, idsId],
+                    ),
+                    createRecord(
+                        idsId,
+                        `
+                            export const HTTP_CONNECTION_ID = 'conn-http';
+                            HTTP_CONNECTION_ID = 'conn-other';
+                        `,
+                    ),
+                ];
+            },
+            expectedMessage: 'unsupported static definition unsupported-binding',
+        },
+        {
+            description: 'unsupported exported bindings',
+            records: () => {
+                const helperId = '/project/src/backend/helpers/http.js';
+                const idsId = '/project/src/backend/helpers/ids.js';
+                return [
+                    createRecord(entryId, "import { getEcho } from './helpers/http.js';", [
+                        helperId,
+                    ]),
+                    createRecord(
+                        helperId,
+                        `
+                            import { request } from '@datadog/action-catalog/http/http';
+                            import { getConnectionId } from './ids.js';
+                            request({ connectionId: getConnectionId, inputs: {} });
+                        `,
+                        [actionCatalogId, idsId],
+                    ),
+                    createRecord(
+                        idsId,
+                        `
+                            export function getConnectionId() {
+                                return 'conn-http';
+                            }
+                        `,
+                    ),
+                ];
+            },
+            expectedMessage: 'unsupported static definition unsupported-binding',
+        },
+    ])(
+        'Should fail closed for imported connection ID $description',
+        ({ records, expectedMessage }) => {
+            expect(() => extract(records())).toThrow(expectedMessage);
+        },
+    );
 
     test('Should read transformed local TypeScript helpers as collected records', () => {
         const helperId = '/project/src/backend/helpers/http.ts';

--- a/packages/plugins/apps/src/backend/ast-parsing/extract-connection-ids-from-module-graph.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/extract-connection-ids-from-module-graph.ts
@@ -21,7 +21,10 @@ export function extractConnectionIdsFromModuleGraph(
     // extraction cost is linear in reachable app-local modules, without
     // reparsing source files here.
     walkModuleGraph(entryId, modules, buildRoot, ({ moduleId, record }) => {
-        const moduleConnectionIds = extractConnectionIds(record.ast, moduleId);
+        const moduleConnectionIds = extractConnectionIds(record.ast, moduleId, {
+            modules,
+            record,
+        });
         for (const connectionId of moduleConnectionIds) {
             connectionIds.add(connectionId);
         }

--- a/packages/plugins/apps/src/backend/ast-parsing/extract-connection-ids.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/extract-connection-ids.test.ts
@@ -6,11 +6,29 @@ import type { Program } from 'estree';
 import { parseAst } from 'rollup/parseAst';
 
 import { extractConnectionIds } from './extract-connection-ids';
+import { createParsedModuleRecord, type ParsedModuleRecord } from './module-graph';
 
 const filePath = '/project/src/backend/actions.backend.js';
+const buildRoot = '/project';
 
 function parse(code: string): Program {
     return parseAst(code) as Program;
+}
+
+function createRecord(ast: Program): ParsedModuleRecord {
+    const record = createParsedModuleRecord(filePath, buildRoot, ast);
+    if (!record) {
+        throw new Error(`Expected ${filePath} to create a parsed module record`);
+    }
+    return record;
+}
+
+function extract(ast: Program): string[] {
+    const record = createRecord(ast);
+    return extractConnectionIds(record.ast, filePath, {
+        modules: new Map([[record.id, record]]),
+        record,
+    });
 }
 
 describe('Backend Functions - extractConnectionIds', () => {
@@ -23,7 +41,7 @@ describe('Backend Functions - extractConnectionIds', () => {
             }
         `);
 
-        expect(extractConnectionIds(ast, filePath)).toEqual(['conn-b']);
+        expect(extract(ast)).toEqual(['conn-b']);
     });
 
     test('Should dedupe and sort connection IDs', () => {
@@ -37,7 +55,7 @@ describe('Backend Functions - extractConnectionIds', () => {
             }
         `);
 
-        expect(extractConnectionIds(ast, filePath)).toEqual(['conn-a', 'conn-b']);
+        expect(extract(ast)).toEqual(['conn-a', 'conn-b']);
     });
 
     test('Should include same-file helper action calls', () => {
@@ -53,7 +71,7 @@ describe('Backend Functions - extractConnectionIds', () => {
             }
         `);
 
-        expect(extractConnectionIds(ast, filePath)).toEqual(['conn-helper']);
+        expect(extract(ast)).toEqual(['conn-helper']);
     });
 
     test('Should detect default and namespace action-catalog imports', () => {
@@ -67,7 +85,7 @@ describe('Backend Functions - extractConnectionIds', () => {
             }
         `);
 
-        expect(extractConnectionIds(ast, filePath)).toEqual(['conn-default', 'conn-namespace']);
+        expect(extract(ast)).toEqual(['conn-default', 'conn-namespace']);
     });
 
     test('Should ignore non-action-catalog calls with connectionId properties', () => {
@@ -79,7 +97,7 @@ describe('Backend Functions - extractConnectionIds', () => {
             }
         `);
 
-        expect(extractConnectionIds(ast, filePath)).toEqual([]);
+        expect(extract(ast)).toEqual([]);
     });
 
     test('Should ignore action-catalog object arguments without connectionId', () => {
@@ -91,7 +109,7 @@ describe('Backend Functions - extractConnectionIds', () => {
             }
         `);
 
-        expect(extractConnectionIds(ast, filePath)).toEqual([]);
+        expect(extract(ast)).toEqual([]);
     });
 
     test('Should ignore type-only action-catalog imports', () => {
@@ -108,7 +126,7 @@ describe('Backend Functions - extractConnectionIds', () => {
         // ESTree field that a TypeScript-aware parser would add.
         importDeclaration.importKind = 'type';
 
-        expect(extractConnectionIds(ast, filePath)).toEqual([]);
+        expect(extract(ast)).toEqual([]);
     });
 
     test('Should ignore type-only action-catalog import specifiers', () => {
@@ -128,7 +146,7 @@ describe('Backend Functions - extractConnectionIds', () => {
         // patch the ESTree field that a TypeScript-aware parser would add.
         importSpecifier.importKind = 'type';
 
-        expect(extractConnectionIds(ast, filePath)).toEqual([]);
+        expect(extract(ast)).toEqual([]);
     });
 
     test.each([
@@ -216,7 +234,7 @@ describe('Backend Functions - extractConnectionIds', () => {
     ])(
         'Should not treat shadowed action-catalog import names as action calls: $description',
         ({ code }) => {
-            expect(extractConnectionIds(parse(code), filePath)).toEqual([]);
+            expect(extract(parse(code))).toEqual([]);
         },
     );
 
@@ -352,7 +370,7 @@ describe('Backend Functions - extractConnectionIds', () => {
             ${code}
         `);
 
-        expect(extractConnectionIds(ast, filePath)).toEqual(expected);
+        expect(extract(ast)).toEqual(expected);
     });
 
     test.each([
@@ -382,7 +400,7 @@ describe('Backend Functions - extractConnectionIds', () => {
                     request({ connectionId: ID, inputs: {} });
                 }
             `,
-            expectedMessage: 'mutable let connectionId binding ID',
+            expectedMessage: 'unsupported static definition mutable-binding',
         },
         {
             description: 'mutable var bindings',
@@ -392,7 +410,7 @@ describe('Backend Functions - extractConnectionIds', () => {
                     request({ connectionId: ID, inputs: {} });
                 }
             `,
-            expectedMessage: 'mutable var connectionId binding ID',
+            expectedMessage: 'unsupported static definition mutable-binding',
         },
         {
             description: 'unresolved identifiers',
@@ -401,7 +419,7 @@ describe('Backend Functions - extractConnectionIds', () => {
                     request({ connectionId: ID, inputs: {} });
                 }
             `,
-            expectedMessage: 'unresolved identifier ID',
+            expectedMessage: 'unsupported static definition unresolved-identifier',
         },
         {
             description: 'function-local const bindings',
@@ -411,7 +429,7 @@ describe('Backend Functions - extractConnectionIds', () => {
                     request({ connectionId: ID, inputs: {} });
                 }
             `,
-            expectedMessage: 'non-top-level connectionId binding ID',
+            expectedMessage: 'unsupported static definition missing-static-binding',
         },
         {
             description: 'imported identifiers',
@@ -421,7 +439,7 @@ describe('Backend Functions - extractConnectionIds', () => {
                     request({ connectionId: ID, inputs: {} });
                 }
             `,
-            expectedMessage: 'imported connectionId binding ID',
+            expectedMessage: 'unsupported static definition missing-module-record',
         },
         {
             description: 'imported object member reads',
@@ -431,7 +449,7 @@ describe('Backend Functions - extractConnectionIds', () => {
                     request({ connectionId: CONNECTIONS.HTTP, inputs: {} });
                 }
             `,
-            expectedMessage: 'imported connectionId object binding CONNECTIONS',
+            expectedMessage: 'unsupported static definition missing-module-record',
         },
         {
             description: 'dynamic template literals',
@@ -513,7 +531,7 @@ describe('Backend Functions - extractConnectionIds', () => {
                     request({ connectionId: process.env.ID, inputs: {} });
                 }
             `,
-            expectedMessage: 'unresolved object binding process',
+            expectedMessage: 'unsupported static definition unresolved-identifier',
         },
         {
             description: 'const cycles',
@@ -532,7 +550,7 @@ describe('Backend Functions - extractConnectionIds', () => {
             ${code}
         `);
 
-        expect(() => extractConnectionIds(ast, filePath)).toThrow(expectedMessage);
+        expect(() => extract(ast)).toThrow(expectedMessage);
     });
 
     test.each([
@@ -617,7 +635,7 @@ describe('Backend Functions - extractConnectionIds', () => {
                 }
             `);
 
-            expect(() => extractConnectionIds(ast, filePath)).toThrow(expectedMessage);
+            expect(() => extract(ast)).toThrow(expectedMessage);
         },
     );
 
@@ -628,6 +646,6 @@ describe('Backend Functions - extractConnectionIds', () => {
             }
         `);
 
-        expect(extractConnectionIds(ast, filePath)).toEqual([]);
+        expect(extract(ast)).toEqual([]);
     });
 });

--- a/packages/plugins/apps/src/backend/ast-parsing/extract-connection-ids.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/extract-connection-ids.ts
@@ -13,17 +13,30 @@ import {
     collectSameModuleConnectionIdBindings,
     extractConnectionIdFromActionCall,
 } from './connection-id-values';
+import type { ParsedModuleRecord } from './module-graph';
 import { analyzeModuleScope } from './module-scope';
 import { ensureProgram } from './type-guards';
 
-export function extractConnectionIds(ast: BaseNode, filePath: string): string[] {
+export interface ConnectionIdExtractionContext {
+    modules: ReadonlyMap<string, ParsedModuleRecord>;
+    record: ParsedModuleRecord;
+}
+
+export function extractConnectionIds(
+    ast: BaseNode,
+    filePath: string,
+    context?: ConnectionIdExtractionContext,
+): string[] {
     const program = ensureProgram(ast, filePath);
 
     const imports = collectActionCatalogImports(program);
-    const moduleScope = analyzeModuleScope(program);
+    const moduleScope = context?.record.scopeAnalysis ?? analyzeModuleScope(program);
     const scopeAnalysis = analyzeActionCatalogScopes(moduleScope, imports);
     const bindings = collectSameModuleConnectionIdBindings(program, moduleScope);
     const connectionIds = new Set<string>();
+    const moduleGraph = context
+        ? { modules: context.modules, moduleId: context.record.id }
+        : undefined;
 
     for (const callSite of findActionCatalogCallSites(program, scopeAnalysis, filePath)) {
         const connectionId = extractConnectionIdFromActionCall(
@@ -31,6 +44,7 @@ export function extractConnectionIds(ast: BaseNode, filePath: string): string[] 
             bindings,
             moduleScope,
             filePath,
+            moduleGraph,
         );
         if (connectionId) {
             connectionIds.add(connectionId);

--- a/packages/plugins/apps/src/backend/ast-parsing/extract-connection-ids.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/extract-connection-ids.ts
@@ -9,12 +9,8 @@ import {
     findActionCatalogCallSites,
 } from './action-catalog-call-sites';
 import { collectActionCatalogImports } from './action-catalog-imports';
-import {
-    collectSameModuleConnectionIdBindings,
-    extractConnectionIdFromActionCall,
-} from './connection-id-values';
+import { extractConnectionIdFromActionCall } from './connection-id-values';
 import type { ParsedModuleRecord } from './module-graph';
-import { analyzeModuleScope } from './module-scope';
 import { ensureProgram } from './type-guards';
 
 export interface ConnectionIdExtractionContext {
@@ -25,23 +21,19 @@ export interface ConnectionIdExtractionContext {
 export function extractConnectionIds(
     ast: BaseNode,
     filePath: string,
-    context?: ConnectionIdExtractionContext,
+    context: ConnectionIdExtractionContext,
 ): string[] {
     const program = ensureProgram(ast, filePath);
 
     const imports = collectActionCatalogImports(program);
-    const moduleScope = context?.record.scopeAnalysis ?? analyzeModuleScope(program);
+    const moduleScope = context.record.scopeAnalysis;
     const scopeAnalysis = analyzeActionCatalogScopes(moduleScope, imports);
-    const bindings = collectSameModuleConnectionIdBindings(program, moduleScope);
     const connectionIds = new Set<string>();
-    const moduleGraph = context
-        ? { modules: context.modules, moduleId: context.record.id }
-        : undefined;
+    const moduleGraph = { modules: context.modules, moduleId: context.record.id };
 
     for (const callSite of findActionCatalogCallSites(program, scopeAnalysis, filePath)) {
         const connectionId = extractConnectionIdFromActionCall(
             callSite,
-            bindings,
             moduleScope,
             filePath,
             moduleGraph,


### PR DESCRIPTION
## Motivation

This is the next PR in the backend connection ID analysis stack. The previous PR adds a domain-neutral static definition resolver that can follow identifier references through named imports, export aliases, re-exports, and star exports. Connection ID extraction can now reuse that resolver instead of maintaining its own import/export traversal.

## Changes

Wires module-graph connection ID extraction into the static definition resolver. `extractConnectionIds(...)` now requires `ParsedModuleRecord` and module-map context so `connection-id-values.ts` can resolve the actual `connectionId` identifier, or the root identifier of a member expression, through `resolveStaticDefinitionForIdentifier(...)` and evaluate the returned const binding in the module where that definition lives.

Supported cases:

- Imported string constants
- Imported static template literals without interpolation
- Imported const-to-const chains across module contexts
- Imported object roots such as `CONNECTIONS.HTTP`
- Imported nested object member paths such as `CONNECTIONS.HTTP.PROD`
- Local export aliases
- Named re-export aliases
- Local import/export relays
- Unambiguous star exports
- Existing same-module inline, const, and object connection IDs

Unsupported cases continue to fail closed with connection ID errors:

- Missing exports
- Ambiguous star exports
- Import/export cycles
- Default imports
- Namespace imports
- Mutable bindings
- Reassigned bindings
- Unsupported top-level declarations and binding patterns
- Dynamic object shapes already rejected by the object resolver

This removes the older optional same-module binding-map path from connection ID value resolution. Same-module identifiers now use the same static definition resolver as imported identifiers.

## QA Instructions

No manual QA needed. This is an internal AST-analysis change covered by unit tests and does not change manifest wiring outside the backend connection ID extractor.

## Blast Radius

This affects High Code Apps backend connection ID extraction in `@dd/apps-plugin` when analyzing reachable app-local backend modules. It expands supported static import/re-export shapes while preserving fail-closed behavior for unsupported module graph and value shapes.

## Documentation

-   [How to reliably make frontend production changes](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2286781319/Frontend+Production+Changesp)
-   [PR Description Guidelines](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/3120334387/PR+Checklist+and+Guidelines+for+Web+UI)
-   [Deploy steps](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/1457750032/)