### PR TITLE
Fix bump workflow branch creation

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -100,7 +100,7 @@ jobs:
           echo "Pushing branch ${{ steps.vars.outputs.branch_name }}..."
           # The signed-commit action expects the remote branch to exist, but it
           # should recreate the local bump commit itself so GitHub verifies it.
-          git push origin HEAD~1:${{ steps.vars.outputs.branch_name }}
+          git push origin HEAD~1:refs/heads/${{ steps.vars.outputs.branch_name }}
 
           echo "created=true" >> $GITHUB_OUTPUT
         env:


### PR DESCRIPTION
### What and why?

The bump workflow failed while creating the remote branch for a version bump. Git rejected `git push origin HEAD~1:bump-version-v3.2.0` because the source is a commit expression and the destination for a new branch was not a fully qualified ref.

Failure: https://github.com/DataDog/build-plugins/actions/runs/27304008949/job/80656884259

### How?

Fully qualify the destination ref when seeding the remote branch for `Asana/push-signed-commits`, using `refs/heads/${{ steps.vars.outputs.branch_name }}`. This keeps the existing signed-commit flow intact while satisfying Git's refspec requirements.
