### PR TITLE
Read backend-function args from $.backendFunctionArgs to fix code injection

### DIFF
--- a/packages/plugins/apps/src/backend/virtual-entry.test.ts
+++ b/packages/plugins/apps/src/backend/virtual-entry.test.ts
@@ -47,14 +47,20 @@ describe('Backend Functions - generateVirtualEntryContent', () => {
             expect(result).toContain('globalThis.$ = $');
         });
 
-        test('Should include backendFunctionArgs template expression', () => {
+        test('Should read args from $.backendFunctionArgs (no source-text substitution)', () => {
             const result = generateVirtualEntryContent(
                 'myHandler',
                 '/src/handler.ts',
                 PROJECT_ROOT,
             );
+            expect(result).toContain('const args = $.backendFunctionArgs ?? [];');
+            // The previous design textually substituted args into a single-quoted
+            // string literal, which allowed `'` in user input to break out and
+            // inject arbitrary JS. The generated script must never wrap a host
+            // template expression inside a quoted string.
             // eslint-disable-next-line no-template-curly-in-string
-            expect(result).toContain("JSON.parse('${backendFunctionArgs}'");
+            expect(result).not.toContain('${backendFunctionArgs}');
+            expect(result).not.toContain('JSON.parse(');
         });
 
         test('Should call the function with spread args', () => {
@@ -128,38 +134,99 @@ describe('Backend Functions - generateDevVirtualEntryContent', () => {
         jest.spyOn(shared, 'isActionCatalogInstalled').mockReturnValue(false);
     });
 
-    test('Should import the function by name from the entry path', () => {
-        const result = generateDevVirtualEntryContent('greet', '/src/backend/greet.ts', []);
-        expect(result).toContain('import { greet } from "/src/backend/greet.ts"');
+    test('Should produce identical output to generateVirtualEntryContent', () => {
+        // Dev and prod share the same runtime contract ($.backendFunctionArgs),
+        // so the dev codegen must produce the same source as production.
+        const dev = generateDevVirtualEntryContent('greet', '/src/greet.ts', PROJECT_ROOT);
+        const prod = generateVirtualEntryContent('greet', '/src/greet.ts', PROJECT_ROOT);
+        expect(dev).toBe(prod);
     });
 
-    test('Should export an async main($) function', () => {
-        const result = generateDevVirtualEntryContent('greet', '/src/greet.ts', []);
-        expect(result).toContain('export async function main($)');
-    });
-
-    test('Should inline args as JSON instead of template expression', () => {
-        const result = generateDevVirtualEntryContent('greet', '/src/greet.ts', ['hello', 42]);
-        expect(result).toContain('const args = ["hello",42]');
+    test('Should read args from $.backendFunctionArgs', () => {
+        const result = generateDevVirtualEntryContent('greet', '/src/greet.ts', PROJECT_ROOT);
+        expect(result).toContain('const args = $.backendFunctionArgs ?? [];');
         // eslint-disable-next-line no-template-curly-in-string
         expect(result).not.toContain('${backendFunctionArgs}');
     });
+});
 
-    test('Should handle empty args array', () => {
-        const result = generateDevVirtualEntryContent('greet', '/src/greet.ts', []);
-        expect(result).toContain('const args = []');
+/**
+ * The bug being fixed: previously, args were substituted as JSON text into a
+ * single-quoted JS string literal. Any string arg containing `'` broke out of
+ * the literal — both a runtime parser error and a code-injection vector.
+ *
+ * These tests evaluate the generated `main` function against adversarial
+ * inputs to confirm values now round-trip losslessly via the $ context.
+ */
+describe('Backend Functions - args round-trip via $.backendFunctionArgs', () => {
+    beforeEach(() => {
+        jest.restoreAllMocks();
+        jest.spyOn(shared, 'isActionCatalogInstalled').mockReturnValue(false);
     });
 
-    test('Should call the function with spread args', () => {
-        const result = generateDevVirtualEntryContent('greet', '/src/greet.ts', []);
-        expect(result).toContain('await greet(...args)');
-    });
-
-    test('Should include action-catalog import when installed', () => {
-        jest.spyOn(shared, 'isActionCatalogInstalled').mockReturnValue(true);
-        const result = generateDevVirtualEntryContent('greet', '/src/greet.ts', []);
-        expect(result).toContain(
-            "import { setExecuteActionImplementation } from '@datadog/action-catalog/action-execution'",
+    // Extract the body of the generated `main($)` function so we can eval it
+    // directly with a custom $ that includes a mocked handler import.
+    function buildMainFromSource(source: string, handler: (...args: unknown[]) => unknown) {
+        // The generated source has `import { handler } from "..."` at the top,
+        // which we can't execute outside a module system. Strip imports and
+        // inject the handler via $ instead.
+        const body = source
+            .split('\n')
+            .filter((line) => !line.trimStart().startsWith('import '))
+            .join('\n')
+            // Replace the call site with a $-bound handler we control.
+            .replace(/await myHandler\(\.\.\.args\)/, 'await $.__handler(...args)');
+        // The generated code declares globalThis.$, which has no effect in this
+        // sandbox but is harmless. Wrap the body so we can return main().
+        const wrapper = `${body}\nreturn main($);`;
+        // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+        const fn = new Function(
+            '$',
+            wrapper.replace(/export async function main/, 'async function main'),
         );
+        return ($: Record<string, unknown>) => fn({ ...$, __handler: handler });
+    }
+
+    const adversarialInputs = [
+        { description: 'single quote', value: "don't break" },
+        { description: 'double quote', value: 'has "quotes" in it' },
+        { description: 'backslash', value: 'C:\\path\\to\\file' },
+        // eslint-disable-next-line no-template-curly-in-string
+        { description: 'template-literal syntax', value: '${alert(1)}' },
+        { description: 'newlines and tabs', value: 'line1\nline2\tcol' },
+        { description: 'emoji', value: '😀' },
+        { description: 'injection attempt', value: "'); alert(1); //" },
+    ];
+
+    test.each(adversarialInputs)(
+        'Should pass $description through unchanged',
+        async ({ value }) => {
+            const source = generateVirtualEntryContent(
+                'myHandler',
+                '/src/handler.ts',
+                PROJECT_ROOT,
+            );
+            let received: unknown;
+            const handler = (arg: unknown) => {
+                received = arg;
+                return 'ok';
+            };
+            const main = buildMainFromSource(source, handler);
+            const result = await main({ backendFunctionArgs: [value] });
+            expect(received).toBe(value);
+            expect(result).toBe('ok');
+        },
+    );
+
+    test('Should default to [] when backendFunctionArgs is absent', async () => {
+        const source = generateVirtualEntryContent('myHandler', '/src/handler.ts', PROJECT_ROOT);
+        let received: unknown[] | undefined;
+        const handler = (...args: unknown[]) => {
+            received = args;
+            return 'ok';
+        };
+        const main = buildMainFromSource(source, handler);
+        await main({});
+        expect(received).toEqual([]);
     });
 });

--- a/packages/plugins/apps/src/backend/virtual-entry.ts
+++ b/packages/plugins/apps/src/backend/virtual-entry.ts
@@ -33,10 +33,7 @@ export function generateVirtualEntryContent(
     lines.push(`    // Register the $.Actions-based implementation for executeAction`);
     lines.push(SET_EXECUTE_ACTION_SNIPPET);
     lines.push('');
-    lines.push('    // backendFunctionArgs is a template expression resolved at runtime by');
-    lines.push("    // App Builder's executeBackendFunction client via template_params.");
-    // eslint-disable-next-line no-template-curly-in-string
-    lines.push("    const args = JSON.parse('${backendFunctionArgs}' || '[]');");
+    lines.push('    const args = $.backendFunctionArgs ?? [];');
     lines.push(`    const result = await ${functionName}(...args);`);
     lines.push('    return result;');
     lines.push('}');
@@ -46,34 +43,12 @@ export function generateVirtualEntryContent(
 
 /**
  * Generate the virtual entry source for a backend function (dev server).
- * Inlines the args as JSON since they are known at request time.
+ * Identical to production: args are read from $.backendFunctionArgs at runtime.
  */
 export function generateDevVirtualEntryContent(
     functionName: string,
     entryPath: string,
-    args: unknown[],
     projectRoot?: string,
 ): string {
-    const lines: string[] = [];
-
-    lines.push(`import { ${functionName} } from ${JSON.stringify(entryPath)};`);
-
-    if (isActionCatalogInstalled(projectRoot ?? process.cwd())) {
-        lines.push(ACTION_CATALOG_IMPORT);
-    }
-
-    lines.push('');
-    lines.push('/** @param {import("./context.types").Context} $ */');
-    lines.push('export async function main($) {');
-    lines.push('    globalThis.$ = $;');
-    lines.push('');
-    lines.push('    // Register the $.Actions-based implementation for executeAction');
-    lines.push(SET_EXECUTE_ACTION_SNIPPET);
-    lines.push('');
-    lines.push(`    const args = ${JSON.stringify(args)};`);
-    lines.push(`    const result = await ${functionName}(...args);`);
-    lines.push('    return result;');
-    lines.push('}');
-
-    return lines.join('\n');
+    return generateVirtualEntryContent(functionName, entryPath, projectRoot ?? process.cwd());
 }

--- a/packages/plugins/apps/src/vite/dev-server.test.ts
+++ b/packages/plugins/apps/src/vite/dev-server.test.ts
@@ -357,9 +357,15 @@ describe('Dev Server Middleware', () => {
                     attributes: {
                         query: {
                             properties: {
-                                spec: { inputs: { allowedConnectionIds: string[] } };
+                                spec: {
+                                    inputs: {
+                                        allowedConnectionIds: string[];
+                                        context: { backendFunctionArgs: unknown[] };
+                                    };
+                                };
                             };
                         };
+                        template_params: Record<string, unknown>;
                     };
                 };
             };
@@ -382,7 +388,7 @@ describe('Dev Server Middleware', () => {
 
             const req = createMockRequest('/__dd/executeAction', {
                 functionName: encodeQueryName(mockFunctions[0]),
-                args: [],
+                args: ['hello', 42],
             });
             const res = createMockResponse();
 
@@ -394,9 +400,64 @@ describe('Dev Server Middleware', () => {
             expect(body.success).toBe(true);
             expect(body.result).toEqual({ data: { value: 42 } });
             expect(apiScope.isDone()).toBe(true);
+            const inputs = capturedBody?.data.attributes.query.properties.spec.inputs;
+            expect(inputs?.allowedConnectionIds).toEqual([]);
+            // Args flow through inputs.context, not template_params. This keeps
+            // them as structured JSON values instead of being textually
+            // substituted into the script source.
+            expect(inputs?.context).toEqual({ backendFunctionArgs: ['hello', 42] });
+            expect(capturedBody?.data.attributes.template_params).toEqual({});
+        });
+
+        test('Should round-trip args containing single quotes via inputs.context', async () => {
+            // Regression: textual substitution into a single-quoted JS string
+            // literal broke when args contained `'`. Args must now appear
+            // verbatim in inputs.context with no escaping or stringification.
+            mockBuildWithParsedBackend();
+
+            type PreviewAsyncBody = {
+                data: {
+                    attributes: {
+                        query: {
+                            properties: {
+                                spec: {
+                                    inputs: {
+                                        context: { backendFunctionArgs: unknown[] };
+                                    };
+                                };
+                            };
+                        };
+                    };
+                };
+            };
+            let capturedBody: PreviewAsyncBody | undefined;
+            const apiScope = nock(DD_API_ORIGIN)
+                .post('/api/v2/app-builder/queries/preview-async', (body) => {
+                    capturedBody = body as PreviewAsyncBody;
+                    return true;
+                })
+                .reply(200, { data: { id: 'receipt-quote' } })
+                .get('/api/v2/app-builder/queries/execution-long-polling/receipt-quote')
+                .reply(200, {
+                    data: { attributes: { done: true, outputs: { data: { ok: true } } } },
+                });
+
+            const trickyArgs = ["don't break", "'); alert(1); //", '😀'];
+            const req = createMockRequest('/__dd/executeAction', {
+                functionName: encodeQueryName(mockFunctions[0]),
+                args: trickyArgs,
+            });
+            const res = createMockResponse();
+
+            middleware(req, res, jest.fn());
+            await res.done;
+
+            expect(res.statusCode).toBe(200);
+            expect(apiScope.isDone()).toBe(true);
             expect(
-                capturedBody?.data.attributes.query.properties.spec.inputs.allowedConnectionIds,
-            ).toEqual([]);
+                capturedBody?.data.attributes.query.properties.spec.inputs.context
+                    .backendFunctionArgs,
+            ).toEqual(trickyArgs);
         });
 
         test('Should use collector output instead of registered backend function allowedConnectionIds', async () => {

--- a/packages/plugins/apps/src/vite/dev-server.ts
+++ b/packages/plugins/apps/src/vite/dev-server.ts
@@ -23,7 +23,7 @@ interface BundleResult {
     code: string;
 }
 
-type BundleFn = (func: BackendFunction, args: unknown[]) => Promise<BundleResult>;
+type BundleFn = (func: BackendFunction) => Promise<BundleResult>;
 
 const DEV_VIRTUAL_PREFIX = 'virtual:dd-backend-dev:';
 
@@ -68,7 +68,6 @@ function parseRequestBody(req: IncomingMessage): Promise<ExecuteActionRequest> {
 async function bundleBackendFunction(
     viteBuild: typeof build,
     func: BackendFunction,
-    args: unknown[],
     projectRoot: string,
     log: Logger,
 ): Promise<BundleResult> {
@@ -77,7 +76,6 @@ async function bundleBackendFunction(
     const virtualContent = generateDevVirtualEntryContent(
         func.name,
         func.absolutePath,
-        args,
         projectRoot,
     );
     const connectionIdCollector = createBackendConnectionIdCollector(
@@ -131,6 +129,7 @@ async function bundleBackendFunction(
 async function executeScriptViaDatadog(
     scriptBody: string,
     func: BackendFunction,
+    args: unknown[],
     auth: AuthConfig,
     log: Logger,
 ): Promise<BackendOutputs> {
@@ -153,6 +152,7 @@ async function executeScriptViaDatadog(
                             inputs: {
                                 script: scriptBody,
                                 allowedConnectionIds: func.allowedConnectionIds,
+                                context: { backendFunctionArgs: args },
                             },
                         },
                         onlyTriggerManually: true,
@@ -268,7 +268,7 @@ async function validateAndBundle(
     req: IncomingMessage,
     functionsByName: Map<string, BackendFunction>,
     bundle: BundleFn,
-): Promise<{ func: BackendFunction; code: string }> {
+): Promise<{ func: BackendFunction; code: string; args: unknown[] }> {
     const { functionName, args = [] } = await parseRequestBody(req);
 
     if (!functionName || typeof functionName !== 'string') {
@@ -280,7 +280,8 @@ async function validateAndBundle(
         throw new HttpError(404, `Backend function "${functionName}" not found`);
     }
 
-    return bundle(func, args);
+    const bundled = await bundle(func);
+    return { ...bundled, args };
 }
 
 /**
@@ -317,12 +318,12 @@ async function handleExecuteAction(
     log: Logger,
 ): Promise<void> {
     try {
-        const { func, code } = await validateAndBundle(req, functionsByName, bundle);
+        const { func, code, args } = await validateAndBundle(req, functionsByName, bundle);
         const displayName = formatRef(func);
 
         log.debug(`Executing action: ${displayName} with args`);
 
-        const result = await executeScriptViaDatadog(code, func, auth, log);
+        const result = await executeScriptViaDatadog(code, func, args, auth, log);
 
         res.statusCode = 200;
         res.setHeader('Content-Type', 'application/json');
@@ -357,8 +358,8 @@ export function createDevServerMiddleware(
     projectRoot: string,
     log: Logger,
 ): (req: IncomingMessage, res: ServerResponse, next: () => void) => void {
-    const bundle = (func: BackendFunction, args: unknown[]) =>
-        bundleBackendFunction(viteBuild, func, args, projectRoot, log);
+    const bundle = (func: BackendFunction) =>
+        bundleBackendFunction(viteBuild, func, projectRoot, log);
 
     const initialFunctions = getBackendFunctions();
     if (initialFunctions.length > 0) {


### PR DESCRIPTION
## Summary

Removes a code-injection vulnerability in the generated production script for `@dd/apps-plugin` backend functions.

The script generated by `virtual-entry.ts` read args via textual substitution into a single-quoted JS string literal:

```js
const args = JSON.parse('${backendFunctionArgs}' || '[]');
```

When the host runtime (web-ui) substituted `${backendFunctionArgs}` with the JSON of the iframe's args, any string arg containing `'` broke out of the literal. `JSON.stringify` does not escape single quotes, so this manifested two ways:

1. **Functional bug:** common English contractions (`don't`, `won't`) sent to any backend function produced `Parsing error: Expected ',', got 's' at <line>:<col>` — the host's parser choking on the closing quote and the next token of the JSON.
2. **Code injection:** a user-controlled string like `'); await $.Actions.<conn>.exfiltrate(...); //` escaped the literal and ran in the backend executor's privileged context (datastore access, connection credentials).

This change moves args off the textual-substitution path entirely. The generated script now reads:

```js
const args = $.backendFunctionArgs ?? [];
```

The companion PR in web-ui (DataDog/web-ui#307916) places args into `inputs.context.backendFunctionArgs` as a structured JSON value before sending the query to the API. Values round-trip losslessly for any Unicode content.

Dev and production codegen are unified — `generateDevVirtualEntryContent` now delegates to `generateVirtualEntryContent` so both paths share the same runtime contract. The dev-server (`/__dd/executeAction`) threads args through to `inputs.context.backendFunctionArgs` in the preview-async POST instead of inlining them into the bundle.

## Changes

- `packages/plugins/apps/src/backend/virtual-entry.ts` — production codegen reads `$.backendFunctionArgs`; dev codegen delegates to production (drops the `args` parameter).
- `packages/plugins/apps/src/vite/dev-server.ts` — `bundleBackendFunction` no longer takes args; `executeScriptViaDatadog` sets `spec.inputs.context.backendFunctionArgs`.
- `packages/plugins/apps/src/backend/virtual-entry.test.ts` — updated assertions to require `$.backendFunctionArgs`; new round-trip test evaluates the generated `main` against adversarial inputs (`don't break`, `'); alert(1); //`, mixed quotes/backslashes, template-literal syntax, newlines/tabs, emoji).
- `packages/plugins/apps/src/vite/dev-server.test.ts` — captures the preview-async body and asserts args appear in `inputs.context` with `template_params` empty; new single-quote round-trip test.

## Coordination

Older apps already deployed against the previous build-plugins release read via `template_params.backendFunctionArgs` and won't pick up this fix until rebuilt + redeployed. The matching web-ui PR removes the `template_params.backendFunctionArgs` write entirely (rather than keeping it during a transition) so no exploitable path remains — older apps will fail loudly until rebuilt. App authors will need to be notified to redeploy.

## Test plan

- [x] `yarn lint` on changed files — clean
- [x] `yarn cli typecheck-workspaces` — clean
- [x] `yarn cli integrity` — clean
- [x] `yarn test:unit packages/plugins/apps` — 234 tests pass (1 pre-existing stale `.d.ts` artifact in `dist/`, unrelated)
- [x] Manual: scaffold an App, build with this branch, deploy alongside web-ui#307916, call a backend function with `args: ["don't break"]`, confirm the value round-trips into the datastore

🤖 Generated with Claude Opus 4.7