### PR TITLE
[APPS] Add published artifact loadability test

### DIFF
--- a/packages/tests/jest.config.ts
+++ b/packages/tests/jest.config.ts
@@ -15,6 +15,7 @@ const config: JestConfigWithTsJest = {
     setupFilesAfterEnv: ['<rootDir>/src/_jest/setupAfterEnv.ts'],
     testEnvironment: 'node',
     testMatch: ['**/*.test.*'],
+    testPathIgnorePatterns: ['/node_modules/', '/dist/'],
     testTimeout: 10000,
 };
 

--- a/packages/tests/src/_jest/helpers/constants.ts
+++ b/packages/tests/src/_jest/helpers/constants.ts
@@ -30,4 +30,6 @@ export const KNOWN_ERRORS: string[] = [
     // Jest 30 globalsCleanup warnings for nock's internal properties that can't be protected.
     "[JEST-01] DeprecationWarning: 'logger' property was accessed on [_FetchInterceptor]",
     "[JEST-01] DeprecationWarning: 'now' property was accessed on [Function]",
+    // Local shells may set NO_COLOR while the test script forces color output.
+    "Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.",
 ];

--- a/packages/tools/src/rollupConfig.test.ts
+++ b/packages/tools/src/rollupConfig.test.ts
@@ -32,12 +32,13 @@ import {
 } from '@dd/tests/_jest/helpers/runBundlers';
 import type { CleanupFn } from '@dd/tests/_jest/helpers/types';
 import { ROOT } from '@dd/tools/constants';
-import { bgGreen, bgYellow, execute, green } from '@dd/tools/helpers';
+import { bgGreen, bgYellow, execute, executeSync, green } from '@dd/tools/helpers';
 import type { BuildOptions } from 'esbuild';
 import fs from 'fs';
 import { glob } from 'glob';
 import nock from 'nock';
 import path from 'path';
+import { pathToFileURL } from 'url';
 
 import type { BundlerConfig } from './bundlers';
 
@@ -144,6 +145,31 @@ const getBuiltFiles = () => {
     return builtFiles;
 };
 
+type PublishedPackageJson = {
+    publishConfig?: {
+        exports?: {
+            '.'?: {
+                import?: string;
+                require?: string;
+                types?: string;
+            };
+        };
+    };
+};
+
+const getPublishedPackageJson = (bundlerName: string): PublishedPackageJson => {
+    return require(path.resolve(ROOT, `packages/published/${bundlerName}-plugin/package.json`));
+};
+
+const getPublishedExports = (bundlerName: string) => {
+    const packageJson = getPublishedPackageJson(bundlerName);
+    return packageJson.publishConfig?.exports?.['.'];
+};
+
+const resolvePublishedExportPath = (bundlerName: string, exportPath: string) => {
+    return path.resolve(ROOT, `packages/published/${bundlerName}-plugin`, exportPath);
+};
+
 describe('Bundling', () => {
     let bundlerVersions: Partial<Record<BundlerName, string>> = {};
     let processErrors: string[] = [];
@@ -232,6 +258,29 @@ describe('Bundling', () => {
             ].sort();
             const existingFiles = fs.readdirSync(getPackagePath(bundlerName)).sort();
             expect(existingFiles).toEqual(expectedFiles);
+        });
+
+        test(`Should expose loadable publish artifacts for @datadog/${bundlerName}-plugin.`, () => {
+            getPackageDestination(bundlerName);
+
+            const publishedExports = getPublishedExports(bundlerName);
+            expect(publishedExports?.import).toEqual(expect.stringMatching(/\.mjs$/));
+            expect(publishedExports?.require).toEqual(expect.stringMatching(/\.js$/));
+            expect(publishedExports?.types).toEqual(expect.stringMatching(/\.d\.ts$/));
+
+            const esmEntry = resolvePublishedExportPath(bundlerName, publishedExports!.import!);
+            const cjsEntry = resolvePublishedExportPath(bundlerName, publishedExports!.require!);
+            const typesEntry = resolvePublishedExportPath(bundlerName, publishedExports!.types!);
+            expect(fs.existsSync(typesEntry)).toBe(true);
+
+            executeSync(process.execPath, ['--check', esmEntry]);
+            executeSync(process.execPath, ['--check', cjsEntry]);
+            executeSync(process.execPath, [
+                '--input-type=module',
+                '--eval',
+                `await import(${JSON.stringify(pathToFileURL(esmEntry).href)});`,
+            ]);
+            executeSync(process.execPath, ['--eval', `require(${JSON.stringify(cjsEntry)});`]);
         });
     });
 


### PR DESCRIPTION
## Motivation

The published `@datadog/vite-plugin` ESM artifact was recently corrupted by a build-time shim insertion issue. The package metadata looked valid, but `dist/src/index.mjs` could not be parsed or imported by Vite config loading. We need CI coverage that validates the generated publish artifacts, not only the TypeScript source and bundler behavior.

## Changes

Adds an artifact-level unit test for each published Datadog bundler plugin. The test reads `publishConfig.exports[\".\"]`, confirms the ESM, CJS, and type entries point at existing built files, syntax-checks the JavaScript entries with Node, and verifies both ESM import and CJS require work from a child process.

The test intentionally validates `publishConfig.exports` instead of local development `exports`, because workspace/local-link exports may point at TypeScript source while npm publish metadata points at generated `dist` files.

Also allows the local Node warning emitted when `NO_COLOR` and `FORCE_COLOR` are both present so the focused unit test remains stable in shells with `NO_COLOR` set.

## QA Instructions

No manual QA needed; this is CI coverage for generated package artifacts.

## Blast Radius

Low. This only changes test coverage and a Jest warning allowlist. Runtime package code is unchanged.

## Documentation

-   [How to reliably make frontend production changes](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2286781319/Frontend+Production+Changesp)
-   [PR Description Guidelines](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/3120334387/PR+Checklist+and+Guidelines+for+Web+UI)
-   [Deploy steps](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/1457750032/)