### PR TITLE
Fix hard-pinned Babel peer deps in published packages

### DIFF
--- a/packages/plugins/live-debugger/package.json
+++ b/packages/plugins/live-debugger/package.json
@@ -36,9 +36,9 @@
         "typescript": "5.4.3"
     },
     "peerDependencies": {
-        "@babel/parser": "7.24.5",
-        "@babel/traverse": "7.24.5",
-        "@babel/types": "7.24.5",
+        "@babel/parser": "^7.24.5",
+        "@babel/traverse": "^7.24.5",
+        "@babel/types": "^7.24.5",
         "magic-string": "^0.30.0"
     },
     "peerDependenciesMeta": {

--- a/packages/published/esbuild-plugin/package.json
+++ b/packages/published/esbuild-plugin/package.json
@@ -85,9 +85,9 @@
         "typescript": "5.4.3"
     },
     "peerDependencies": {
-        "@babel/parser": "7.24.5",
-        "@babel/traverse": "7.24.5",
-        "@babel/types": "7.24.5",
+        "@babel/parser": "^7.24.5",
+        "@babel/traverse": "^7.24.5",
+        "@babel/types": "^7.24.5",
         "esbuild": ">=0.x",
         "magic-string": "^0.30.0"
     },

--- a/packages/published/rollup-plugin/package.json
+++ b/packages/published/rollup-plugin/package.json
@@ -88,9 +88,9 @@
         "typescript": "5.4.3"
     },
     "peerDependencies": {
-        "@babel/parser": "7.24.5",
-        "@babel/traverse": "7.24.5",
-        "@babel/types": "7.24.5",
+        "@babel/parser": "^7.24.5",
+        "@babel/traverse": "^7.24.5",
+        "@babel/types": "^7.24.5",
         "magic-string": "^0.30.0",
         "rollup": ">= 3.x < 5.x"
     },

--- a/packages/published/rspack-plugin/package.json
+++ b/packages/published/rspack-plugin/package.json
@@ -85,9 +85,9 @@
         "typescript": "5.4.3"
     },
     "peerDependencies": {
-        "@babel/parser": "7.24.5",
-        "@babel/traverse": "7.24.5",
-        "@babel/types": "7.24.5",
+        "@babel/parser": "^7.24.5",
+        "@babel/traverse": "^7.24.5",
+        "@babel/types": "^7.24.5",
         "@rspack/core": "1.x",
         "magic-string": "^0.30.0"
     },

--- a/packages/published/vite-plugin/package.json
+++ b/packages/published/vite-plugin/package.json
@@ -85,9 +85,9 @@
         "typescript": "5.4.3"
     },
     "peerDependencies": {
-        "@babel/parser": "7.24.5",
-        "@babel/traverse": "7.24.5",
-        "@babel/types": "7.24.5",
+        "@babel/parser": "^7.24.5",
+        "@babel/traverse": "^7.24.5",
+        "@babel/types": "^7.24.5",
         "magic-string": "^0.30.0",
         "vite": ">= 5.x <= 7.x"
     },

--- a/packages/published/webpack-plugin/package.json
+++ b/packages/published/webpack-plugin/package.json
@@ -85,9 +85,9 @@
         "typescript": "5.4.3"
     },
     "peerDependencies": {
-        "@babel/parser": "7.24.5",
-        "@babel/traverse": "7.24.5",
-        "@babel/types": "7.24.5",
+        "@babel/parser": "^7.24.5",
+        "@babel/traverse": "^7.24.5",
+        "@babel/types": "^7.24.5",
         "magic-string": "^0.30.0",
         "webpack": ">= 5.x < 6.x"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1714,9 +1714,9 @@ __metadata:
     typescript: "npm:5.4.3"
     unplugin: "npm:2.3.11"
   peerDependencies:
-    "@babel/parser": 7.24.5
-    "@babel/traverse": 7.24.5
-    "@babel/types": 7.24.5
+    "@babel/parser": ^7.24.5
+    "@babel/traverse": ^7.24.5
+    "@babel/types": ^7.24.5
     esbuild: ">=0.x"
     magic-string: ^0.30.0
   peerDependenciesMeta:
@@ -1774,9 +1774,9 @@ __metadata:
     typescript: "npm:5.4.3"
     unplugin: "npm:2.3.11"
   peerDependencies:
-    "@babel/parser": 7.24.5
-    "@babel/traverse": 7.24.5
-    "@babel/types": 7.24.5
+    "@babel/parser": ^7.24.5
+    "@babel/traverse": ^7.24.5
+    "@babel/types": ^7.24.5
     magic-string: ^0.30.0
     rollup: ">= 3.x < 5.x"
   peerDependenciesMeta:
@@ -1827,9 +1827,9 @@ __metadata:
     typescript: "npm:5.4.3"
     unplugin: "npm:2.3.11"
   peerDependencies:
-    "@babel/parser": 7.24.5
-    "@babel/traverse": 7.24.5
-    "@babel/types": 7.24.5
+    "@babel/parser": ^7.24.5
+    "@babel/traverse": ^7.24.5
+    "@babel/types": ^7.24.5
     "@rspack/core": 1.x
     magic-string: ^0.30.0
   peerDependenciesMeta:
@@ -1880,9 +1880,9 @@ __metadata:
     typescript: "npm:5.4.3"
     unplugin: "npm:2.3.11"
   peerDependencies:
-    "@babel/parser": 7.24.5
-    "@babel/traverse": 7.24.5
-    "@babel/types": 7.24.5
+    "@babel/parser": ^7.24.5
+    "@babel/traverse": ^7.24.5
+    "@babel/types": ^7.24.5
     magic-string: ^0.30.0
     vite: ">= 5.x <= 7.x"
   peerDependenciesMeta:
@@ -1933,9 +1933,9 @@ __metadata:
     typescript: "npm:5.4.3"
     unplugin: "npm:2.3.11"
   peerDependencies:
-    "@babel/parser": 7.24.5
-    "@babel/traverse": 7.24.5
-    "@babel/types": 7.24.5
+    "@babel/parser": ^7.24.5
+    "@babel/traverse": ^7.24.5
+    "@babel/types": ^7.24.5
     magic-string: ^0.30.0
     webpack: ">= 5.x < 6.x"
   peerDependenciesMeta:
@@ -2118,9 +2118,9 @@ __metadata:
     magic-string: "npm:0.30.21"
     typescript: "npm:5.4.3"
   peerDependencies:
-    "@babel/parser": 7.24.5
-    "@babel/traverse": 7.24.5
-    "@babel/types": 7.24.5
+    "@babel/parser": ^7.24.5
+    "@babel/traverse": ^7.24.5
+    "@babel/types": ^7.24.5
     magic-string: ^0.30.0
   peerDependenciesMeta:
     "@babel/parser":


### PR DESCRIPTION
### What and why?

All 5 published packages (`webpack-plugin`, `esbuild-plugin`, `rollup-plugin`, `rspack-plugin`, `vite-plugin`) and the `live-debugger` internal plugin had exact-pinned `peerDependencies` for `@babel/parser`, `@babel/traverse`, and `@babel/types` at `"7.24.5"`. npm 7+ treats a mismatched peer dep as a hard error, so any user on a newer Babel version is blocked from installing the plugin without `--legacy-peer-deps`. Fixes #391.

### How?

Changed the three Babel peer dep versions from the exact pin `"7.24.5"` to the caret range `"^7.24.5"` in every affected `peerDependencies` block. The `devDependencies` exact pins in `live-debugger/package.json` are internal to the monorepo and left untouched — they do not affect consumers.

`yarn cli integrity` and `yarn typecheck:all` both pass without changes.