### PR TITLE
chore(vite-plugin): add bugs metadata

### DIFF
--- a/packages/published/vite-plugin/package.json
+++ b/packages/published/vite-plugin/package.json
@@ -18,6 +18,9 @@
         "url": "https://github.com/DataDog/build-plugins",
         "directory": "packages/published/vite-plugin"
     },
+    "bugs": {
+        "url": "https://github.com/DataDog/build-plugins/issues"
+    },
     "main": "./dist/src/index.js",
     "module": "./dist/src/index.mjs",
     "types": "./dist/src/index.d.ts",


### PR DESCRIPTION
## Summary
- add missing npm `bugs.url` metadata for `@datadog/vite-plugin`

This is package metadata-only: no runtime code, dependencies, exports, generated files, or build behavior changed.

## Testing
- `node` package metadata assertion
- `cd packages/published/vite-plugin && npm pack --dry-run --ignore-scripts --json`
- `git diff --check`