### PR TITLE
Ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 yarn-error.log
 .yarn/*
 !.yarn/cache


### PR DESCRIPTION
### What and why?

Add `.DS_Store` to `.gitignore`. These files are generated by MacOS in all folders opened in Finder. These shouldn't be committed to git.
