### PR TITLE
Fix nested paren arrow bodies in Live Debugger

### DIFF
--- a/packages/plugins/live-debugger/src/transform/index.test.ts
+++ b/packages/plugins/live-debugger/src/transform/index.test.ts
@@ -163,6 +163,28 @@ describe('transformCode', () => {
             expect(validateSyntax(result.code, '/src/utils.ts')).toBeNull();
             expect(result.code).toContain('const $dd_rv0 = (sideEffect(), value);');
         });
+
+        it('should instrument arrow expression body wrapped in nested parentheses', () => {
+            const result = transformCode({
+                ...BASE_OPTIONS,
+                code: 'const fn = () => ((1));',
+            });
+
+            expect(result.instrumentedCount).toBe(1);
+            const syntaxError = validateSyntax(result.code, '/src/utils.ts');
+            expect(syntaxError).toBeNull();
+        });
+
+        it('should instrument arrow object expression body wrapped in nested parentheses', () => {
+            const result = transformCode({
+                ...BASE_OPTIONS,
+                code: 'const fn = () => (({a: 1}));',
+            });
+
+            expect(result.instrumentedCount).toBe(1);
+            const syntaxError = validateSyntax(result.code, '/src/utils.ts');
+            expect(syntaxError).toBeNull();
+        });
     });
 
     describe('nested functions', () => {

--- a/packages/plugins/live-debugger/src/transform/index.ts
+++ b/packages/plugins/live-debugger/src/transform/index.ts
@@ -414,19 +414,18 @@ function injectInstrumentation(s: MagicStringType, code: string, target: Functio
         // Handle parenthesized expression bodies: () => ({key: value})
         // The parentheses must be removed when converting to a block body,
         // otherwise the output would be => ({block_code}) which is a syntax error.
-        // Uses Babel's `extra.parenStart` for the opening `(` and scans between
-        // bodyEnd and functionEnd for the closing `)`.
+        // Babel stores nested bodies like `((1))` as body `1`, so every wrapper
+        // paren around the body range must be removed before injecting a block.
         if (bodyParenStart != null) {
-            let parenAfter = -1;
-            for (let i = bodyEnd; i < functionEnd; i++) {
-                if (code[i] === ')') {
-                    parenAfter = i;
-                    break;
-                }
-            }
-            if (parenAfter !== -1) {
-                s.remove(bodyParenStart, bodyParenStart + 1);
-                s.remove(parenAfter, parenAfter + 1);
+            const openingParens = getLeadingArrowBodyParens(code, bodyParenStart, bodyStart);
+            const closingParens = getTrailingArrowBodyParens(code, bodyEnd, functionEnd);
+            const parenCount = Math.min(openingParens.length, closingParens.length);
+
+            for (let i = 0; i < parenCount; i++) {
+                const openingParen = openingParens[i];
+                const closingParen = closingParens[i];
+                s.remove(openingParen, openingParen + 1);
+                s.remove(closingParen, closingParen + 1);
             }
         }
 
@@ -551,6 +550,26 @@ function getReturnCaptureArgs(
         return `, undefined, ${localsArg}`;
     }
     return '';
+}
+
+function getLeadingArrowBodyParens(code: string, start: number, end: number): number[] {
+    const parens: number[] = [];
+    for (let i = start; i < end; i++) {
+        if (code[i] === '(') {
+            parens.push(i);
+        }
+    }
+    return parens;
+}
+
+function getTrailingArrowBodyParens(code: string, start: number, end: number): number[] {
+    const parens: number[] = [];
+    for (let i = end - 1; i >= start; i--) {
+        if (code[i] === ')') {
+            parens.push(i);
+        }
+    }
+    return parens;
 }
 
 function getLocalCaptureArg(


### PR DESCRIPTION
### What and why?

Fix Live Debugger instrumentation for arrow expression bodies wrapped in multiple parentheses. Babel exposes the unwrapped expression range for these bodies, so the previous paren-stripping logic could leave wrapper parens around the injected block and generate invalid JavaScript.

Input examples that now transform correctly:

```ts
const getNumber = () => ((1));
const getObject = () => (({a: 1}));
```

Before this fix, `const getNumber = () => ((1));` could be transformed into invalid syntax shaped like this:

```ts
const getNumber = () => ({
const $dd_p0 = $dd_probes('src/utils.ts;getNumber');
try {
  const $dd_rv0 = 1;
  return $dd_rv0;
} catch(e) {
  throw e;
}
});
```

The injected block was left inside a parenthesized expression, so the first `const` caused a syntax error.

After this fix, the same input is still instrumented and produces a valid block-bodied arrow function shaped like this:

```ts
const getNumber = () => {
const $dd_p0 = $dd_probes('src/utils.ts;getNumber');
try {
  const $dd_rv0 = 1;
  if ($dd_p0) $dd_return($dd_p0, $dd_rv0, this);
  return $dd_rv0;
} catch(e) {
  if ($dd_p0) $dd_throw($dd_p0, e, this);
  throw e;
}
};
```

Single-wrapper cases such as `() => (1)` and `() => ({a: 1})` already worked and continue to work.

### How?

Remove every wrapper paren found between Babel's recorded arrow body range and the containing arrow function end before injecting the block body. Added regression tests covering nested parenthesized scalar and object expression bodies, and verified with `yarn test:unit packages/plugins/live-debugger/src/transform/index.test.ts`.
