### PR TITLE
Add bugs metadata to Vite plugin package

### DIFF
--- a/packages/published/vite-plugin/package.json
+++ b/packages/published/vite-plugin/package.json
@@ -104,5 +104,8 @@
         "magic-string": {
             "optional": true
         }
+    },
+    "bugs": {
+        "url": "https://github.com/DataDog/build-plugins/issues"
     }
 }


### PR DESCRIPTION
Adds the package issue tracker metadata for `@datadog/vite-plugin`.

The npm package already publishes repository, homepage, and license metadata, but it does not expose `bugs.url`. This adds the repository issue tracker URL without changing runtime code.

Verification:
- Parsed `packages/published/vite-plugin/package.json` and confirmed `bugs.url` points to `https://github.com/DataDog/build-plugins/issues`.
