### PR TITLE
chore: widen @rspack/core peer dep range to 1.x || 2.x

### DIFF
--- a/packages/published/rspack-plugin/package.json
+++ b/packages/published/rspack-plugin/package.json
@@ -88,7 +88,7 @@
         "@babel/parser": "^7.24.5",
         "@babel/traverse": "^7.24.5",
         "@babel/types": "^7.24.5",
-        "@rspack/core": "1.x",
+        "@rspack/core": "1.x || 2.x",
         "magic-string": "^0.30.0"
     },
     "peerDependenciesMeta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1830,7 +1830,7 @@ __metadata:
     "@babel/parser": ^7.24.5
     "@babel/traverse": ^7.24.5
     "@babel/types": ^7.24.5
-    "@rspack/core": 1.x
+    "@rspack/core": 1.x || 2.x
     magic-string: ^0.30.0
   peerDependenciesMeta:
     "@babel/parser":


### PR DESCRIPTION
## Summary

Widens the `@rspack/core` peer dependency range in `@datadog/rspack-plugin` from `"1.x"` to `"1.x || 2.x"`, allowing users on rspack v2 to install the plugin without peer dep conflicts.

This is a fast-track subset of #419 — the full rspack v2 upgrade (experiments.css fix, @rspack/core bump in tests/tools) will follow separately.

Fixes #418