### PR TITLE
chore: add vite plugin bugs metadata

### DIFF
--- a/packages/published/vite-plugin/package.json
+++ b/packages/published/vite-plugin/package.json
@@ -18,6 +18,9 @@
         "url": "https://github.com/DataDog/build-plugins",
         "directory": "packages/published/vite-plugin"
     },
+    "bugs": {
+        "url": "https://github.com/DataDog/build-plugins/issues"
+    },
     "main": "./dist/src/index.js",
     "module": "./dist/src/index.mjs",
     "types": "./dist/src/index.d.ts",


### PR DESCRIPTION
## Summary
- add bugs.url metadata to the @datadog/vite-plugin package manifest
- leave runtime code, dependencies, entry points, and package files unchanged

## Validation
- node package metadata assertion
- npm pack --dry-run --ignore-scripts --json --cache /private/tmp/codex-npm-cache-datadog-vite
- git diff --check