### PR TITLE
[APPS] Use app host for OAuth authorization

### DIFF
--- a/packages/core/src/helpers/oauth-request.test.ts
+++ b/packages/core/src/helpers/oauth-request.test.ts
@@ -177,7 +177,7 @@ describe('Core - OAuth', () => {
     describe('getDatadogOAuthConfig', () => {
         test('Should derive OAuth endpoints and default client ID from the site', () => {
             expect(getDatadogOAuthConfig('datadoghq.eu')).toEqual({
-                authorizationUrl: 'https://api.datadoghq.eu/oauth2/v1/authorize',
+                authorizationUrl: 'https://app.datadoghq.eu/oauth2/v1/authorize',
                 cacheTokens: true,
                 clientId: DEFAULT_OAUTH_CLIENT_ID,
                 openBrowser: true,
@@ -190,7 +190,7 @@ describe('Core - OAuth', () => {
         test('Should use the datad0g OAuth client ID for datad0g.com', () => {
             const config = getDatadogOAuthConfig('datad0g.com');
             expect(config.clientId).toBe(DATAD0G_OAUTH_CLIENT_ID);
-            expect(config.authorizationUrl).toBe('https://api.datad0g.com/oauth2/v1/authorize');
+            expect(config.authorizationUrl).toBe('https://app.datad0g.com/oauth2/v1/authorize');
             expect(config.tokenUrl).toBe('https://api.datad0g.com/oauth2/v1/token');
         });
     });

--- a/packages/core/src/helpers/oauth-request.ts
+++ b/packages/core/src/helpers/oauth-request.ts
@@ -90,16 +90,17 @@ export const getOAuthClientId = (site: string) => {
 
 export const getDatadogOAuthConfig = (site: string): OAuthConfig => {
     const clientId = getOAuthClientId(site);
-    const baseOAuthUrl = `https://api.${site}/oauth2/v1`;
+    const authorizationUrl = `https://app.${site}/oauth2/v1/authorize`;
+    const tokenUrl = `https://api.${site}/oauth2/v1/token`;
 
     return {
-        authorizationUrl: `${baseOAuthUrl}/authorize`,
+        authorizationUrl,
         cacheTokens: true,
         clientId,
         openBrowser: true,
         redirectUri: DEFAULT_OAUTH_REDIRECT_URI,
         timeoutMs: DEFAULT_OAUTH_TIMEOUT_MS,
-        tokenUrl: `${baseOAuthUrl}/token`,
+        tokenUrl,
     };
 };
 


### PR DESCRIPTION
## Motivation

Apps upload OAuth currently builds the browser authorization URL on `https://api.<site>/oauth2/v1/authorize`. [Datadog OAuth docs](https://datadoghq.atlassian.net/wiki/spaces/DAL/pages/2519139368/OAuth+Onboarding+Endpoints#Example-Request) and other internal clients use the app host for browser authorization and the api host for token exchange. In the wrong-org upload investigation, this is one suspicious difference in our OAuth client flow.

## Changes

Split the derived Datadog OAuth endpoints so browser authorization uses `https://app.<site>/oauth2/v1/authorize`, while the token exchange continues to use `https://api.<site>/oauth2/v1/token`.

This PR is intentionally narrow. It does not include token persistence changes or org-selection validation.

## QA Instructions

Run an Apps upload that uses OAuth and confirm the browser opens the Datadog OAuth authorization flow on the `app` host.

## Blast Radius

This affects Apps upload OAuth flows that rely on the default Datadog OAuth configuration. API key upload flows and callers that provide a custom OAuth config are unchanged.

## Documentation

-   [How to reliably make frontend production changes](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2286781319/Frontend+Production+Changesp)
-   [PR Description Guidelines](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/3120334387/PR+Checklist+and+Guidelines+for+Web+UI)
-   [Deploy steps](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/1457750032/)