### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/published/vite-plugin/package.json
+++ b/packages/published/vite-plugin/package.json
@@ -1,108 +1,111 @@
 {
-    "name": "@datadog/vite-plugin",
-    "packageManager": "yarn@4.0.2",
-    "version": "3.2.0",
-    "license": "MIT",
-    "author": "Datadog",
-    "description": "Datadog Vite Plugin",
-    "keywords": [
-        "datadog",
-        "vite",
-        "bundler",
-        "plugin",
-        "unplugin"
-    ],
-    "homepage": "https://github.com/DataDog/build-plugins#readme",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/DataDog/build-plugins",
-        "directory": "packages/published/vite-plugin"
-    },
-    "main": "./dist/src/index.js",
-    "module": "./dist/src/index.mjs",
+  "name": "@datadog/vite-plugin",
+  "packageManager": "yarn@4.0.2",
+  "version": "3.2.0",
+  "bugs": {
+    "url": "https://github.com/DataDog/build-plugins/issues"
+  },
+  "license": "MIT",
+  "author": "Datadog",
+  "description": "Datadog Vite Plugin",
+  "keywords": [
+    "datadog",
+    "vite",
+    "bundler",
+    "plugin",
+    "unplugin"
+  ],
+  "homepage": "https://github.com/DataDog/build-plugins#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DataDog/build-plugins",
+    "directory": "packages/published/vite-plugin"
+  },
+  "main": "./dist/src/index.js",
+  "module": "./dist/src/index.mjs",
+  "types": "./dist/src/index.d.ts",
+  "exports": {
+    "./dist/src": "./dist/src/index.js",
+    "./dist/src/*": "./dist/src/*",
+    ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
     "types": "./dist/src/index.d.ts",
     "exports": {
-        "./dist/src": "./dist/src/index.js",
-        "./dist/src/*": "./dist/src/*",
-        ".": "./src/index.ts"
-    },
-    "publishConfig": {
-        "access": "public",
-        "types": "./dist/src/index.d.ts",
-        "exports": {
-            "./package.json": "./package.json",
-            ".": {
-                "import": "./dist/src/index.mjs",
-                "require": "./dist/src/index.js",
-                "types": "./dist/src/index.d.ts"
-            }
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "buildCmd": "rollup --config rollup.config.mjs",
-        "build": "yarn clean && yarn buildCmd",
-        "clean": "rm -rf dist",
-        "prepack": "yarn build",
-        "typecheck": "tsc --noEmit",
-        "watch": "yarn build --watch"
-    },
-    "dependencies": {
-        "@datadog/js-instrumentation-wasm": "1.0.8",
-        "@jridgewell/remapping": "2.3.5",
-        "async-retry": "1.3.3",
-        "chalk": "2.3.1",
-        "eslint-scope": "7.2.2",
-        "glob": "11.1.0",
-        "json-stream-stringify": "3.1.6",
-        "jszip": "3.10.1",
-        "outdent": "0.8.0",
-        "p-queue": "6.6.2",
-        "pretty-bytes": "5.6.0",
-        "simple-git": "3.36.0",
-        "unplugin": "2.3.11"
-    },
-    "devDependencies": {
-        "@babel/core": "7.24.5",
-        "@babel/preset-env": "7.24.5",
-        "@babel/preset-typescript": "7.24.1",
-        "@dd/factory": "workspace:*",
-        "@dd/tools": "workspace:*",
-        "@rollup/plugin-babel": "6.0.4",
-        "@rollup/plugin-commonjs": "28.0.1",
-        "@rollup/plugin-esm-shim": "0.1.8",
-        "@rollup/plugin-json": "6.1.0",
-        "@rollup/plugin-node-resolve": "15.3.0",
-        "@rollup/plugin-terser": "0.4.4",
-        "@types/babel__core": "^7",
-        "@types/babel__preset-env": "^7",
-        "dts-bundle-generator": "patch:dts-bundle-generator@npm%3A9.5.1#~/.yarn/patches/dts-bundle-generator-npm-9.5.1-0927b6826f.patch",
-        "esbuild": "0.25.8",
-        "rollup": "4.45.1",
-        "rollup-plugin-esbuild": "6.1.1",
-        "typescript": "5.4.3"
-    },
-    "peerDependencies": {
-        "@babel/parser": "^7.24.5",
-        "@babel/traverse": "^7.24.5",
-        "@babel/types": "^7.24.5",
-        "magic-string": "^0.30.0",
-        "vite": ">= 5.x <= 7.x"
-    },
-    "peerDependenciesMeta": {
-        "@babel/parser": {
-            "optional": true
-        },
-        "@babel/traverse": {
-            "optional": true
-        },
-        "@babel/types": {
-            "optional": true
-        },
-        "magic-string": {
-            "optional": true
-        }
+      "./package.json": "./package.json",
+      ".": {
+        "import": "./dist/src/index.mjs",
+        "require": "./dist/src/index.js",
+        "types": "./dist/src/index.d.ts"
+      }
     }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "buildCmd": "rollup --config rollup.config.mjs",
+    "build": "yarn clean && yarn buildCmd",
+    "clean": "rm -rf dist",
+    "prepack": "yarn build",
+    "typecheck": "tsc --noEmit",
+    "watch": "yarn build --watch"
+  },
+  "dependencies": {
+    "@datadog/js-instrumentation-wasm": "1.0.8",
+    "@jridgewell/remapping": "2.3.5",
+    "async-retry": "1.3.3",
+    "chalk": "2.3.1",
+    "eslint-scope": "7.2.2",
+    "glob": "11.1.0",
+    "json-stream-stringify": "3.1.6",
+    "jszip": "3.10.1",
+    "outdent": "0.8.0",
+    "p-queue": "6.6.2",
+    "pretty-bytes": "5.6.0",
+    "simple-git": "3.36.0",
+    "unplugin": "2.3.11"
+  },
+  "devDependencies": {
+    "@babel/core": "7.24.5",
+    "@babel/preset-env": "7.24.5",
+    "@babel/preset-typescript": "7.24.1",
+    "@dd/factory": "workspace:*",
+    "@dd/tools": "workspace:*",
+    "@rollup/plugin-babel": "6.0.4",
+    "@rollup/plugin-commonjs": "28.0.1",
+    "@rollup/plugin-esm-shim": "0.1.8",
+    "@rollup/plugin-json": "6.1.0",
+    "@rollup/plugin-node-resolve": "15.3.0",
+    "@rollup/plugin-terser": "0.4.4",
+    "@types/babel__core": "^7",
+    "@types/babel__preset-env": "^7",
+    "dts-bundle-generator": "patch:dts-bundle-generator@npm%3A9.5.1#~/.yarn/patches/dts-bundle-generator-npm-9.5.1-0927b6826f.patch",
+    "esbuild": "0.25.8",
+    "rollup": "4.45.1",
+    "rollup-plugin-esbuild": "6.1.1",
+    "typescript": "5.4.3"
+  },
+  "peerDependencies": {
+    "@babel/parser": "^7.24.5",
+    "@babel/traverse": "^7.24.5",
+    "@babel/types": "^7.24.5",
+    "magic-string": "^0.30.0",
+    "vite": ">= 5.x <= 7.x"
+  },
+  "peerDependenciesMeta": {
+    "@babel/parser": {
+      "optional": true
+    },
+    "@babel/traverse": {
+      "optional": true
+    },
+    "@babel/types": {
+      "optional": true
+    },
+    "magic-string": {
+      "optional": true
+    }
+  }
 }


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/published/vite-plugin/package.json`.

Fixes npm tooling unable to resolve package metadata.