### PR TITLE
Fix sequence return capture in Live Debugger

### DIFF
--- a/packages/plugins/live-debugger/src/transform/index.test.ts
+++ b/packages/plugins/live-debugger/src/transform/index.test.ts
@@ -3,6 +3,7 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping';
+import { runInNewContext } from 'vm';
 
 import { transformCode, validateSyntax } from './index';
 
@@ -126,6 +127,32 @@ describe('transformCode', () => {
             expect(result.code).toContain('$dd_return');
             expect(result.code).toContain('undefined');
             expect(result.code).toContain('return;');
+        });
+
+        it('should preserve sequence expression semantics in return statements', () => {
+            const result = transformCode({
+                ...BASE_OPTIONS,
+                code: 'function f() { let a = 0; return (a = 2), a + 10; }',
+            });
+
+            expect(result.instrumentedCount).toBe(1);
+            expect(validateSyntax(result.code, '/src/utils.ts')).toBeNull();
+            expect(result.code).toContain('return ($dd_rv0 = ((a = 2), a + 10),');
+            expect(runTransformedFunction(result.code)).toBe(12);
+        });
+
+        it('should preserve all sequence expression side effects in return statements', () => {
+            const result = transformCode({
+                ...BASE_OPTIONS,
+                code: 'function f() { const log = []; return log.push(1), log.push(2), log.length; }',
+            });
+
+            expect(result.instrumentedCount).toBe(1);
+            expect(validateSyntax(result.code, '/src/utils.ts')).toBeNull();
+            expect(result.code).toContain(
+                'return ($dd_rv0 = (log.push(1), log.push(2), log.length),',
+            );
+            expect(runTransformedFunction(result.code)).toBe(2);
         });
     });
 
@@ -991,3 +1018,24 @@ describe('transformCode', () => {
         });
     });
 });
+
+interface RuntimeGlobal {
+    result: unknown;
+}
+
+interface RuntimeSandbox {
+    $dd_probes: () => undefined;
+    globalThis: RuntimeGlobal;
+}
+
+// TODO: Investigate if we can use this in more tests.
+function runTransformedFunction(code: string): unknown {
+    const runtimeGlobal: RuntimeGlobal = { result: undefined };
+    const sandbox: RuntimeSandbox = {
+        $dd_probes: () => undefined,
+        globalThis: runtimeGlobal,
+    };
+    const executableCode = `${code}\nglobalThis.result = f();`;
+    runInNewContext(executableCode, sandbox);
+    return runtimeGlobal.result;
+}

--- a/packages/plugins/live-debugger/src/transform/index.ts
+++ b/packages/plugins/live-debugger/src/transform/index.ts
@@ -143,6 +143,7 @@ interface ReturnInfo {
     end: number;
     argStart: number | undefined;
     argEnd: number | undefined;
+    hasSequenceExpressionArgument: boolean;
 }
 
 interface FunctionTarget {
@@ -484,10 +485,15 @@ function injectInstrumentation(s: MagicStringType, code: string, target: Functio
 
             if (ret.argStart != null && ret.argEnd != null) {
                 // return EXPR; → return ($dd_rvN = EXPR, probe ? $dd_return(...) : $dd_rvN);
-                s.appendLeft(ret.argStart, `(${rvVarName} = `);
+                const assignmentPrefix = ret.hasSequenceExpressionArgument
+                    ? `(${rvVarName} = (`
+                    : `(${rvVarName} = `;
+                const assignmentSuffix = ret.hasSequenceExpressionArgument ? ')' : '';
+
+                s.appendLeft(ret.argStart, assignmentPrefix);
                 s.appendLeft(
                     ret.argEnd,
-                    `, ${probeVarName} ? $dd_return(${probeVarName}, ${rvVarName}, this${returnCaptureArgs}) : ${rvVarName})`,
+                    `${assignmentSuffix}, ${probeVarName} ? $dd_return(${probeVarName}, ${rvVarName}, this${returnCaptureArgs}) : ${rvVarName})`,
                 );
             } else {
                 // return; → if (probe) $dd_return(...); return;
@@ -614,6 +620,7 @@ function collectReturnStatements(
                 end: stmt.end!,
                 argStart: stmt.argument?.start ?? undefined,
                 argEnd: stmt.argument?.end ?? undefined,
+                hasSequenceExpressionArgument: typesModule.isSequenceExpression(stmt.argument),
             });
             continue;
         }


### PR DESCRIPTION
### What and why?

Fix Live Debugger instrumentation for `return` statements whose argument is a sequence expression. Before this change, the instrumentation assigned only the first operand into `$dd_rv`, so `return (a = 2), a + 10` returned `2` instead of `12`, and `return log.push(1), log.push(2), log.length` returned `1` instead of `2`.

### How?

Track whether each collected return argument is a Babel `SequenceExpression`. When injecting return instrumentation, wrap only those sequence arguments in an extra pair of parentheses so `$dd_rv` captures the full sequence result before the probe comma expression is appended.

Added focused regression tests that validate syntax, assert the generated grouping, and execute the transformed code in a small VM sandbox to prove the reported runtime results.

Validated with `yarn test:unit packages/plugins/live-debugger/src/transform/index.test.ts` and `yarn workspace @dd/live-debugger-plugin typecheck`.
