### PR TITLE
chore: update live debugger codeowners to debugger-nodejs team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,4 +44,5 @@ packages/plugins/output                                               @yoannmoin
 packages/plugins/apps                                                 @DataDog/app-builder-high-code @yoannmoinet
 
 # Live Debugger
-packages/plugins/live-debugger/                                       @DataDog/debugger @yoannmoinet
+packages/plugins/live-debugger/                                       @DataDog/debugger-nodejs @yoannmoinet
+packages/tests/src/e2e/liveDebugger/                                  @DataDog/debugger-nodejs @yoannmoinet


### PR DESCRIPTION
### What and why?

Updates `CODEOWNERS` for the Live Debugger plugin to point at the `@DataDog/debugger-nodejs` team rather than the broader `@DataDog/debugger` team, ensuring review requests go to the team that actually owns this code. Also adds an entry so the Live Debugger e2e tests are owned by the same team.

### How?

- Changed the owner of `packages/plugins/live-debugger/` from `@DataDog/debugger @yoannmoinet` to `@DataDog/debugger-nodejs @yoannmoinet`.
- Added `packages/tests/src/e2e/liveDebugger/` owned by `@DataDog/debugger-nodejs @yoannmoinet`.
