### PR TITLE
fix live debugger sequence arrow body capture

### DIFF
--- a/packages/plugins/live-debugger/src/transform/index.test.ts
+++ b/packages/plugins/live-debugger/src/transform/index.test.ts
@@ -152,6 +152,17 @@ describe('transformCode', () => {
             expect(result.code).toContain('$dd_probes');
             expect(result.code).toContain('($dd_rv0 = x + 1');
         });
+
+        it('should preserve comma operator semantics in arrow expression body', () => {
+            const result = transformCode({
+                ...BASE_OPTIONS,
+                code: 'const fn = () => (sideEffect(), value);',
+            });
+
+            expect(result.instrumentedCount).toBe(1);
+            expect(validateSyntax(result.code, '/src/utils.ts')).toBeNull();
+            expect(result.code).toContain('const $dd_rv0 = (sideEffect(), value);');
+        });
     });
 
     describe('nested functions', () => {

--- a/packages/plugins/live-debugger/src/transform/index.ts
+++ b/packages/plugins/live-debugger/src/transform/index.ts
@@ -150,6 +150,7 @@ interface FunctionTarget {
     bodyEnd: number;
     functionEnd: number;
     isExpressionBody: boolean;
+    hasSequenceExpressionBody: boolean;
     needsTrailingReturn: boolean;
     bodyParenStart: number | undefined;
     directivesEnd: number | undefined;
@@ -288,6 +289,8 @@ export function transformCode(options: TransformOptions): TransformResult {
                 const isExpressionBody =
                     babelTypes.isArrowFunctionExpression(node) &&
                     !babelTypes.isBlockStatement(node.body);
+                const hasSequenceExpressionBody =
+                    isExpressionBody && babelTypes.isSequenceExpression(node.body);
 
                 const returns: ReturnInfo[] = [];
                 const needsTrailingReturn =
@@ -313,6 +316,7 @@ export function transformCode(options: TransformOptions): TransformResult {
                     bodyEnd: node.body.end!,
                     functionEnd: node.end!,
                     isExpressionBody,
+                    hasSequenceExpressionBody,
                     needsTrailingReturn,
                     bodyParenStart:
                         isExpressionBody && typeof node.body.extra?.parenStart === 'number'
@@ -382,6 +386,7 @@ function injectInstrumentation(s: MagicStringType, code: string, target: Functio
         bodyEnd,
         functionEnd,
         isExpressionBody,
+        hasSequenceExpressionBody,
         bodyParenStart,
         directivesEnd,
     } = target;
@@ -437,8 +442,9 @@ function injectInstrumentation(s: MagicStringType, code: string, target: Functio
             .join('\n');
 
         const returnCaptureArgs = getReturnCaptureArgs(entryHelper, hasParams, localVars, bodyEnd);
+        const expressionSuffix = hasSequenceExpressionBody ? ');' : ';';
         const suffix = [
-            ';',
+            expressionSuffix,
             `if (${probeVarName}) $dd_return(${probeVarName}, ${rvVarName}, this${returnCaptureArgs});`,
             `return ${rvVarName};`,
             `} ${catchBlock}`,
@@ -451,7 +457,10 @@ function injectInstrumentation(s: MagicStringType, code: string, target: Functio
         // For a single-char body (e.g. `() => 1`) the two ranges would
         // collide, so we fall back to one update covering the whole body.
         if (bodyEnd - bodyStart >= 2) {
-            s.update(bodyStart, bodyStart + 1, prefix + code[bodyStart]);
+            const bodyPrefix = hasSequenceExpressionBody
+                ? `${prefix}(${code[bodyStart]}`
+                : prefix + code[bodyStart];
+            s.update(bodyStart, bodyStart + 1, bodyPrefix);
             s.update(bodyEnd - 1, bodyEnd, code[bodyEnd - 1] + suffix);
         } else {
             s.update(bodyStart, bodyEnd, prefix + code.slice(bodyStart, bodyEnd) + suffix);


### PR DESCRIPTION
### What and why?

Fix Live Debugger instrumentation for expression-bodied arrow functions whose body is a comma/sequence expression.

Live Debugger rewrites expression-bodied arrows into block bodies so it can report the function's return value before returning it. To do that, it stores the original expression result in a temporary `$dd_rv` variable, calls the return-reporting hook with that value, then returns the same value.

For example, this valid input:

```ts
const fn = () => (sideEffect(), value);
```

was previously instrumented into invalid JavaScript like this:

```ts
const $dd_rv0 = sideEffect(), value;
```

Because the captured expression was not parenthesized, the comma operator was parsed as a variable declarator separator instead of part of the `$dd_rv0` initializer.

### How?

Detect sequence-expression arrow bodies while collecting transform targets and wrap only those captured return-value initializers in parentheses.

The instrumented output now keeps the sequence expression grouped while still storing its final result in `$dd_rv0` for return reporting:

```ts
const $dd_rv0 = (sideEffect(), value);
```

Added a regression test that verifies the emitted output remains syntactically valid.
