### PR TITLE
Fix Live Debugger local capture TDZ reads

### DIFF
--- a/packages/plugins/live-debugger/README.md
+++ b/packages/plugins/live-debugger/README.md
@@ -68,7 +68,7 @@ The Live Debugger plugin automatically instruments all JavaScript functions in y
 Each instrumented function gets:
 - A unique, stable function ID (format: `<file-path>;<function-name>`)
 - A `$dd_probes()` call that returns active probes for that function (or `undefined` if none)
-- Deferred variable-capture helpers (`$dd_e<N>` for entry variables, `$dd_l<N>` for exit variables) that are only evaluated when probes are active
+- Deferred parameter-capture helpers (`$dd_e<N>`)
 - Entry point tracking with parameter capture via `$dd_entry()`
 - Return value tracking with local variable capture via `$dd_return()`
 - Exception tracking with variable state at throw time via `$dd_throw()`
@@ -91,16 +91,14 @@ function add(a, b) {
     const $dd_p = $dd_probes('src/utils.js;add');
     const $dd_e = () => ({a, b});
     try {
-        const $dd_l = () => ({a, b, sum});
         let $dd_rv;
         if ($dd_p) $dd_entry($dd_p, this, $dd_e());
         const sum = a + b;
-        return ($dd_rv = sum, $dd_p ? $dd_return($dd_p, $dd_rv, this, $dd_e(), $dd_l()) : $dd_rv);
+        return ($dd_rv = sum, $dd_p ? $dd_return($dd_p, $dd_rv, this, $dd_e(), { sum }) : $dd_rv);
     } catch(e) { if ($dd_p) $dd_throw($dd_p, e, this, $dd_e()); throw e; }
 }
 ```
 
-When entry and exit variables are the same (i.e. the function has no local variable declarations), only a single helper is emitted and shared for both positions.
 
 **Example transformation (arrow expression body):**
 
@@ -115,7 +113,7 @@ const double = (x) => {
     try {
         if ($dd_p) $dd_entry($dd_p, this, $dd_e());
         const $dd_rv = x * 2;
-        if ($dd_p) $dd_return($dd_p, $dd_rv, this, $dd_e(), $dd_e());
+        if ($dd_p) $dd_return($dd_p, $dd_rv, this, $dd_e());
         return $dd_rv;
     } catch(e) { if ($dd_p) $dd_throw($dd_p, e, this, $dd_e()); throw e; }
 };

--- a/packages/plugins/live-debugger/src/transform/index.test.ts
+++ b/packages/plugins/live-debugger/src/transform/index.test.ts
@@ -258,25 +258,25 @@ describe('transformCode', () => {
         });
     });
 
-    describe('hoisted variable capture', () => {
-        it('should generate args and locals helpers', () => {
+    describe('local variable capture', () => {
+        it('should generate args helpers and inline local captures', () => {
             const result = transformCode({
                 ...BASE_OPTIONS,
                 code: 'function f(a, b) { const c = 1; return a + b + c; }',
             });
 
             expect(result.code).toMatch(/\$dd_e\d+ = \(\) => \(\{a, b\}\)/);
-            expect(result.code).toMatch(/\$dd_l\d+ = \(\) => \(\{c\}\)/);
+            expect(result.code).toContain('$dd_return($dd_p0, $dd_rv0, this, $dd_e0(), {c})');
         });
 
-        it('should omit the locals helper when there are no locals', () => {
+        it('should omit local captures when there are no locals', () => {
             const result = transformCode({
                 ...BASE_OPTIONS,
                 code: 'function f(a, b) { return a + b; }',
             });
 
             expect(result.code).toMatch(/\$dd_e\d+ = \(\) => \(\{a, b\}\)/);
-            expect(result.code).not.toMatch(/\$dd_l\d+/);
+            expect(result.code).toContain('$dd_return($dd_p0, $dd_rv0, this, $dd_e0())');
         });
 
         it('should omit both helpers when there are no params and no locals', () => {
@@ -286,7 +286,6 @@ describe('transformCode', () => {
             });
 
             expect(result.code).not.toMatch(/\$dd_e\d+/);
-            expect(result.code).not.toMatch(/\$dd_l\d+/);
         });
     });
 
@@ -738,9 +737,8 @@ describe('transformCode', () => {
                 normalizeCode(
                     "function getTime() {const $dd_p0 = $dd_probes('src/utils.ts;getTime');",
                     '  try {',
-                    '    const $dd_l0 = () => ({now});',
                     '    let $dd_rv0;',
-                    '    if ($dd_p0) $dd_entry($dd_p0, this); const now = Date.now(); return ($dd_rv0 = now, $dd_p0 ? $dd_return($dd_p0, $dd_rv0, this, undefined, $dd_l0()) : $dd_rv0); ',
+                    '    if ($dd_p0) $dd_entry($dd_p0, this); const now = Date.now(); return ($dd_rv0 = now, $dd_p0 ? $dd_return($dd_p0, $dd_rv0, this, undefined, {now}) : $dd_rv0); ',
                     '  } catch(e) { if ($dd_p0) $dd_throw($dd_p0, e, this); throw e; }',
                     '}',
                 ),
@@ -777,10 +775,47 @@ describe('transformCode', () => {
                     "function add(a, b) {const $dd_p0 = $dd_probes('src/utils.ts;add');",
                     '  const $dd_e0 = () => ({a, b});',
                     '  try {',
-                    '    const $dd_l0 = () => ({sum});',
                     '    let $dd_rv0;',
-                    '    if ($dd_p0) $dd_entry($dd_p0, this, $dd_e0()); const sum = a + b; return ($dd_rv0 = sum, $dd_p0 ? $dd_return($dd_p0, $dd_rv0, this, $dd_e0(), $dd_l0()) : $dd_rv0); ',
+                    '    if ($dd_p0) $dd_entry($dd_p0, this, $dd_e0()); const sum = a + b; return ($dd_rv0 = sum, $dd_p0 ? $dd_return($dd_p0, $dd_rv0, this, $dd_e0(), {sum}) : $dd_rv0); ',
                     '  } catch(e) { if ($dd_p0) $dd_throw($dd_p0, e, this, $dd_e0()); throw e; }',
+                    '}',
+                ),
+            );
+        });
+
+        it('should produce the expected output for returns before local declarations', () => {
+            const result = transformCode({
+                ...BASE_OPTIONS,
+                code: 'function f(flag) { if (flag) { return 1; } const later = 2; return later; }',
+            });
+
+            expect(normalizeCode(result.code)).toBe(
+                normalizeCode(
+                    "function f(flag) {const $dd_p0 = $dd_probes('src/utils.ts;f');",
+                    '  const $dd_e0 = () => ({flag});',
+                    '  try {',
+                    '    let $dd_rv0;',
+                    '    if ($dd_p0) $dd_entry($dd_p0, this, $dd_e0()); if (flag) { return ($dd_rv0 = 1, $dd_p0 ? $dd_return($dd_p0, $dd_rv0, this, $dd_e0()) : $dd_rv0); } const later = 2; return ($dd_rv0 = later, $dd_p0 ? $dd_return($dd_p0, $dd_rv0, this, $dd_e0(), {later}) : $dd_rv0); ',
+                    '  } catch(e) { if ($dd_p0) $dd_throw($dd_p0, e, this, $dd_e0()); throw e; }',
+                    '}',
+                ),
+            );
+        });
+
+        it('should produce the expected output for returns before shadowing locals', () => {
+            const result = transformCode({
+                ...BASE_OPTIONS,
+                code: 'function f() { let a = 1; if (a) { return; let a = 2; return a; } }',
+            });
+
+            expect(normalizeCode(result.code)).toBe(
+                normalizeCode(
+                    "function f() {const $dd_p0 = $dd_probes('src/utils.ts;f');",
+                    '  try {',
+                    '    let $dd_rv0;',
+                    '    if ($dd_p0) $dd_entry($dd_p0, this); let a = 1; if (a) { if ($dd_p0) $dd_return($dd_p0, undefined, this); return; let a = 2; return ($dd_rv0 = a, $dd_p0 ? $dd_return($dd_p0, $dd_rv0, this, undefined, {a}) : $dd_rv0); } ',
+                    '    if ($dd_p0) $dd_return($dd_p0, undefined, this, undefined, {a});',
+                    '  } catch(e) { if ($dd_p0) $dd_throw($dd_p0, e, this); throw e; }',
                     '}',
                 ),
             );

--- a/packages/plugins/live-debugger/src/transform/index.ts
+++ b/packages/plugins/live-debugger/src/transform/index.ts
@@ -14,7 +14,8 @@ import type { BabelPath, BabelTypesModule } from './babel-path.types';
 import { resolveCjsDefaultExport } from './cjs-interop';
 import { generateFunctionId, getFunctionName } from './functionId';
 import { canInstrumentFunction, shouldSkipFunction } from './instrumentation';
-import { getVariableNames } from './scopeTracker';
+import { getLocalVariableDeclarations, getParameterNames } from './scopeTracker';
+import type { LocalVariableDeclaration } from './scopeTracker';
 
 type TraverseFn = typeof _traverse;
 type ParseFn = (
@@ -156,7 +157,7 @@ interface FunctionTarget {
     probeVarName: string;
     probeIdx: string;
     entryVars: string[];
-    exitVars: string[];
+    localVars: LocalVariableDeclaration[];
     returns: ReturnInfo[];
 }
 
@@ -281,8 +282,8 @@ export function transformCode(options: TransformOptions): TransformResult {
                 const node = path.node;
                 const idx = probeVarCounter++;
                 const probeVarName = `$dd_p${idx}`;
-                const entryVars = getVariableNames(node, true, false, babelTypes);
-                const exitVars = getVariableNames(node, false, true, babelTypes);
+                const entryVars = getParameterNames(node, babelTypes);
+                const localVars = getLocalVariableDeclarations(node, babelTypes);
 
                 const isExpressionBody =
                     babelTypes.isArrowFunctionExpression(node) &&
@@ -322,7 +323,7 @@ export function transformCode(options: TransformOptions): TransformResult {
                     probeVarName,
                     probeIdx: String(idx),
                     entryVars,
-                    exitVars,
+                    localVars,
                     returns,
                 });
 
@@ -375,7 +376,7 @@ function injectInstrumentation(s: MagicStringType, code: string, target: Functio
         probeIdx,
         functionId,
         entryVars,
-        exitVars,
+        localVars,
         returns,
         bodyStart,
         bodyEnd,
@@ -386,29 +387,18 @@ function injectInstrumentation(s: MagicStringType, code: string, target: Functio
     } = target;
 
     const entryHelper = `$dd_e${probeIdx}`;
-    const exitHelper = `$dd_l${probeIdx}`;
     const rvVarName = `$dd_rv${probeIdx}`;
 
     const entryVarsList = entryVars.join(', ');
-    const exitVarsList = exitVars.join(', ');
 
     const hasParams = entryVarsList !== '';
-    const hasLocals = exitVarsList !== '';
 
     const argsArg = hasParams ? `, ${entryHelper}()` : '';
-    const returnArgsAndLocals = hasParams
-        ? hasLocals
-            ? `, ${entryHelper}(), ${exitHelper}()`
-            : `, ${entryHelper}()`
-        : hasLocals
-          ? `, undefined, ${exitHelper}()`
-          : '';
 
     // TODO: functionId is not escaped — if it contains a single quote (e.g. quoted method names),
     // the generated code will be invalid. Escaping is not currently supported.
     const probeDecl = `const ${probeVarName} = $dd_probes('${functionId}');`;
     const entryHelperDecl = hasParams ? `const ${entryHelper} = () => ({${entryVarsList}});` : '';
-    const exitHelperDecl = hasLocals ? `const ${exitHelper} = () => ({${exitVarsList}});` : '';
     const entryCall = `if (${probeVarName}) $dd_entry(${probeVarName}, this${argsArg});`;
     const catchBlock = `catch(e) { if (${probeVarName}) $dd_throw(${probeVarName}, e, this${argsArg}); throw e; }`;
 
@@ -439,7 +429,6 @@ function injectInstrumentation(s: MagicStringType, code: string, target: Functio
             '{',
             probeDecl,
             entryHelperDecl,
-            exitHelperDecl,
             'try {',
             entryCall,
             `const ${rvVarName} = `,
@@ -447,9 +436,10 @@ function injectInstrumentation(s: MagicStringType, code: string, target: Functio
             .filter(Boolean)
             .join('\n');
 
+        const returnCaptureArgs = getReturnCaptureArgs(entryHelper, hasParams, localVars, bodyEnd);
         const suffix = [
             ';',
-            `if (${probeVarName}) $dd_return(${probeVarName}, ${rvVarName}, this${returnArgsAndLocals});`,
+            `if (${probeVarName}) $dd_return(${probeVarName}, ${rvVarName}, this${returnCaptureArgs});`,
             `return ${rvVarName};`,
             `} ${catchBlock}`,
             '}',
@@ -468,14 +458,7 @@ function injectInstrumentation(s: MagicStringType, code: string, target: Functio
         }
     } else {
         // Block body function
-        const preamble = [
-            probeDecl,
-            entryHelperDecl,
-            'try {',
-            exitHelperDecl,
-            `let ${rvVarName};`,
-            entryCall,
-        ]
+        const preamble = [probeDecl, entryHelperDecl, 'try {', `let ${rvVarName};`, entryCall]
             .filter(Boolean)
             .join('\n');
 
@@ -484,18 +467,25 @@ function injectInstrumentation(s: MagicStringType, code: string, target: Functio
         // bodyEnd - 1, the return suffix is appended to the preceding chunk
         // (its outro) and ends up before the postamble in the generated code.
         for (const ret of returns) {
+            const returnCaptureArgs = getReturnCaptureArgs(
+                entryHelper,
+                hasParams,
+                localVars,
+                ret.start,
+            );
+
             if (ret.argStart != null && ret.argEnd != null) {
                 // return EXPR; → return ($dd_rvN = EXPR, probe ? $dd_return(...) : $dd_rvN);
                 s.appendLeft(ret.argStart, `(${rvVarName} = `);
                 s.appendLeft(
                     ret.argEnd,
-                    `, ${probeVarName} ? $dd_return(${probeVarName}, ${rvVarName}, this${returnArgsAndLocals}) : ${rvVarName})`,
+                    `, ${probeVarName} ? $dd_return(${probeVarName}, ${rvVarName}, this${returnCaptureArgs}) : ${rvVarName})`,
                 );
             } else {
                 // return; → if (probe) $dd_return(...); return;
                 s.appendLeft(
                     ret.start,
-                    `if (${probeVarName}) $dd_return(${probeVarName}, undefined, this${returnArgsAndLocals}); `,
+                    `if (${probeVarName}) $dd_return(${probeVarName}, undefined, this${returnCaptureArgs}); `,
                 );
             }
         }
@@ -521,12 +511,63 @@ function injectInstrumentation(s: MagicStringType, code: string, target: Functio
         // included here (rather than as a separate appendLeft) so that the
         // single boundary update for `}` covers it; this keeps the trailing
         // helper's source-map segment anchored to the closing brace too.
+        const trailingReturnCaptureArgs = getReturnCaptureArgs(
+            entryHelper,
+            hasParams,
+            localVars,
+            bodyEnd,
+        );
         const trailingReturn = target.needsTrailingReturn
-            ? `if (${probeVarName}) $dd_return(${probeVarName}, undefined, this${returnArgsAndLocals});\n`
+            ? `if (${probeVarName}) $dd_return(${probeVarName}, undefined, this${trailingReturnCaptureArgs});\n`
             : '';
         const postamble = `\n${trailingReturn}} ${catchBlock}\n`;
         s.update(bodyEnd - 1, bodyEnd, `${postamble}${code[bodyEnd - 1]}`);
     }
+}
+
+function getReturnCaptureArgs(
+    entryHelper: string,
+    hasParams: boolean,
+    localVars: LocalVariableDeclaration[],
+    exitPosition: number,
+): string {
+    const localsArg = getLocalCaptureArg(localVars, exitPosition);
+    if (hasParams && localsArg) {
+        return `, ${entryHelper}(), ${localsArg}`;
+    }
+    if (hasParams) {
+        return `, ${entryHelper}()`;
+    }
+    if (localsArg) {
+        return `, undefined, ${localsArg}`;
+    }
+    return '';
+}
+
+function getLocalCaptureArg(
+    localVars: LocalVariableDeclaration[],
+    exitPosition: number,
+): string | undefined {
+    const availableLocals = localVars
+        .filter(
+            ({ declarationEnd, temporalDeadZones }) =>
+                declarationEnd <= exitPosition &&
+                !isInTemporalDeadZone(temporalDeadZones, exitPosition),
+        )
+        .map(({ name }) => name);
+
+    if (availableLocals.length === 0) {
+        return undefined;
+    }
+
+    return `{${availableLocals.join(', ')}}`;
+}
+
+function isInTemporalDeadZone(
+    temporalDeadZones: LocalVariableDeclaration['temporalDeadZones'],
+    position: number,
+): boolean {
+    return temporalDeadZones.some(({ start, end }) => start <= position && position < end);
 }
 
 /**

--- a/packages/plugins/live-debugger/src/transform/scopeTracker.test.ts
+++ b/packages/plugins/live-debugger/src/transform/scopeTracker.test.ts
@@ -7,7 +7,11 @@ import type * as t from '@babel/types';
 
 import type { BabelPath } from './babel-path.types';
 import { resolveCjsDefaultExport } from './cjs-interop';
-import { getVariableNames, MAX_CAPTURE_VARIABLES } from './scopeTracker';
+import {
+    getLocalVariableDeclarations,
+    getParameterNames,
+    MAX_CAPTURE_VARIABLES,
+} from './scopeTracker';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
 const babelTypes = require('@babel/types') as typeof import('@babel/types');
@@ -42,8 +46,8 @@ function parseFunctionNode(code: string): t.Function {
     return functionNode;
 }
 
-describe('getVariableNames', () => {
-    describe('params only', () => {
+describe('scopeTracker', () => {
+    describe('getParameterNames', () => {
         const cases = [
             {
                 description: 'return simple parameter names',
@@ -109,11 +113,11 @@ describe('getVariableNames', () => {
 
         test.each(cases)('should $description', ({ code, expected }) => {
             const node = parseFunctionNode(code);
-            expect(getVariableNames(node, true, false, babelTypes)).toEqual(expected);
+            expect(getParameterNames(node, babelTypes)).toEqual(expected);
         });
     });
 
-    describe('locals only', () => {
+    describe('getLocalVariableDeclarations', () => {
         const cases = [
             {
                 description: 'return top-level variable declaration names',
@@ -159,43 +163,18 @@ describe('getVariableNames', () => {
 
         test.each(cases)('should $description', ({ code, expected }) => {
             const node = parseFunctionNode(code);
-            expect(getVariableNames(node, false, true, babelTypes)).toEqual(expected);
-        });
-    });
-
-    describe('params and locals combined', () => {
-        const cases = [
-            {
-                description: 'return both params and locals',
-                code: 'function f(a, b) { const c = 1; let d = 2; }',
-                expected: ['a', 'b', 'c', 'd'],
-            },
-            {
-                description: 'deduplicate locals that match param names',
-                code: 'function f(x) { var x = 1; var y = 2; }',
-                expected: ['x', 'y'],
-            },
-        ];
-
-        test.each(cases)('should $description', ({ code, expected }) => {
-            const node = parseFunctionNode(code);
-            expect(getVariableNames(node, true, true, babelTypes)).toEqual(expected);
-        });
-    });
-
-    describe('neither params nor locals', () => {
-        it('should return empty when both flags are false', () => {
-            const node = parseFunctionNode('function f(a, b) { const c = 1; }');
-            expect(getVariableNames(node, false, false, babelTypes)).toEqual([]);
+            const declarations = getLocalVariableDeclarations(node, babelTypes);
+            const names = declarations.map(({ name }) => name);
+            expect(names).toEqual(expected);
         });
     });
 
     describe('MAX_CAPTURE_VARIABLES cap', () => {
-        it('should truncate at MAX_CAPTURE_VARIABLES', () => {
+        it('should truncate parameters at MAX_CAPTURE_VARIABLES', () => {
             const paramNames = Array.from({ length: 30 }, (_, i) => `p${i}`);
             const code = `function f(${paramNames.join(', ')}) {}`;
             const node = parseFunctionNode(code);
-            const result = getVariableNames(node, true, false, babelTypes);
+            const result = getParameterNames(node, babelTypes);
 
             expect(result).toHaveLength(MAX_CAPTURE_VARIABLES);
             expect(result).toEqual(paramNames.slice(0, MAX_CAPTURE_VARIABLES));
@@ -206,21 +185,19 @@ describe('getVariableNames', () => {
             const code = `function f(${paramNames.join(', ')}) {}`;
             const node = parseFunctionNode(code);
 
-            expect(getVariableNames(node, true, false, babelTypes)).toHaveLength(
-                MAX_CAPTURE_VARIABLES,
-            );
+            expect(getParameterNames(node, babelTypes)).toHaveLength(MAX_CAPTURE_VARIABLES);
         });
 
-        it('should cap combined params and locals', () => {
-            const paramNames = Array.from({ length: 20 }, (_, i) => `p${i}`);
-            const localNames = Array.from({ length: 20 }, (_, i) => `v${i}`);
-            const locals = localNames.map((n) => `const ${n} = 0;`).join(' ');
-            const code = `function f(${paramNames.join(', ')}) { ${locals} }`;
+        it('should truncate local declarations at MAX_CAPTURE_VARIABLES', () => {
+            const localNames = Array.from({ length: 30 }, (_, i) => `v${i}`);
+            const locals = localNames.map((name) => `const ${name} = 0;`).join(' ');
+            const code = `function f() { ${locals} }`;
             const node = parseFunctionNode(code);
-            const result = getVariableNames(node, true, true, babelTypes);
+            const declarations = getLocalVariableDeclarations(node, babelTypes);
+            const result = declarations.map(({ name }) => name);
 
             expect(result).toHaveLength(MAX_CAPTURE_VARIABLES);
-            expect(result).toEqual([...paramNames, ...localNames].slice(0, MAX_CAPTURE_VARIABLES));
+            expect(result).toEqual(localNames.slice(0, MAX_CAPTURE_VARIABLES));
         });
     });
 
@@ -228,7 +205,7 @@ describe('getVariableNames', () => {
         it('should return name from a TS parameter property', () => {
             const code = 'class C { constructor(public name: string, private age: number) {} }';
             const node = parseFunctionNode(code);
-            expect(getVariableNames(node, true, false, babelTypes)).toEqual(['name', 'age']);
+            expect(getParameterNames(node, babelTypes)).toEqual(['name', 'age']);
         });
     });
 });

--- a/packages/plugins/live-debugger/src/transform/scopeTracker.ts
+++ b/packages/plugins/live-debugger/src/transform/scopeTracker.ts
@@ -8,50 +8,30 @@ import type { BabelTypesModule } from './babel-path.types';
 
 export const MAX_CAPTURE_VARIABLES = 25;
 
-/**
- * Get variable names to capture for a function.
- * Scans params and direct-child variable declarations to avoid
- * triggering Babel's expensive scope analysis.
- */
-export function getVariableNames(
+export interface LocalVariableTemporalDeadZone {
+    start: number;
+    end: number;
+}
+
+export interface LocalVariableDeclaration {
+    name: string;
+    declarationEnd: number;
+    temporalDeadZones: LocalVariableTemporalDeadZone[];
+}
+
+export function getParameterNames(
     functionNode: t.Function,
-    includeParams: boolean,
-    includeLocals: boolean,
     typesModule: BabelTypesModule,
 ): string[] {
     const variables: string[] = [];
 
-    if (includeParams) {
-        for (const param of functionNode.params) {
-            for (const name of getPatternIdentifiers(param, typesModule)) {
-                // TypeScript's `this` parameter (e.g. `fn(this: Type)`) is not
-                // a real parameter and `this` can't be used as a shorthand
-                // property name in object literals.
-                if (name !== 'this') {
-                    variables.push(name);
-                }
-            }
-        }
-    }
-
-    if (includeLocals && typesModule.isBlockStatement(functionNode.body)) {
-        const paramSet = new Set(
-            functionNode.params.flatMap((p) => getPatternIdentifiers(p, typesModule)),
-        );
-        const functionName =
-            'id' in functionNode && typesModule.isIdentifier(functionNode.id)
-                ? functionNode.id.name
-                : '';
-
-        for (const stmt of functionNode.body.body) {
-            if (typesModule.isVariableDeclaration(stmt)) {
-                for (const decl of stmt.declarations) {
-                    for (const name of getPatternIdentifiers(decl.id, typesModule)) {
-                        if (!paramSet.has(name) && name !== functionName) {
-                            variables.push(name);
-                        }
-                    }
-                }
+    for (const param of functionNode.params) {
+        for (const name of getPatternIdentifiers(param, typesModule)) {
+            // TypeScript's `this` parameter (e.g. `fn(this: Type)`) is not
+            // a real parameter and `this` can't be used as a shorthand
+            // property name in object literals.
+            if (name !== 'this') {
+                variables.push(name);
             }
         }
     }
@@ -61,6 +41,272 @@ export function getVariableNames(
     }
 
     return variables;
+}
+
+export function getLocalVariableDeclarations(
+    functionNode: t.Function,
+    typesModule: BabelTypesModule,
+): LocalVariableDeclaration[] {
+    const variables: LocalVariableDeclaration[] = [];
+
+    if (typesModule.isBlockStatement(functionNode.body)) {
+        const paramNames = functionNode.params.flatMap((param) =>
+            getPatternIdentifiers(param, typesModule),
+        );
+        const paramSet = new Set(paramNames);
+        const functionName =
+            'id' in functionNode && typesModule.isIdentifier(functionNode.id)
+                ? functionNode.id.name
+                : '';
+
+        for (const stmt of functionNode.body.body) {
+            if (typesModule.isVariableDeclaration(stmt)) {
+                const declarationEnd = stmt.end;
+                if (declarationEnd == null) {
+                    continue;
+                }
+
+                for (const decl of stmt.declarations) {
+                    for (const name of getPatternIdentifiers(decl.id, typesModule)) {
+                        if (!paramSet.has(name) && name !== functionName) {
+                            variables.push({
+                                name,
+                                declarationEnd,
+                                temporalDeadZones: [],
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    const cappedVariables =
+        variables.length > MAX_CAPTURE_VARIABLES
+            ? variables.slice(0, MAX_CAPTURE_VARIABLES)
+            : variables;
+
+    if (typesModule.isBlockStatement(functionNode.body)) {
+        const localNames = cappedVariables.map(({ name }) => name);
+        const localNameSet = new Set(localNames);
+        const temporalDeadZonesByName = getNestedTemporalDeadZonesByName(
+            functionNode.body,
+            localNameSet,
+            typesModule,
+        );
+
+        for (const variable of cappedVariables) {
+            variable.temporalDeadZones = temporalDeadZonesByName.get(variable.name) ?? [];
+        }
+    }
+
+    return cappedVariables;
+}
+
+function getNestedTemporalDeadZonesByName(
+    functionBody: t.BlockStatement,
+    localNames: Set<string>,
+    typesModule: BabelTypesModule,
+): Map<string, LocalVariableTemporalDeadZone[]> {
+    const temporalDeadZonesByName = new Map<string, LocalVariableTemporalDeadZone[]>();
+
+    for (const stmt of functionBody.body) {
+        collectTemporalDeadZonesFromStatement(
+            stmt,
+            localNames,
+            temporalDeadZonesByName,
+            typesModule,
+        );
+    }
+
+    return temporalDeadZonesByName;
+}
+
+function collectTemporalDeadZonesFromStatement(
+    stmt: t.Statement,
+    localNames: Set<string>,
+    temporalDeadZonesByName: Map<string, LocalVariableTemporalDeadZone[]>,
+    typesModule: BabelTypesModule,
+): void {
+    if (typesModule.isFunctionDeclaration(stmt) || typesModule.isClassDeclaration(stmt)) {
+        return;
+    }
+
+    if (typesModule.isBlockStatement(stmt)) {
+        collectTemporalDeadZonesFromBlock(stmt, localNames, temporalDeadZonesByName, typesModule);
+    } else if (typesModule.isIfStatement(stmt)) {
+        collectTemporalDeadZonesFromStatement(
+            stmt.consequent,
+            localNames,
+            temporalDeadZonesByName,
+            typesModule,
+        );
+        if (stmt.alternate) {
+            collectTemporalDeadZonesFromStatement(
+                stmt.alternate,
+                localNames,
+                temporalDeadZonesByName,
+                typesModule,
+            );
+        }
+    } else if (
+        typesModule.isForStatement(stmt) ||
+        typesModule.isForInStatement(stmt) ||
+        typesModule.isForOfStatement(stmt) ||
+        typesModule.isWhileStatement(stmt) ||
+        typesModule.isDoWhileStatement(stmt)
+    ) {
+        collectTemporalDeadZonesFromStatement(
+            stmt.body,
+            localNames,
+            temporalDeadZonesByName,
+            typesModule,
+        );
+    } else if (typesModule.isSwitchStatement(stmt)) {
+        collectTemporalDeadZonesFromSwitch(stmt, localNames, temporalDeadZonesByName, typesModule);
+    } else if (typesModule.isTryStatement(stmt)) {
+        collectTemporalDeadZonesFromBlock(
+            stmt.block,
+            localNames,
+            temporalDeadZonesByName,
+            typesModule,
+        );
+        if (stmt.handler) {
+            collectTemporalDeadZonesFromBlock(
+                stmt.handler.body,
+                localNames,
+                temporalDeadZonesByName,
+                typesModule,
+            );
+        }
+        if (stmt.finalizer) {
+            collectTemporalDeadZonesFromBlock(
+                stmt.finalizer,
+                localNames,
+                temporalDeadZonesByName,
+                typesModule,
+            );
+        }
+    } else if (typesModule.isLabeledStatement(stmt) || typesModule.isWithStatement(stmt)) {
+        collectTemporalDeadZonesFromStatement(
+            stmt.body,
+            localNames,
+            temporalDeadZonesByName,
+            typesModule,
+        );
+    }
+}
+
+function collectTemporalDeadZonesFromBlock(
+    block: t.BlockStatement,
+    localNames: Set<string>,
+    temporalDeadZonesByName: Map<string, LocalVariableTemporalDeadZone[]>,
+    typesModule: BabelTypesModule,
+): void {
+    addTemporalDeadZonesFromStatements(
+        block.body,
+        block.start,
+        localNames,
+        temporalDeadZonesByName,
+        typesModule,
+    );
+
+    for (const stmt of block.body) {
+        collectTemporalDeadZonesFromStatement(
+            stmt,
+            localNames,
+            temporalDeadZonesByName,
+            typesModule,
+        );
+    }
+}
+
+function collectTemporalDeadZonesFromSwitch(
+    stmt: t.SwitchStatement,
+    localNames: Set<string>,
+    temporalDeadZonesByName: Map<string, LocalVariableTemporalDeadZone[]>,
+    typesModule: BabelTypesModule,
+): void {
+    for (const caseClause of stmt.cases) {
+        addTemporalDeadZonesFromStatements(
+            caseClause.consequent,
+            stmt.start,
+            localNames,
+            temporalDeadZonesByName,
+            typesModule,
+        );
+
+        for (const consequent of caseClause.consequent) {
+            collectTemporalDeadZonesFromStatement(
+                consequent,
+                localNames,
+                temporalDeadZonesByName,
+                typesModule,
+            );
+        }
+    }
+}
+
+function addTemporalDeadZonesFromStatements(
+    statements: t.Statement[],
+    scopeStart: number | null | undefined,
+    localNames: Set<string>,
+    temporalDeadZonesByName: Map<string, LocalVariableTemporalDeadZone[]>,
+    typesModule: BabelTypesModule,
+): void {
+    if (scopeStart == null) {
+        return;
+    }
+
+    for (const stmt of statements) {
+        if (typesModule.isVariableDeclaration(stmt) && stmt.kind !== 'var') {
+            addVariableDeclarationTemporalDeadZones(
+                stmt,
+                scopeStart,
+                localNames,
+                temporalDeadZonesByName,
+                typesModule,
+            );
+        } else if (typesModule.isClassDeclaration(stmt) && stmt.id) {
+            addTemporalDeadZone(
+                stmt.id.name,
+                scopeStart,
+                stmt.end,
+                localNames,
+                temporalDeadZonesByName,
+            );
+        }
+    }
+}
+
+function addVariableDeclarationTemporalDeadZones(
+    stmt: t.VariableDeclaration,
+    scopeStart: number,
+    localNames: Set<string>,
+    temporalDeadZonesByName: Map<string, LocalVariableTemporalDeadZone[]>,
+    typesModule: BabelTypesModule,
+): void {
+    for (const decl of stmt.declarations) {
+        for (const name of getPatternIdentifiers(decl.id, typesModule)) {
+            addTemporalDeadZone(name, scopeStart, stmt.end, localNames, temporalDeadZonesByName);
+        }
+    }
+}
+
+function addTemporalDeadZone(
+    name: string,
+    start: number,
+    end: number | null | undefined,
+    localNames: Set<string>,
+    temporalDeadZonesByName: Map<string, LocalVariableTemporalDeadZone[]>,
+): void {
+    if (end == null || !localNames.has(name)) {
+        return;
+    }
+
+    const existingZones = temporalDeadZonesByName.get(name) ?? [];
+    existingZones.push({ start, end });
+    temporalDeadZonesByName.set(name, existingZones);
 }
 
 function getPatternIdentifiers(pattern: t.Node, typesModule: BabelTypesModule): string[] {

--- a/packages/tests/src/e2e/liveDebugger/project/patterns.js
+++ b/packages/tests/src/e2e/liveDebugger/project/patterns.js
@@ -5,12 +5,12 @@
 // Each function below matches a distinct instrumentation code path exercised
 // by the smoke tests in live-debugger/src/transform/index.test.ts.
 
-// 1. Block body, single value return, shared entry/exit snapshot.
+// 1. Block body, single value return, parameter snapshot.
 export function add(a, b) {
     return a + b;
 }
 
-// 2. Block body with local variables — split entry/exit snapshots ($dd_eN vs $dd_lN).
+// 2. Block body with local variables — parameter snapshot and inline local capture.
 export function addWithLocal(a, b) {
     const sum = a + b;
     return sum;


### PR DESCRIPTION
### What and why?

Fixes a Live Debugger instrumentation bug where return probes could read local variables before their declaration had executed. The previous transform emitted one function-wide local capture helper, so an early return before a later `let`/`const` declaration could trigger a TDZ error when probes were active.

### How?

Track direct local declarations with their declaration end positions and compute return capture arguments per exit point. Local captures are now inlined at `$dd_return` call sites only when the local declaration is available for that return, while parameter capture still uses the shared entry helper.

Updated transform coverage for inline local captures, no-local returns, and the early-return-before-local edge case. Updated the Live Debugger README examples to remove the old local helper shape.

The current version of this branch is published to npm as version `3.1.8-dev.2`.