### PR TITLE
[APPS] Default apps plugin auth to OAuth without keys

### DIFF
--- a/packages/core/src/helpers/env.ts
+++ b/packages/core/src/helpers/env.ts
@@ -26,7 +26,7 @@ const yellow = chalk.bold.yellow;
 //   - DATADOG_APPS_AUTH_METHOD
 //   - DD_SITE
 //   - DATADOG_SITE
-const OVERRIDE_VARIABLES = [
+export const OVERRIDE_VARIABLES = [
     'API_KEY',
     'APP_KEY',
     'SOURCEMAP_INTAKE_URL',

--- a/packages/plugins/apps/README.md
+++ b/packages/plugins/apps/README.md
@@ -72,13 +72,15 @@ Additional glob patterns (relative to the project root) to include in the upload
 
 ### apps.authOverrides.method
 
-> default: `apiKey`
+> default: `apiKey` when both `DD_API_KEY` and `DD_APP_KEY` are configured, otherwise `oauth`
 
 Authentication method for uploading app bundles.
 
 Use `apiKey` to send `DD_API_KEY`/`DD_APP_KEY` credentials from the shared `auth` config. Use `oauth` to complete a local Authorization Code + PKCE flow and upload with a short-lived bearer token instead.
 
-You can also set `DATADOG_APPS_AUTH_METHOD=oauth` or `DD_APPS_AUTH_METHOD=oauth`.
+When `apps.authOverrides.method` is not set, the plugin uses API/App-key auth if both keys are configured. If either key is missing, it uses OAuth by default.
+
+You can also set `DATADOG_APPS_AUTH_METHOD` or `DD_APPS_AUTH_METHOD` to `apiKey` or `oauth`.
 
 When the method is `oauth`, the plugin derives OAuth client settings from the resolved Datadog site. The plugin reads tokens from the OS credential store, refreshes expired access tokens when a refresh token is available, and only starts browser authorization when no usable stored token exists.
 

--- a/packages/plugins/apps/src/upload.test.ts
+++ b/packages/plugins/apps/src/upload.test.ts
@@ -9,9 +9,13 @@ import { createRequestData, getOriginHeaders, NB_RETRIES } from '@dd/core/helper
 import { getMockLogger, mockLogFn } from '@dd/tests/_jest/helpers/mocks';
 import stripAnsi from 'strip-ansi';
 
-jest.mock('@dd/core/helpers/env', () => ({
-    getDDEnvValue: jest.fn(),
-}));
+jest.mock('@dd/core/helpers/env', () => {
+    const actual = jest.requireActual('@dd/core/helpers/env');
+    return {
+        ...actual,
+        getDDEnvValue: jest.fn(),
+    };
+});
 
 jest.mock('@dd/core/helpers/fs', () => {
     const actual = jest.requireActual('@dd/core/helpers/fs');

--- a/packages/plugins/apps/src/validate.test.ts
+++ b/packages/plugins/apps/src/validate.test.ts
@@ -3,40 +3,17 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import { validateOptions } from '@dd/apps-plugin/validate';
-
-const authEnvVars = [
-    'DATADOG_API_KEY',
-    'DD_API_KEY',
-    'DATADOG_APP_KEY',
-    'DD_APP_KEY',
-    'DATADOG_APPS_AUTH_METHOD',
-    'DD_APPS_AUTH_METHOD',
-] as const;
-
-const savedAuthEnv = Object.fromEntries(
-    authEnvVars.map((key) => [key, process.env[key]]),
-) as Record<(typeof authEnvVars)[number], string | undefined>;
-
-const restoreAuthEnv = () => {
-    for (const key of authEnvVars) {
-        const value = savedAuthEnv[key];
-        if (value === undefined) {
-            delete process.env[key];
-        } else {
-            process.env[key] = value;
-        }
-    }
-};
+import { cleanEnv } from '@dd/tests/_jest/helpers/env';
 
 describe('Apps Plugin - validateOptions', () => {
+    let restoreEnv: () => void;
+
     beforeEach(() => {
-        for (const key of authEnvVars) {
-            delete process.env[key];
-        }
+        restoreEnv = cleanEnv();
     });
 
     afterEach(() => {
-        restoreAuthEnv();
+        restoreEnv();
     });
 
     describe('defaults', () => {

--- a/packages/plugins/apps/src/validate.test.ts
+++ b/packages/plugins/apps/src/validate.test.ts
@@ -4,19 +4,82 @@
 
 import { validateOptions } from '@dd/apps-plugin/validate';
 
+const authEnvVars = [
+    'DATADOG_API_KEY',
+    'DD_API_KEY',
+    'DATADOG_APP_KEY',
+    'DD_APP_KEY',
+    'DATADOG_APPS_AUTH_METHOD',
+    'DD_APPS_AUTH_METHOD',
+] as const;
+
+const savedAuthEnv = Object.fromEntries(
+    authEnvVars.map((key) => [key, process.env[key]]),
+) as Record<(typeof authEnvVars)[number], string | undefined>;
+
+const restoreAuthEnv = () => {
+    for (const key of authEnvVars) {
+        const value = savedAuthEnv[key];
+        if (value === undefined) {
+            delete process.env[key];
+        } else {
+            process.env[key] = value;
+        }
+    }
+};
+
 describe('Apps Plugin - validateOptions', () => {
+    beforeEach(() => {
+        for (const key of authEnvVars) {
+            delete process.env[key];
+        }
+    });
+
+    afterEach(() => {
+        restoreAuthEnv();
+    });
+
     describe('defaults', () => {
-        test('Should set defaults when nothing is provided', () => {
+        test('Should default to OAuth when API/App keys are not provided', () => {
             const result = validateOptions({});
             expect(result).toEqual({
                 authOverrides: {
-                    method: 'apiKey',
+                    method: 'oauth',
                 },
                 dryRun: true,
                 include: [],
                 identifier: undefined,
                 name: undefined,
             });
+        });
+
+        test('Should default to API-key auth when API/App keys are configured', () => {
+            const result = validateOptions({
+                auth: {
+                    apiKey: 'api-key',
+                    appKey: 'app-key',
+                },
+            });
+
+            expect(result.authOverrides.method).toBe('apiKey');
+        });
+
+        test('Should default to API-key auth when API/App keys are configured through env vars', () => {
+            process.env.DATADOG_API_KEY = 'api-key';
+            process.env.DATADOG_APP_KEY = 'app-key';
+
+            const result = validateOptions({});
+            expect(result.authOverrides.method).toBe('apiKey');
+        });
+
+        test('Should default to OAuth when API-key auth is incomplete', () => {
+            const result = validateOptions({
+                auth: {
+                    apiKey: 'api-key',
+                },
+            });
+
+            expect(result.authOverrides.method).toBe('oauth');
         });
 
         test('Should set dryRun to false when DATADOG_APPS_UPLOAD_ASSETS is set', () => {
@@ -63,7 +126,7 @@ describe('Apps Plugin - validateOptions', () => {
 
             expect(result).toEqual({
                 authOverrides: {
-                    method: 'apiKey',
+                    method: 'oauth',
                 },
                 dryRun: true,
                 include: ['public/**/*', 'dist/**/*'],
@@ -83,14 +146,44 @@ describe('Apps Plugin - validateOptions', () => {
             expect(result.authOverrides.method).toBe('oauth');
         });
 
+        test('Should prefer configured OAuth over available API/App keys', () => {
+            const result = validateOptions({
+                auth: {
+                    apiKey: 'api-key',
+                    appKey: 'app-key',
+                },
+                apps: {
+                    enable: true,
+                    authOverrides: { method: 'oauth' },
+                },
+            });
+
+            expect(result.authOverrides.method).toBe('oauth');
+        });
+
+        test('Should enable API-key method when configured', () => {
+            const result = validateOptions({
+                apps: {
+                    enable: true,
+                    authOverrides: { method: 'apiKey' },
+                },
+            });
+
+            expect(result.authOverrides.method).toBe('apiKey');
+        });
+
         test('Should allow env vars to opt into OAuth', () => {
             process.env.DATADOG_APPS_AUTH_METHOD = 'oauth';
-            try {
-                const result = validateOptions({ apps: {} });
-                expect(result.authOverrides.method).toBe('oauth');
-            } finally {
-                delete process.env.DATADOG_APPS_AUTH_METHOD;
-            }
+
+            const result = validateOptions({ apps: {} });
+            expect(result.authOverrides.method).toBe('oauth');
+        });
+
+        test('Should allow env vars to opt into API-key auth', () => {
+            process.env.DATADOG_APPS_AUTH_METHOD = 'apiKey';
+
+            const result = validateOptions({ apps: {} });
+            expect(result.authOverrides.method).toBe('apiKey');
         });
     });
 });

--- a/packages/plugins/apps/src/validate.ts
+++ b/packages/plugins/apps/src/validate.ts
@@ -22,12 +22,18 @@ const resolveAuthMethod = (value: string | undefined): AuthMethod | undefined =>
     throw new Error(`apps.authOverrides.method must be one of: ${AUTH_METHODS.join(', ')}`);
 };
 
+const hasApiKeyAuth = (options: Options): boolean =>
+    Boolean(
+        (getDDEnvValue('API_KEY') || options.auth?.apiKey) &&
+            (getDDEnvValue('APP_KEY') || options.auth?.appKey),
+    );
+
 export const validateOptions = (options: Options): AppsOptionsWithDefaults => {
     const resolvedOptions = (options[CONFIG_KEY] || {}) as AppsOptions;
     const method =
         resolveAuthMethod(
             getDDEnvValue('APPS_AUTH_METHOD') || resolvedOptions.authOverrides?.method,
-        ) || 'apiKey';
+        ) || (hasApiKeyAuth(options) ? 'apiKey' : 'oauth');
 
     return {
         include: resolvedOptions.include || [],

--- a/packages/plugins/apps/src/vite/dev-server.test.ts
+++ b/packages/plugins/apps/src/vite/dev-server.test.ts
@@ -478,7 +478,7 @@ describe('Dev Server Middleware', () => {
             expect(apiScope.isDone()).toBe(true);
         });
 
-        test('Should return 400 with auth guidance when default API-key auth is missing keys', async () => {
+        test('Should return 400 with auth guidance when explicit API-key auth is missing keys', async () => {
             const noKeyMiddleware = createDevServerMiddleware(
                 mockViteBuild,
                 () => mockFunctions,

--- a/packages/tests/src/_jest/helpers/env.ts
+++ b/packages/tests/src/_jest/helpers/env.ts
@@ -3,6 +3,7 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import { SUPPORTED_BUNDLERS } from '@dd/core/constants';
+import { OVERRIDE_VARIABLES } from '@dd/core/helpers/env';
 import { mkdirSync } from '@dd/core/helpers/fs';
 import type { BundlerName } from '@dd/core/types';
 import { bgYellow, dim, green, red } from '@dd/tools/helpers';
@@ -11,6 +12,14 @@ import os from 'os';
 import path from 'path';
 
 const fsp = fs.promises;
+
+type EnvOverrideVariable =
+    | `DATADOG_${(typeof OVERRIDE_VARIABLES)[number]}`
+    | `DD_${(typeof OVERRIDE_VARIABLES)[number]}`;
+
+const ENV_OVERRIDE_VARIABLES = OVERRIDE_VARIABLES.flatMap(
+    (key) => [`DATADOG_${key}`, `DD_${key}`] as const,
+) as EnvOverrideVariable[];
 
 type TestEnv = {
     NO_CLEANUP: boolean;
@@ -66,35 +75,23 @@ export const setupEnv = (env: TestEnv): void => {
 };
 
 export const cleanEnv = () => {
-    const previousEnv = {
-        DATADOG_API_KEY: process.env.DATADOG_API_KEY,
-        DD_API_KEY: process.env.DD_API_KEY,
-        DATADOG_APP_KEY: process.env.DATADOG_APP_KEY,
-        DD_APP_KEY: process.env.DD_APP_KEY,
-        DATADOG_APPS_UPLOAD_ASSETS: process.env.DATADOG_APPS_UPLOAD_ASSETS,
-        DD_APPS_UPLOAD_ASSETS: process.env.DD_APPS_UPLOAD_ASSETS,
-        DATADOG_SITE: process.env.DATADOG_SITE,
-        DD_SITE: process.env.DD_SITE,
-    };
+    const previousEnv = Object.fromEntries(
+        ENV_OVERRIDE_VARIABLES.map((key) => [key, process.env[key]]),
+    ) as Record<EnvOverrideVariable, string | undefined>;
 
-    delete process.env.DATADOG_API_KEY;
-    delete process.env.DD_API_KEY;
-    delete process.env.DATADOG_APP_KEY;
-    delete process.env.DD_APP_KEY;
-    delete process.env.DATADOG_APPS_UPLOAD_ASSETS;
-    delete process.env.DD_APPS_UPLOAD_ASSETS;
-    delete process.env.DATADOG_SITE;
-    delete process.env.DD_SITE;
+    for (const key of ENV_OVERRIDE_VARIABLES) {
+        delete process.env[key];
+    }
 
     return () => {
-        process.env.DATADOG_API_KEY = previousEnv.DATADOG_API_KEY;
-        process.env.DD_API_KEY = previousEnv.DD_API_KEY;
-        process.env.DATADOG_APP_KEY = previousEnv.DATADOG_APP_KEY;
-        process.env.DD_APP_KEY = previousEnv.DD_APP_KEY;
-        process.env.DATADOG_APPS_UPLOAD_ASSETS = previousEnv.DATADOG_APPS_UPLOAD_ASSETS;
-        process.env.DD_APPS_UPLOAD_ASSETS = previousEnv.DD_APPS_UPLOAD_ASSETS;
-        process.env.DATADOG_SITE = previousEnv.DATADOG_SITE;
-        process.env.DD_SITE = previousEnv.DD_SITE;
+        for (const key of ENV_OVERRIDE_VARIABLES) {
+            const value = previousEnv[key];
+            if (value === undefined) {
+                delete process.env[key];
+            } else {
+                process.env[key] = value;
+            }
+        }
     };
 };
 


### PR DESCRIPTION
## Motivation

Datadog Apps local development and upload should use OAuth by default when API/App keys are not configured. This matches the intended customer setup where `npm run dev` and `npm run upload` can start an OAuth browser flow instead of failing with missing key guidance.

## Changes

The apps plugin now resolves `apps.authOverrides.method` in this order:

```ts
DD_APPS_AUTH_METHOD / DATADOG_APPS_AUTH_METHOD
apps.authOverrides.method
apiKey when both API and App keys are available
oauth otherwise
```

Explicit config and environment overrides still win, and users can force API/App-key auth with `DD_APPS_AUTH_METHOD=apiKey`. The README documents the conditional default, and the validation tests cover configured keys, env keys, incomplete auth, explicit override precedence, and env isolation.

## QA Instructions

In a Datadog App using `@datadog/vite-plugin`, run `npm run dev` or `npm run upload` without `DD_API_KEY`/`DD_APP_KEY`; the apps plugin should select OAuth. Set both keys and rerun to confirm API/App-key auth remains the default. Set `DD_APPS_AUTH_METHOD=apiKey` or `DD_APPS_AUTH_METHOD=oauth` to confirm explicit method selection still wins.

## Blast Radius

This affects the Datadog Apps plugin auth default for app upload and local backend function execution. Other build plugin products keep their existing auth behavior because the override remains scoped to `apps.authOverrides.method`.

## Documentation

-   [How to reliably make frontend production changes](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2286781319/Frontend+Production+Changesp)
-   [PR Description Guidelines](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/3120334387/PR+Checklist+and+Guidelines+for+Web+UI)
-   [Deploy steps](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/1457750032/)