### PR TITLE
Accept any string for auth.site, validate at startup

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -248,10 +248,10 @@ export type Site = (typeof SITES)[number];
 export type AuthOptions = {
     apiKey?: string;
     appKey?: string;
-    site?: Site;
+    site?: string;
 };
 
-export type AuthOptionsWithDefaults = WithRequired<AuthOptions, 'site'>;
+export type AuthOptionsWithDefaults = Omit<AuthOptions, 'site'> & { site: Site };
 
 export interface BaseOptions {
     auth?: AuthOptions;


### PR DESCRIPTION
## Summary
- Loosen the user-facing `AuthOptions.site` type from the `Site` union to plain `string`, so callers can pass values sourced from env vars or dynamic config without TypeScript friction.
- Runtime behaviour is unchanged: `validateOptions` already validates `auth.site` against the `SITES` list at startup (via `resolveSite`) and throws an aggregated error for unsupported sites.
- `AuthOptionsWithDefaults` still narrows `site` back to `Site` (via `Omit<AuthOptions, 'site'> & { site: Site }`), so downstream consumers (RUM SDK config, Metrics URL templates, Error Tracking, Apps) keep the constrained type.

## Test plan
- [x] `yarn typecheck:all`
- [x] `yarn test:unit packages/factory` (covers `validateOptions`)
- [x] `yarn cli integrity`

🤖 Generated with Claude Opus 4.7