### PR TITLE
Remove reference to dd-auth

### DIFF
--- a/packages/plugins/apps/src/vite/dev-server.ts
+++ b/packages/plugins/apps/src/vite/dev-server.ts
@@ -377,7 +377,7 @@ export function createDevServerMiddleware(
     if (!fullAuth) {
         log.warn(
             'Auth credentials not configured. The /__dd/executeAction endpoint will be unavailable. ' +
-                'Use dd-auth or set DD_API_KEY and DD_APP_KEY to enable remote execution.',
+                'Set DD_API_KEY and DD_APP_KEY to enable remote execution.',
         );
     }
 


### PR DESCRIPTION
## Summary

- Simplified the auth-missing warning emitted by `createDevServerMiddleware` in the apps plugin's Vite dev server.
- The message now points users directly at the `DD_API_KEY` / `DD_APP_KEY` env vars.

## Test plan

- [x] `yarn typecheck:all` passes
- [x] `yarn lint packages/plugins/apps/src/vite/dev-server.ts` passes
- [x] Trigger the warning path locally (run the Vite dev server without `DD_API_KEY` / `DD_APP_KEY`) and confirm the new message is shown

🤖 Generated with Claude Opus 4.7