### PR TITLE
Fix Live Debugger probe IDs with quoted method names

### DIFF
--- a/packages/plugins/live-debugger/src/transform/index.test.ts
+++ b/packages/plugins/live-debugger/src/transform/index.test.ts
@@ -702,16 +702,15 @@ describe('transformCode', () => {
             expect(validateSyntax(result.code, '/src/utils.ts')).toBeNull();
         });
 
-        it('should produce invalid syntax when a method name contains a single quote (known limitation)', () => {
+        it('should escape a method name containing a single quote', () => {
             const result = transformCode({
                 ...BASE_OPTIONS,
                 code: `const obj = { "it's"() { return 1; } };`,
             });
 
-            // The unescaped single quote in the function ID breaks the
-            // generated $dd_probes('...') call — see TODO in injectInstrumentation.
             expect(result.instrumentedCount).toBe(1);
-            expect(validateSyntax(result.code, '/src/utils.ts')).not.toBeNull();
+            expect(result.code).toContain("$dd_probes('src/utils.ts;it\\'s')");
+            expect(validateSyntax(result.code, '/src/utils.ts')).toBeNull();
         });
     });
 

--- a/packages/plugins/live-debugger/src/transform/index.ts
+++ b/packages/plugins/live-debugger/src/transform/index.ts
@@ -136,6 +136,27 @@ function isMissingPeerDepError(error: unknown): error is NodeModuleError {
     return REQUIRED_PEER_DEPS.some((dep) => error.message.includes(dep));
 }
 
+function escapeSingleQuotedJavaScriptString(value: string): string {
+    return value.replace(/['\\\n\r\u2028\u2029]/g, (character) => {
+        switch (character) {
+            case "'":
+                return "\\'";
+            case '\\':
+                return '\\\\';
+            case '\n':
+                return '\\n';
+            case '\r':
+                return '\\r';
+            case '\u2028':
+                return '\\u2028';
+            case '\u2029':
+                return '\\u2029';
+            default:
+                return character;
+        }
+    });
+}
+
 const HAS_FUNCTION_SYNTAX = /\bfunction\b|=>|\bclass\b|\)\s*\{/;
 
 interface ReturnInfo {
@@ -400,9 +421,8 @@ function injectInstrumentation(s: MagicStringType, code: string, target: Functio
 
     const argsArg = hasParams ? `, ${entryHelper}()` : '';
 
-    // TODO: functionId is not escaped — if it contains a single quote (e.g. quoted method names),
-    // the generated code will be invalid. Escaping is not currently supported.
-    const probeDecl = `const ${probeVarName} = $dd_probes('${functionId}');`;
+    const escapedFunctionId = escapeSingleQuotedJavaScriptString(functionId);
+    const probeDecl = `const ${probeVarName} = $dd_probes('${escapedFunctionId}');`;
     const entryHelperDecl = hasParams ? `const ${entryHelper} = () => ({${entryVarsList}});` : '';
     const entryCall = `if (${probeVarName}) $dd_entry(${probeVarName}, this${argsArg});`;
     const catchBlock = `catch(e) { if (${probeVarName}) $dd_throw(${probeVarName}, e, this${argsArg}); throw e; }`;


### PR DESCRIPTION
### What and why?

Live Debugger instrumentation could generate invalid JavaScript when a function ID contained a single quote, such as an object method named `"it's"`. This fixes the generated `$dd_probes(...)` call so those function IDs are escaped before being embedded in the injected source.

### How?

Added a small escaping helper for single-quoted JavaScript string literals and use it when generating the probe declaration. Updated the quoted method name regression test to assert the escaped function ID and validate the transformed output syntax.
