### PR TITLE
[APPS] Defer OAuth token persistence until first request succeeds

### DIFF
--- a/packages/core/src/helpers/oauth-request.test.ts
+++ b/packages/core/src/helpers/oauth-request.test.ts
@@ -220,7 +220,10 @@ describe('Core - OAuth', () => {
             // The memo returns the same in-flight promise, so both callers
             // resolve to the very same token object (not two cache reads).
             expect(first).toBe(second);
-            expect(first.accessToken).toBe('cached-token');
+            expect(first).toEqual({
+                persistAfterSuccessfulRequest: false,
+                token: expect.objectContaining({ accessToken: 'cached-token' }),
+            });
         });
     });
 

--- a/packages/core/src/helpers/oauth-request.ts
+++ b/packages/core/src/helpers/oauth-request.ts
@@ -63,6 +63,11 @@ export type CachedOAuthToken = Omit<OAuthToken, 'expiresIn'> & {
     clientId: string;
 };
 
+export type ResolvedOAuthToken = {
+    persistAfterSuccessfulRequest: boolean;
+    token: OAuthToken;
+};
+
 type StoredOAuthCredential = {
     token: CachedOAuthToken;
     version: 1;
@@ -629,14 +634,28 @@ export const getOAuthToken = async (
 
 // Memoize per site+client for the lifetime of the process so concurrent requests
 // (and the sequential upload + release calls) share a single browser authorization.
-const tokenCache = new Map<string, Promise<OAuthToken>>();
+const tokenCache = new Map<string, Promise<ResolvedOAuthToken>>();
 
-export const resolveOAuthToken = (site: string, log: Logger): Promise<OAuthToken> => {
+const resolveOAuthTokenFromStorage = async (
+    site: string,
+    options: OAuthConfig,
+    log: Logger,
+): Promise<ResolvedOAuthToken> => {
+    const cachedToken = await getCachedOAuthToken(site, options, log);
+    if (cachedToken) {
+        return { persistAfterSuccessfulRequest: false, token: cachedToken };
+    }
+
+    const token = await authorizeWithPKCE(site, options, log);
+    return { persistAfterSuccessfulRequest: true, token };
+};
+
+export const resolveOAuthToken = async (site: string, log: Logger): Promise<ResolvedOAuthToken> => {
     const options = getDatadogOAuthConfig(site);
     const key = `${site}:${options.clientId}`;
     let pending = tokenCache.get(key);
     if (!pending) {
-        pending = getOAuthToken(site, options, log).catch((error) => {
+        pending = resolveOAuthTokenFromStorage(site, options, log).catch((error) => {
             tokenCache.delete(key);
             throw error;
         });
@@ -652,16 +671,22 @@ export type OAuthRequestOpts = Omit<RequestOpts, 'auth'> & {
 
 export const doOAuthRequest = async <T>({ auth, log, ...opts }: OAuthRequestOpts): Promise<T> => {
     const { site } = auth;
-    const token = await resolveOAuthToken(site, log);
+    const { persistAfterSuccessfulRequest, token } = await resolveOAuthToken(site, log);
 
     if (!token.accessToken) {
         throw new Error('OAuth authentication did not return an access token.');
     }
 
-    return doRequest<T>({
+    const result = await doRequest<T>({
         ...opts,
         auth: {
             accessToken: token.accessToken,
         },
     });
+
+    if (persistAfterSuccessfulRequest) {
+        await saveOAuthToken(token, getDatadogOAuthConfig(site), log, site);
+    }
+
+    return result;
 };


### PR DESCRIPTION
## Motivation

Apps OAuth can complete the browser PKCE flow and still produce a token that fails on the first app-builder request, for example when the selected org/user principal is not valid for the downstream operation. Before this change, the freshly issued token was written to the OS credential store before any authenticated request proved it was usable. A failed upload could therefore leave a bad token cached for future commands.

PR #436 moved browser authorization to the app host (`https://app.${site}/oauth2/v1/authorize`) while keeping token exchange on the API host. This PR is rebased on that behavior and keeps that host split intact; the remaining functional change is when fresh OAuth tokens are persisted.

## Changes

`resolveOAuthToken` now returns both the token and persistence metadata:

```ts
{
    token: OAuthToken,
    persistAfterSuccessfulRequest: boolean,
}
```

Cached tokens return `persistAfterSuccessfulRequest: false` and continue to be used normally. Fresh PKCE tokens return `persistAfterSuccessfulRequest: true`.

`doOAuthRequest` uses a fresh token immediately for the current request, but saves it to Keychain only after `doRequest` succeeds. If the first authenticated request fails, the token is not persisted for future commands. Direct `getOAuthToken` behavior is preserved for existing callers.

## QA Instructions

No manual QA required. Covered by the OAuth unit test file.

Validated with:

```sh
yarn workspace @dd/tests test:unit packages/core/src/helpers/oauth-request.test.ts --runInBand
```

## Blast Radius

This affects OAuth-backed build plugin requests that go through `doOAuthRequest`, including Apps upload/release flows.

Existing cached tokens are still read and used as before. Successfully used fresh tokens are still persisted. The changed behavior is limited to fresh OAuth tokens whose first authenticated request fails: those tokens are no longer written to the OS credential store.

## Documentation

-   [How to reliably make frontend production changes](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2286781319/Frontend+Production+Changesp)
-   [PR Description Guidelines](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/3120334387/PR+Checklist+and+Guidelines+for+Web+UI)
-   [Deploy steps](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/1457750032/)
