### PR TITLE
Fix CI typecheck cache invalidation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
           path: packages/published/**/dist
           key: ${{ matrix.node }}-cache-build-${{ hashFiles('packages/core/**',
             'packages/factory/**', 'packages/plugins/**',
-            'packages/published/**', 'packages/tools/src/rollupConfig.mjs',
+            'packages/published/**', 'packages/tools/src/**',
             'yarn.lock') }}
 
       - name: Configure Datadog Test Optimization
@@ -76,7 +76,7 @@ jobs:
           path: packages/published/**/dist
           key: node18-cache-build-${{ hashFiles('packages/core/**', 'packages/factory/**',
             'packages/plugins/**', 'packages/published/**',
-            'packages/tools/src/rollupConfig.mjs', 'yarn.lock') }}
+            'packages/tools/src/**', 'yarn.lock') }}
 
       - name: Cache playwright binaries
         id: cache-playwright-binaries
@@ -153,7 +153,7 @@ jobs:
           path: packages/published/rollup-plugin/dist-basic
           key: node18-cache-build-rollup-${{ hashFiles('packages/core/**',
             'packages/factory/**', 'packages/plugins/**',
-            'packages/published/**', 'packages/tools/src/rollupConfig.mjs',
+            'packages/published/**', 'packages/tools/src/**',
             'yarn.lock') }}
 
       - name: Cache build:all
@@ -163,7 +163,7 @@ jobs:
           path: packages/published/**/dist
           key: node18-cache-build-${{ hashFiles('packages/core/**', 'packages/factory/**',
             'packages/plugins/**', 'packages/published/**',
-            'packages/tools/src/rollupConfig.mjs', 'yarn.lock') }}
+            'packages/tools/src/**', 'yarn.lock') }}
 
       - run: yarn install
 

--- a/.yarn/patches/@jridgewell-remapping-npm-2.3.5-df8dacc063.patch
+++ b/.yarn/patches/@jridgewell-remapping-npm-2.3.5-df8dacc063.patch
@@ -1,0 +1,13 @@
+diff --git a/types/remapping.d.cts b/types/remapping.d.cts
+index 2022784752343ea9079b466504b00f93026e4f93..324c0a6c85e5c728dcdda7007ed6ba5bccf0ef6a 100644
+--- a/types/remapping.d.cts
++++ b/types/remapping.d.cts
+@@ -17,5 +17,6 @@ export type { SourceMap };
+  * Pass `decodedMappings` to receive a SourceMap with decoded (instead of
+  * VLQ encoded) mappings.
+  */
+-export =       function remapping(input: SourceMapInput | SourceMapInput[], loader: SourceMapLoader, options?: boolean | Options): SourceMap;
++declare function remapping(input: SourceMapInput | SourceMapInput[], loader: SourceMapLoader, options?: boolean | Options): SourceMap;
++export = remapping;
+ //# sourceMappingURL=remapping.d.ts.map
+\ No newline at end of file

--- a/LICENSES-3rdparty.csv
+++ b/LICENSES-3rdparty.csv
@@ -160,7 +160,7 @@ Component,Origin,Licence,Copyright
 @jest/transform,npm,MIT,(https://www.npmjs.com/package/@jest/transform)
 @jest/types,npm,MIT,(https://www.npmjs.com/package/@jest/types)
 @jridgewell/gen-mapping,npm,MIT,Justin Ridgewell (https://www.npmjs.com/package/@jridgewell/gen-mapping)
-@jridgewell/remapping,npm,MIT,Justin Ridgewell (https://github.com/jridgewell/sourcemaps/tree/main/packages/remapping)
+@jridgewell/remapping,patch,MIT,Justin Ridgewell (https://github.com/jridgewell/sourcemaps/tree/main/packages/remapping)
 @jridgewell/resolve-uri,npm,MIT,Justin Ridgewell (https://www.npmjs.com/package/@jridgewell/resolve-uri)
 @jridgewell/set-array,npm,MIT,Justin Ridgewell (https://www.npmjs.com/package/@jridgewell/set-array)
 @jridgewell/source-map,npm,MIT,Justin Ridgewell (https://www.npmjs.com/package/@jridgewell/source-map)

--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
     "resolutions": {
         "rollup": "4.45.1",
         "dts-bundle-generator/typescript": "5.4.3",
-        "dts-bundle-generator@npm:9.5.1": "patch:dts-bundle-generator@npm%3A9.5.1#~/.yarn/patches/dts-bundle-generator-npm-9.5.1-0927b6826f.patch"
+        "dts-bundle-generator@npm:9.5.1": "patch:dts-bundle-generator@npm%3A9.5.1#~/.yarn/patches/dts-bundle-generator-npm-9.5.1-0927b6826f.patch",
+        "@jridgewell/remapping@npm:2.3.5": "patch:@jridgewell/remapping@npm%3A2.3.5#~/.yarn/patches/@jridgewell-remapping-npm-2.3.5-df8dacc063.patch",
+        "@jridgewell/remapping@npm:^2.3.5": "patch:@jridgewell/remapping@npm%3A2.3.5#~/.yarn/patches/@jridgewell-remapping-npm-2.3.5-df8dacc063.patch"
     },
     "packageManager": "yarn@4.10.3"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3196,13 +3196,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/remapping@npm:2.3.5, @jridgewell/remapping@npm:^2.3.5":
+"@jridgewell/remapping@npm:2.3.5":
   version: 2.3.5
   resolution: "@jridgewell/remapping@npm:2.3.5"
   dependencies:
     "@jridgewell/gen-mapping": "npm:^0.3.5"
     "@jridgewell/trace-mapping": "npm:^0.3.24"
   checksum: 10/c2bb01856e65b506d439455f28aceacf130d6c023d1d4e3b48705e88def3571753e1a887daa04b078b562316c92d26ce36408a60534bceca3f830aec88a339ad
+  languageName: node
+  linkType: hard
+
+"@jridgewell/remapping@patch:@jridgewell/remapping@npm%3A2.3.5#~/.yarn/patches/@jridgewell-remapping-npm-2.3.5-df8dacc063.patch":
+  version: 2.3.5
+  resolution: "@jridgewell/remapping@patch:@jridgewell/remapping@npm%3A2.3.5#~/.yarn/patches/@jridgewell-remapping-npm-2.3.5-df8dacc063.patch::version=2.3.5&hash=ee7509"
+  dependencies:
+    "@jridgewell/gen-mapping": "npm:^0.3.5"
+    "@jridgewell/trace-mapping": "npm:^0.3.24"
+  checksum: 10/bd73d9754dca1cae092edcb2dd3811b44b30ce451a4a6720868df6d8ea379a4742c630c3f1d615c3c5e011b84fbc759421519b681ed450a3ab44ab6efc3e3981
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

Fixes CI typecheck failures caused by TypeScript parsing `@jridgewell/remapping`'s invalid CJS declaration when cached generated build artifacts make the package resolve through the default export condition.

Example failure: https://github.com/DataDog/build-plugins/actions/runs/28236150739/job/84499949413

```text
../../node_modules/@jridgewell/remapping/types/remapping.d.cts(20,141): error TS1005: '{' expected.
The command failed in workspace @dd/tests@workspace:packages/tests with exit code 2
```

Also broadens the CI build cache key so generated `dist` artifacts are invalidated when any build tooling source changes, not only `rollupConfig.mjs`.

### How?

Adds a Yarn patch for `@jridgewell/remapping@2.3.5` that rewrites the invalid `export = function remapping(...)` declaration into the standard `declare function remapping(...); export = remapping;` form.

Updates CI cache `hashFiles` inputs from `packages/tools/src/rollupConfig.mjs` to `packages/tools/src/**` for the plugin build caches.
