### PR TITLE
Support optional dependency integrity

### DIFF
--- a/packages/tools/src/commands/integrity/dependencies.test.ts
+++ b/packages/tools/src/commands/integrity/dependencies.test.ts
@@ -1,0 +1,118 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import { outputJsonSync, readJsonSync } from '@dd/core/helpers/fs';
+import { updateDependencies } from '@dd/tools/commands/integrity/dependencies';
+import type { Workspace } from '@dd/tools/types';
+
+jest.mock('@dd/tools/constants', () => ({
+    ROOT: '/repo',
+}));
+
+jest.mock('@dd/core/helpers/fs', () => ({
+    outputJsonSync: jest.fn(),
+    readJsonSync: jest.fn(),
+}));
+
+const mockOutputJsonSync = jest.mocked(outputJsonSync);
+const mockReadJsonSync = jest.mocked(readJsonSync);
+
+const getWorkspace = (name: string): Workspace => ({
+    name,
+    slug: name.replace(/^@[^/]+\//, '').replace(/[^a-z0-9]+/g, '-'),
+    location: `packages/${name.replace(/^@[^/]+\//, '')}`,
+});
+
+const mockPackageJsons = (packages: Record<string, Record<string, unknown>>) => {
+    mockReadJsonSync.mockImplementation((filePath) => {
+        const match = String(filePath).match(/\/repo\/(.+)\/package\.json$/);
+        if (!match) {
+            throw new Error(`Unexpected package path: ${filePath}`);
+        }
+
+        const pkg = packages[match[1]];
+        if (!pkg) {
+            throw new Error(`Missing package fixture for: ${match[1]}`);
+        }
+
+        return pkg;
+    });
+};
+
+describe('updateDependencies', () => {
+    beforeEach(() => {
+        jest.spyOn(console, 'log').mockImplementation();
+    });
+
+    test('writes package.json once when dependencies and optionalDependencies both change', async () => {
+        const bundler = getWorkspace('@datadog/write-once-plugin');
+        const internalDependency = getWorkspace('@dd/write-once-internal');
+
+        mockPackageJsons({
+            [bundler.location]: {
+                dependencies: {
+                    [internalDependency.name]: 'workspace:*',
+                    extra: '1.0.0',
+                },
+                optionalDependencies: {
+                    'old-optional': '1.0.0',
+                },
+            },
+            [internalDependency.location]: {
+                dependencies: {
+                    required: '2.0.0',
+                },
+                optionalDependencies: {
+                    optional: '3.0.0',
+                },
+            },
+        });
+
+        const errors = await updateDependencies([bundler, internalDependency], [bundler]);
+
+        expect(errors).toEqual([]);
+        expect(mockOutputJsonSync).toHaveBeenCalledTimes(1);
+        expect(mockOutputJsonSync).toHaveBeenCalledWith(
+            '/repo/packages/write-once-plugin/package.json',
+            {
+                dependencies: {
+                    required: '2.0.0',
+                },
+                optionalDependencies: {
+                    optional: '3.0.0',
+                },
+            },
+        );
+    });
+
+    test('removes optionalDependencies when the expected record is empty', async () => {
+        const bundler = getWorkspace('@datadog/remove-empty-plugin');
+        const internalDependency = getWorkspace('@dd/remove-empty-internal');
+
+        mockPackageJsons({
+            [bundler.location]: {
+                dependencies: {
+                    [internalDependency.name]: 'workspace:*',
+                },
+                optionalDependencies: {
+                    'old-optional': '1.0.0',
+                },
+            },
+            [internalDependency.location]: {
+                dependencies: {},
+            },
+        });
+
+        const errors = await updateDependencies([bundler, internalDependency], [bundler]);
+
+        expect(errors).toEqual([]);
+        expect(mockOutputJsonSync).toHaveBeenCalledTimes(1);
+        expect(mockOutputJsonSync).toHaveBeenCalledWith(
+            '/repo/packages/remove-empty-plugin/package.json',
+            {
+                dependencies: {},
+            },
+        );
+    });
+});

--- a/packages/tools/src/commands/integrity/dependencies.ts
+++ b/packages/tools/src/commands/integrity/dependencies.ts
@@ -213,6 +213,18 @@ const syncDependencyRecord = (
     return { dependenciesMatch, newDependenciesToApply, outputLog };
 };
 
+const applyOptionalDependencies = (
+    pkg: PackageJson,
+    optionalDependencies: Record<string, string>,
+) => {
+    if (Object.keys(optionalDependencies).length === 0) {
+        delete pkg.optionalDependencies;
+        return;
+    }
+
+    pkg.optionalDependencies = optionalDependencies;
+};
+
 // Based on the internal dependencies, we need to verify that the declared dependencies are correct
 // in the published packages.
 export const updateDependencies = async (workspaces: Workspace[], bundlers: Workspace[]) => {
@@ -247,6 +259,8 @@ export const updateDependencies = async (workspaces: Workspace[], bundlers: Work
             expected.optionalDependencies,
         );
 
+        let shouldWritePackageJson = false;
+
         if (!dependenciesSync.dependenciesMatch) {
             // Log the error.
             console.log(
@@ -254,8 +268,7 @@ export const updateDependencies = async (workspaces: Workspace[], bundlers: Work
             );
             // Fix the dependencies.
             pkg.dependencies = dependenciesSync.newDependenciesToApply;
-            console.log(`    Writing ${red('package.json')} of ${red(bundler.name)}.`);
-            outputJsonSync(path.resolve(ROOT, bundler.location, 'package.json'), pkg);
+            shouldWritePackageJson = true;
         }
 
         if (!optionalDependenciesSync.dependenciesMatch) {
@@ -264,7 +277,11 @@ export const updateDependencies = async (workspaces: Workspace[], bundlers: Work
                 `    Mismatch ${red('optionalDependencies')} for ${red(bundler.name)}:\n${optionalDependenciesSync.outputLog}`,
             );
             // Fix the dependencies.
-            pkg.optionalDependencies = optionalDependenciesSync.newDependenciesToApply;
+            applyOptionalDependencies(pkg, optionalDependenciesSync.newDependenciesToApply);
+            shouldWritePackageJson = true;
+        }
+
+        if (shouldWritePackageJson) {
             console.log(`    Writing ${red('package.json')} of ${red(bundler.name)}.`);
             outputJsonSync(path.resolve(ROOT, bundler.location, 'package.json'), pkg);
         }

--- a/packages/tools/src/commands/integrity/dependencies.ts
+++ b/packages/tools/src/commands/integrity/dependencies.ts
@@ -11,6 +11,7 @@ import path from 'path';
 type PackageJson = {
     dependencies?: Record<string, string>;
     devDependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
 };
 
 const jsonCache: Map<string, PackageJson> = new Map();
@@ -83,15 +84,36 @@ const getInternalDependencies = (
     return { errors, dependencies };
 };
 
+type DependencyType = 'dependencies' | 'optionalDependencies';
+
+const mergeDependency = (
+    dependencies: Map<string, string>,
+    errors: string[],
+    workspaceName: string,
+    dependencyName: string,
+    version: string,
+) => {
+    const recordedVersion = dependencies.get(dependencyName);
+    if (recordedVersion && recordedVersion !== version) {
+        errors.push(
+            `Dependency mismatch for ${dependencyName} in ${workspaceName}: ${recordedVersion} vs ${version}`,
+        );
+        return;
+    }
+
+    dependencies.set(dependencyName, version);
+};
+
 // From a workspace name, returns its dependencies and their versions.
 const getDependencies = (workspaces: Workspace[], name: string) => {
     const errors: string[] = [];
     const dependencies: Map<string, string> = new Map();
+    const optionalDependencies: Map<string, string> = new Map();
 
     const workspace = workspaces.find((w) => w.name === name);
     if (!workspace) {
         errors.push(`Could not find workspace for ${name}.`);
-        return { errors, dependencies };
+        return { errors, dependencies, optionalDependencies };
     }
 
     const pkg: PackageJson = getPackageJson(workspace);
@@ -100,7 +122,95 @@ const getDependencies = (workspaces: Workspace[], name: string) => {
         dependencies.set(dependencyName, version);
     }
 
-    return { errors, dependencies };
+    for (const [dependencyName, version] of Object.entries(pkg.optionalDependencies || {})) {
+        optionalDependencies.set(dependencyName, version);
+    }
+
+    return { errors, dependencies, optionalDependencies };
+};
+
+const getExpectedDependencies = (
+    workspaces: Workspace[],
+    bundler: Workspace,
+    internalDependencies: Set<string>,
+    errors: string[],
+) => {
+    const dependencies: Map<string, string> = new Map();
+    const optionalDependencies: Map<string, string> = new Map();
+
+    // Look through the internal dependencies we're loading.
+    for (const internalDep of internalDependencies) {
+        const externalDependencies = getDependencies(workspaces, internalDep);
+        errors.push(...externalDependencies.errors);
+
+        for (const [depName, depVersion] of externalDependencies.dependencies) {
+            mergeDependency(dependencies, errors, bundler.name, depName, depVersion);
+        }
+
+        for (const [depName, depVersion] of externalDependencies.optionalDependencies) {
+            mergeDependency(optionalDependencies, errors, bundler.name, depName, depVersion);
+        }
+    }
+
+    // Required dependencies win if a transitive workspace lists the same package
+    // as optional while another requires it.
+    for (const depName of dependencies.keys()) {
+        optionalDependencies.delete(depName);
+    }
+
+    return {
+        dependencies: cleanDependencies(Object.fromEntries(dependencies), onlyExternalDependencies),
+        optionalDependencies: cleanDependencies(
+            Object.fromEntries(optionalDependencies),
+            onlyExternalDependencies,
+        ),
+    };
+};
+
+const syncDependencyRecord = (
+    pkg: PackageJson,
+    dependencyType: DependencyType,
+    currentDependencies: Record<string, string>,
+    expectedDependencies: Record<string, string>,
+) => {
+    // First list all the dependencies we need to check.
+    const dependenciesToCheck = new Map([
+        ...Object.entries(expectedDependencies),
+        ...Object.entries(currentDependencies),
+    ]);
+
+    // Crawl through each list and identify the differences.
+    let dependenciesMatch = true;
+    let outputLog = `{`;
+    const newDependenciesToApply = { ...(pkg[dependencyType] || {}) };
+    for (const [depName, depVersion] of dependenciesToCheck) {
+        if (!currentDependencies[depName]) {
+            // Missing dependency.
+            dependenciesMatch = false;
+            newDependenciesToApply[depName] = depVersion;
+            outputLog += green(`\n +  "${depName}": "${depVersion}"`);
+        } else if (!expectedDependencies[depName]) {
+            // Extra dependency.
+            dependenciesMatch = false;
+            delete newDependenciesToApply[depName];
+            outputLog += red(`\n -  "${depName}": "${depVersion}"`);
+        } else if (
+            currentDependencies[depName] !== depVersion ||
+            expectedDependencies[depName] !== depVersion
+        ) {
+            // Mismatching versions.
+            dependenciesMatch = false;
+            newDependenciesToApply[depName] = expectedDependencies[depName];
+            outputLog += red(`\n -  "${depName}": "${currentDependencies[depName]}"`);
+            outputLog += green(`\n +  "${depName}": "${expectedDependencies[depName]}"`);
+        } else {
+            // All good.
+            outputLog += dim(`\n    "${depName}": "${depVersion}"`);
+        }
+    }
+    outputLog += '\n}';
+
+    return { dependenciesMatch, newDependenciesToApply, outputLog };
 };
 
 // Based on the internal dependencies, we need to verify that the declared dependencies are correct
@@ -111,76 +221,50 @@ export const updateDependencies = async (workspaces: Workspace[], bundlers: Work
         console.log(`  Verifying ${green('dependencies')} for ${green(bundler.name)}.`);
         const pkg = getPackageJson(bundler);
         const currentDependencies = cleanDependencies(pkg.dependencies, allDependencies);
-        const recordedDependencies: Record<string, string> = {};
+        const currentOptionalDependencies = cleanDependencies(
+            pkg.optionalDependencies,
+            allDependencies,
+        );
         const internalDependencies = getInternalDependencies(workspaces, bundler);
         errors.push(...internalDependencies.errors);
-
-        // Look through the internal dependencies we're loading.
-        for (const internalDep of internalDependencies.dependencies) {
-            const externalDependencies = getDependencies(workspaces, internalDep);
-            errors.push(...externalDependencies.errors);
-
-            for (const [depName, depVersion] of externalDependencies.dependencies) {
-                if (recordedDependencies[depName] && recordedDependencies[depName] !== depVersion) {
-                    errors.push(
-                        `Dependency mismatch for ${depName} in ${bundler.name}: ${recordedDependencies[depName]} vs ${depVersion}`,
-                    );
-                    continue;
-                }
-
-                recordedDependencies[depName] = depVersion;
-            }
-        }
-
-        const expectedDependencies: Record<string, string> = cleanDependencies(
-            recordedDependencies,
-            onlyExternalDependencies,
+        const expected = getExpectedDependencies(
+            workspaces,
+            bundler,
+            internalDependencies.dependencies,
+            errors,
         );
 
-        // First list all the dependencies we need to check.
-        const depdenciesToCheck = new Map([
-            ...Object.entries(expectedDependencies),
-            ...Object.entries(currentDependencies),
-        ]);
+        const dependenciesSync = syncDependencyRecord(
+            pkg,
+            'dependencies',
+            currentDependencies,
+            expected.dependencies,
+        );
+        const optionalDependenciesSync = syncDependencyRecord(
+            pkg,
+            'optionalDependencies',
+            currentOptionalDependencies,
+            expected.optionalDependencies,
+        );
 
-        // Crawl through each list and identify the differences.
-        let dependenciesMatch = true;
-        let outputLog = `{`;
-        const newDependenciesToApply = { ...pkg.dependencies };
-        for (const [depName, depVersion] of depdenciesToCheck) {
-            if (!currentDependencies[depName]) {
-                // Missing dependency.
-                dependenciesMatch = false;
-                newDependenciesToApply[depName] = depVersion;
-                outputLog += green(`\n +  "${depName}": "${depVersion}"`);
-            } else if (!expectedDependencies[depName]) {
-                // Extra dependency.
-                dependenciesMatch = false;
-                delete newDependenciesToApply[depName];
-                outputLog += red(`\n -  "${depName}": "${depVersion}"`);
-            } else if (
-                currentDependencies[depName] !== depVersion ||
-                expectedDependencies[depName] !== depVersion
-            ) {
-                // Mismatching versions.
-                dependenciesMatch = false;
-                newDependenciesToApply[depName] = expectedDependencies[depName];
-                outputLog += red(`\n -  "${depName}": "${currentDependencies[depName]}"`);
-                outputLog += green(`\n +  "${depName}": "${expectedDependencies[depName]}"`);
-            } else {
-                // All good.
-                outputLog += dim(`\n    "${depName}": "${depVersion}"`);
-            }
-        }
-        outputLog += '\n}';
-
-        if (!dependenciesMatch) {
+        if (!dependenciesSync.dependenciesMatch) {
             // Log the error.
             console.log(
-                `    Mismatch ${red('dependencies')} for ${red(bundler.name)}:\n${outputLog}`,
+                `    Mismatch ${red('dependencies')} for ${red(bundler.name)}:\n${dependenciesSync.outputLog}`,
             );
             // Fix the dependencies.
-            pkg.dependencies = newDependenciesToApply;
+            pkg.dependencies = dependenciesSync.newDependenciesToApply;
+            console.log(`    Writing ${red('package.json')} of ${red(bundler.name)}.`);
+            outputJsonSync(path.resolve(ROOT, bundler.location, 'package.json'), pkg);
+        }
+
+        if (!optionalDependenciesSync.dependenciesMatch) {
+            // Log the error.
+            console.log(
+                `    Mismatch ${red('optionalDependencies')} for ${red(bundler.name)}:\n${optionalDependenciesSync.outputLog}`,
+            );
+            // Fix the dependencies.
+            pkg.optionalDependencies = optionalDependenciesSync.newDependenciesToApply;
             console.log(`    Writing ${red('package.json')} of ${red(bundler.name)}.`);
             outputJsonSync(path.resolve(ROOT, bundler.location, 'package.json'), pkg);
         }


### PR DESCRIPTION
## Motivation

Published plugin packages currently sync required dependencies from internal workspaces, but the integrity command does not preserve whether a propagated dependency is optional. That makes it difficult to keep native, platform-specific packages optional when they are introduced by shared internal code.

## Changes

- Teach dependency integrity to read internal workspace `optionalDependencies`.
- Propagate expected optional dependencies separately from required dependencies.
- Keep required dependencies authoritative when the same package appears as required in one workspace and optional in another.
- Reuse the same mismatch reporting/apply flow for both dependency sections.

## QA Instructions

```bash
yarn cli integrity
git diff --check
```