### PR TITLE
Add CODEOWNERS for published versions directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,3 +50,6 @@ packages/plugins/apps                                                 @DataDog/a
 # Live Debugger
 packages/plugins/live-debugger/                                       @DataDog/debugger-nodejs @yoannmoinet
 packages/tests/src/e2e/liveDebugger/                                  @DataDog/debugger-nodejs @yoannmoinet
+
+# Published Versions
+packages/published/                                                   @DataDog/app-builder-high-code @yoannmoinet


### PR DESCRIPTION
To allow members of the Datadog Apps team to release a new version when yoann is e.g. OOO
