### PR TITLE
Add bugs metadata to published packages

### DIFF
--- a/packages/published/esbuild-plugin/package.json
+++ b/packages/published/esbuild-plugin/package.json
@@ -13,6 +13,9 @@
         "unplugin"
     ],
     "homepage": "https://github.com/DataDog/build-plugins#readme",
+    "bugs": {
+        "url": "https://github.com/DataDog/build-plugins/issues"
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/DataDog/build-plugins",

--- a/packages/published/rollup-plugin/package.json
+++ b/packages/published/rollup-plugin/package.json
@@ -13,6 +13,9 @@
         "unplugin"
     ],
     "homepage": "https://github.com/DataDog/build-plugins#readme",
+    "bugs": {
+        "url": "https://github.com/DataDog/build-plugins/issues"
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/DataDog/build-plugins",

--- a/packages/published/rspack-plugin/package.json
+++ b/packages/published/rspack-plugin/package.json
@@ -13,6 +13,9 @@
         "unplugin"
     ],
     "homepage": "https://github.com/DataDog/build-plugins#readme",
+    "bugs": {
+        "url": "https://github.com/DataDog/build-plugins/issues"
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/DataDog/build-plugins",

--- a/packages/published/vite-plugin/package.json
+++ b/packages/published/vite-plugin/package.json
@@ -13,6 +13,9 @@
         "unplugin"
     ],
     "homepage": "https://github.com/DataDog/build-plugins#readme",
+    "bugs": {
+        "url": "https://github.com/DataDog/build-plugins/issues"
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/DataDog/build-plugins",

--- a/packages/published/webpack-plugin/package.json
+++ b/packages/published/webpack-plugin/package.json
@@ -13,6 +13,9 @@
         "unplugin"
     ],
     "homepage": "https://github.com/DataDog/build-plugins#readme",
+    "bugs": {
+        "url": "https://github.com/DataDog/build-plugins/issues"
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/DataDog/build-plugins",


### PR DESCRIPTION
## Summary
- add standard npm `bugs.url` metadata for all published packages in this repository
- point the issue tracker link at the public DataDog/build-plugins issues page

Covered packages:
- `@datadog/esbuild-plugin`
- `@datadog/rollup-plugin`
- `@datadog/rspack-plugin`
- `@datadog/vite-plugin`
- `@datadog/webpack-plugin`

## Verification
- `node -e "const fs=require('fs'); const path=require('path'); const dir='packages/published'; const out={}; for (const name of fs.readdirSync(dir)) { const file=path.join(dir,name,'package.json'); if (!fs.existsSync(file)) continue; const p=require('./'+file.replace(/\\/g,'/')); out[p.name]={homepage:p.homepage,bugs:p.bugs,repository:p.repository}; if(p.bugs?.url!=='https://github.com/DataDog/build-plugins/issues') process.exitCode=1; } console.log(JSON.stringify(out,null,2));"`
- `git diff --check`