### PR TITLE
[APPS-2784] feat(apps): add description, selfService, permissions to manifest and config

### DIFF
--- a/packages/plugins/apps/README.md
+++ b/packages/plugins/apps/README.md
@@ -21,6 +21,10 @@ A plugin to upload assets to Datadog's storage
     -   [apps.authOverrides.method](#appsauthoverridesmethod)
     -   [apps.identifier](#appsidentifier)
     -   [apps.name](#appsname)
+    -   [apps.description](#appsdescription)
+    -   [apps.selfService](#appsselfservice)
+    -   [apps.permissions.protectionLevel](#appspermissionsprotectionlevel)
+    -   [apps.permissions.runAs](#appspermissionsrunas)
     -   [apps.publish](#appspublish)
 <!-- #toc -->
 
@@ -33,6 +37,12 @@ apps?: {
     include?: string[];
     identifier?: string;
     name?: string;
+    description?: string;
+    selfService?: boolean;
+    permissions?: {
+        protectionLevel?: 'direct_publish' | 'approval_required';
+        runAs?: string;
+    };
     authOverrides?: {
         method?: 'apiKey' | 'oauth';
     };
@@ -105,6 +115,38 @@ Can be useful to enforce a static identifier instead of relying on possibly chan
 Override the app's name used in the assets upload API request.
 
 Can be useful to enforce a static name instead of relying on the package.json name field.
+
+### apps.description
+
+> default: `undefined` (preserves existing description)
+
+Human-readable description for the app. Set once at initial deploy; subsequent deploys without this field leave the existing description unchanged.
+
+### apps.selfService
+
+> default: `undefined` (preserves existing setting)
+
+When `true`, the app appears in the Datadog self-service catalog so other users can run it from a central directory. When `false`, the app is hidden from the catalog. Omitting this field leaves the existing setting unchanged.
+
+### apps.permissions.protectionLevel
+
+> default: `undefined` (preserves existing setting)
+
+Controls whether publishing the app requires a second approver.
+
+- `direct_publish` — any user with publish rights can deploy immediately.
+- `approval_required` — a second editor must approve before the app goes live.
+
+Omitting this field leaves the existing setting unchanged.
+
+### apps.permissions.runAs
+
+> default: `undefined` (preserves existing setting)
+
+UUID of the service account the app's backend functions run as. When set, all backend function executions use this service account's credentials instead of the uploading user's. Omitting this field leaves the existing setting unchanged.
+
+> [!NOTE]
+> Only service accounts are accepted. Arbitrary user UUIDs are rejected by the Datadog API. The caller must have `service_account_write` permission and the service account's role set must be a subset of the caller's roles.
 
 ### apps.publish
 

--- a/packages/plugins/apps/src/index.test.ts
+++ b/packages/plugins/apps/src/index.test.ts
@@ -230,6 +230,94 @@ describe('Apps Plugin - getPlugins', () => {
         expect(fsHelpers.rm).toHaveBeenCalledWith(expect.stringContaining('dd-apps-manifest-'));
     });
 
+    test('Should include description, selfService, and permissions in manifest.json when configured', async () => {
+        jest.spyOn(identifier, 'resolveIdentifier').mockReturnValue({
+            identifier: 'repo:app',
+            name: 'test-app',
+        });
+        jest.spyOn(assets, 'collectAssets').mockResolvedValue([
+            { absolutePath: '/project/dist/index.js', relativePath: 'dist/index.js' },
+        ]);
+        jest.spyOn(fsHelpers, 'rm').mockResolvedValue(undefined);
+        let manifest: unknown;
+        jest.spyOn(archive, 'createArchive').mockImplementation(async (archiveAssets) => {
+            const manifestAsset = archiveAssets.find(
+                (asset) => asset.relativePath === 'manifest.json',
+            );
+            expect(manifestAsset).toBeDefined();
+            manifest = JSON.parse(await fsp.readFile(manifestAsset!.absolutePath, 'utf8'));
+            return {
+                archivePath: '/tmp/dd-apps-123/datadog-apps-assets.zip',
+                assets: archiveAssets,
+                size: 10,
+            };
+        });
+        jest.spyOn(uploader, 'uploadArchive').mockResolvedValue({ errors: [], warnings: [] });
+
+        const closeBundle = extractCloseBundle(
+            getPlugins(
+                getGetPluginsArg(
+                    {
+                        apps: {
+                            description: 'My app description',
+                            selfService: true,
+                            permissions: {
+                                protectionLevel: 'approval_required',
+                            },
+                        },
+                    },
+                    {
+                        bundler: { ...getMockBundler({ name: 'vite' }), outDir },
+                        buildRoot,
+                        git: getRepositoryDataMock({ remote: 'git@github.com:org/repo.git' }),
+                    },
+                ),
+            ),
+        );
+        await closeBundle();
+
+        expect(manifest).toEqual({
+            description: 'My app description',
+            selfService: true,
+            permissions: { protectionLevel: 'approval_required' },
+            backend: { functions: {} },
+        });
+    });
+
+    test('Should omit description, selfService, and permissions from manifest.json when not configured', async () => {
+        jest.spyOn(identifier, 'resolveIdentifier').mockReturnValue({
+            identifier: 'repo:app',
+            name: 'test-app',
+        });
+        jest.spyOn(assets, 'collectAssets').mockResolvedValue([
+            { absolutePath: '/project/dist/index.js', relativePath: 'dist/index.js' },
+        ]);
+        jest.spyOn(fsHelpers, 'rm').mockResolvedValue(undefined);
+        let manifest: unknown;
+        jest.spyOn(archive, 'createArchive').mockImplementation(async (archiveAssets) => {
+            const manifestAsset = archiveAssets.find(
+                (asset) => asset.relativePath === 'manifest.json',
+            );
+            expect(manifestAsset).toBeDefined();
+            manifest = JSON.parse(await fsp.readFile(manifestAsset!.absolutePath, 'utf8'));
+            return {
+                archivePath: '/tmp/dd-apps-123/datadog-apps-assets.zip',
+                assets: archiveAssets,
+                size: 10,
+            };
+        });
+        jest.spyOn(uploader, 'uploadArchive').mockResolvedValue({ errors: [], warnings: [] });
+
+        const closeBundle = extractCloseBundle(getPlugins(getArgs()));
+        await closeBundle();
+
+        // Backwards compat: manifest must not contain new fields when not configured
+        expect(manifest).toEqual({ backend: { functions: {} } });
+        expect(manifest).not.toHaveProperty('description');
+        expect(manifest).not.toHaveProperty('selfService');
+        expect(manifest).not.toHaveProperty('permissions');
+    });
+
     test('Should pass API credentials through when upload method is not specified', async () => {
         jest.spyOn(identifier, 'resolveIdentifier').mockReturnValue({
             identifier: 'repo:app',

--- a/packages/plugins/apps/src/index.test.ts
+++ b/packages/plugins/apps/src/index.test.ts
@@ -318,6 +318,107 @@ describe('Apps Plugin - getPlugins', () => {
         expect(manifest).not.toHaveProperty('permissions');
     });
 
+    test('Should include runAs in manifest.json when configured', async () => {
+        jest.spyOn(identifier, 'resolveIdentifier').mockReturnValue({
+            identifier: 'repo:app',
+            name: 'test-app',
+        });
+        jest.spyOn(assets, 'collectAssets').mockResolvedValue([
+            { absolutePath: '/project/dist/index.js', relativePath: 'dist/index.js' },
+        ]);
+        jest.spyOn(fsHelpers, 'rm').mockResolvedValue(undefined);
+        let manifest: unknown;
+        jest.spyOn(archive, 'createArchive').mockImplementation(async (archiveAssets) => {
+            const manifestAsset = archiveAssets.find(
+                (asset) => asset.relativePath === 'manifest.json',
+            );
+            expect(manifestAsset).toBeDefined();
+            manifest = JSON.parse(await fsp.readFile(manifestAsset!.absolutePath, 'utf8'));
+            return {
+                archivePath: '/tmp/dd-apps-123/datadog-apps-assets.zip',
+                assets: archiveAssets,
+                size: 10,
+            };
+        });
+        jest.spyOn(uploader, 'uploadArchive').mockResolvedValue({ errors: [], warnings: [] });
+
+        const closeBundle = extractCloseBundle(
+            getPlugins(
+                getGetPluginsArg(
+                    {
+                        apps: {
+                            permissions: {
+                                protectionLevel: 'direct_publish',
+                                runAs: '550e8400-e29b-41d4-a716-446655440000',
+                            },
+                        },
+                    },
+                    {
+                        bundler: { ...getMockBundler({ name: 'vite' }), outDir },
+                        buildRoot,
+                        git: getRepositoryDataMock({ remote: 'git@github.com:org/repo.git' }),
+                    },
+                ),
+            ),
+        );
+        await closeBundle();
+
+        expect(manifest).toEqual({
+            permissions: {
+                protectionLevel: 'direct_publish',
+                runAs: '550e8400-e29b-41d4-a716-446655440000',
+            },
+            backend: { functions: {} },
+        });
+    });
+
+    test('Should omit permissions from manifest.json when permissions is an empty object', async () => {
+        jest.spyOn(identifier, 'resolveIdentifier').mockReturnValue({
+            identifier: 'repo:app',
+            name: 'test-app',
+        });
+        jest.spyOn(assets, 'collectAssets').mockResolvedValue([
+            { absolutePath: '/project/dist/index.js', relativePath: 'dist/index.js' },
+        ]);
+        jest.spyOn(fsHelpers, 'rm').mockResolvedValue(undefined);
+        let manifest: unknown;
+        jest.spyOn(archive, 'createArchive').mockImplementation(async (archiveAssets) => {
+            const manifestAsset = archiveAssets.find(
+                (asset) => asset.relativePath === 'manifest.json',
+            );
+            expect(manifestAsset).toBeDefined();
+            manifest = JSON.parse(await fsp.readFile(manifestAsset!.absolutePath, 'utf8'));
+            return {
+                archivePath: '/tmp/dd-apps-123/datadog-apps-assets.zip',
+                assets: archiveAssets,
+                size: 10,
+            };
+        });
+        jest.spyOn(uploader, 'uploadArchive').mockResolvedValue({ errors: [], warnings: [] });
+
+        const closeBundle = extractCloseBundle(
+            getPlugins(
+                getGetPluginsArg(
+                    {
+                        apps: {
+                            // Empty permissions object — must not appear in manifest
+                            permissions: {},
+                        },
+                    },
+                    {
+                        bundler: { ...getMockBundler({ name: 'vite' }), outDir },
+                        buildRoot,
+                        git: getRepositoryDataMock({ remote: 'git@github.com:org/repo.git' }),
+                    },
+                ),
+            ),
+        );
+        await closeBundle();
+
+        expect(manifest).toEqual({ backend: { functions: {} } });
+        expect(manifest).not.toHaveProperty('permissions');
+    });
+
     test('Should pass API credentials through when upload method is not specified', async () => {
         jest.spyOn(identifier, 'resolveIdentifier').mockReturnValue({
             identifier: 'repo:app',

--- a/packages/plugins/apps/src/index.test.ts
+++ b/packages/plugins/apps/src/index.test.ts
@@ -459,6 +459,59 @@ describe('Apps Plugin - getPlugins', () => {
         expect(manifest).not.toHaveProperty('permissions');
     });
 
+    test('Should omit null subfields from permissions in manifest.json', async () => {
+        jest.spyOn(identifier, 'resolveIdentifier').mockReturnValue({
+            identifier: 'repo:app',
+            name: 'test-app',
+        });
+        jest.spyOn(assets, 'collectAssets').mockResolvedValue([
+            { absolutePath: '/project/dist/index.js', relativePath: 'dist/index.js' },
+        ]);
+        jest.spyOn(fsHelpers, 'rm').mockResolvedValue(undefined);
+        let manifest: unknown;
+        jest.spyOn(archive, 'createArchive').mockImplementation(async (archiveAssets) => {
+            const manifestAsset = archiveAssets.find(
+                (asset) => asset.relativePath === 'manifest.json',
+            );
+            expect(manifestAsset).toBeDefined();
+            manifest = JSON.parse(await fsp.readFile(manifestAsset!.absolutePath, 'utf8'));
+            return {
+                archivePath: '/tmp/dd-apps-123/datadog-apps-assets.zip',
+                assets: archiveAssets,
+                size: 10,
+            };
+        });
+        jest.spyOn(uploader, 'uploadArchive').mockResolvedValue({ errors: [], warnings: [] });
+
+        const closeBundle = extractCloseBundle(
+            getPlugins(
+                getGetPluginsArg(
+                    {
+                        apps: {
+                            // protectionLevel is null — only runAs should appear in manifest
+                            permissions: {
+                                protectionLevel: null as unknown as 'direct_publish',
+                                runAs: '550e8400-e29b-41d4-a716-446655440000',
+                            },
+                        },
+                    },
+                    {
+                        bundler: { ...getMockBundler({ name: 'vite' }), outDir },
+                        buildRoot,
+                        git: getRepositoryDataMock({ remote: 'git@github.com:org/repo.git' }),
+                    },
+                ),
+            ),
+        );
+        await closeBundle();
+
+        expect(manifest).toEqual({
+            permissions: { runAs: '550e8400-e29b-41d4-a716-446655440000' },
+            backend: { functions: {} },
+        });
+        expect((manifest as any).permissions).not.toHaveProperty('protectionLevel');
+    });
+
     test('Should pass API credentials through when upload method is not specified', async () => {
         jest.spyOn(identifier, 'resolveIdentifier').mockReturnValue({
             identifier: 'repo:app',

--- a/packages/plugins/apps/src/index.test.ts
+++ b/packages/plugins/apps/src/index.test.ts
@@ -284,6 +284,46 @@ describe('Apps Plugin - getPlugins', () => {
         });
     });
 
+    test('Should include selfService: false in manifest.json when explicitly set to false', async () => {
+        jest.spyOn(identifier, 'resolveIdentifier').mockReturnValue({
+            identifier: 'repo:app',
+            name: 'test-app',
+        });
+        jest.spyOn(assets, 'collectAssets').mockResolvedValue([
+            { absolutePath: '/project/dist/index.js', relativePath: 'dist/index.js' },
+        ]);
+        jest.spyOn(fsHelpers, 'rm').mockResolvedValue(undefined);
+        let manifest: unknown;
+        jest.spyOn(archive, 'createArchive').mockImplementation(async (archiveAssets) => {
+            const manifestAsset = archiveAssets.find(
+                (asset) => asset.relativePath === 'manifest.json',
+            );
+            manifest = JSON.parse(await fsp.readFile(manifestAsset!.absolutePath, 'utf8'));
+            return {
+                archivePath: '/tmp/dd-apps-123/datadog-apps-assets.zip',
+                assets: archiveAssets,
+                size: 10,
+            };
+        });
+        jest.spyOn(uploader, 'uploadArchive').mockResolvedValue({ errors: [], warnings: [] });
+
+        const closeBundle = extractCloseBundle(
+            getPlugins(
+                getGetPluginsArg(
+                    { apps: { selfService: false } },
+                    {
+                        bundler: { ...getMockBundler({ name: 'vite' }), outDir },
+                        buildRoot,
+                        git: getRepositoryDataMock({ remote: 'git@github.com:org/repo.git' }),
+                    },
+                ),
+            ),
+        );
+        await closeBundle();
+
+        expect(manifest).toHaveProperty('selfService', false);
+    });
+
     test('Should omit description, selfService, and permissions from manifest.json when not configured', async () => {
         jest.spyOn(identifier, 'resolveIdentifier').mockReturnValue({
             identifier: 'repo:app',

--- a/packages/plugins/apps/src/types.ts
+++ b/packages/plugins/apps/src/types.ts
@@ -6,12 +6,33 @@ import type { Assign, WithRequired } from '@dd/core/types';
 
 export type AuthMethod = 'apiKey' | 'oauth';
 
+export type AppsProtectionLevel = 'direct_publish' | 'approval_required';
+
 export type AppsOptions = {
     enable?: boolean;
     include?: string[];
     dryRun?: boolean;
     identifier?: string;
     name?: string;
+    /** Human-readable description of the app. */
+    description?: string;
+    /** When true, the app appears in the Datadog self-service catalog. */
+    selfService?: boolean;
+    /** Deployment and identity settings for the app. */
+    permissions?: {
+        /**
+         * Controls whether publishing the app requires a second approver.
+         * - `direct_publish`: any user with publish rights can deploy immediately.
+         * - `approval_required`: a second user must approve before the app goes live.
+         */
+        protectionLevel?: AppsProtectionLevel;
+        /**
+         * UUID of the service account the app's backend functions run as.
+         * When omitted the app runs as the uploading user.
+         * Only service accounts are accepted; arbitrary user UUIDs are rejected by the API.
+         */
+        runAs?: string;
+    };
     // Per-app auth overrides. `method` is scoped here rather than on the shared
     // `auth` config because not every product endpoint supports OAuth.
     authOverrides?: {
@@ -20,6 +41,15 @@ export type AppsOptions = {
 };
 
 export type AppsManifest = {
+    /** Human-readable description of the app. */
+    description?: string;
+    /** When true, the app appears in the Datadog self-service catalog. */
+    selfService?: boolean;
+    /** Deployment and identity settings for the app. */
+    permissions?: {
+        protectionLevel?: AppsProtectionLevel;
+        runAs?: string;
+    };
     backend: {
         /** Mapping of encoded query name to information about that backend function. */
         functions: Record<

--- a/packages/plugins/apps/src/validate.test.ts
+++ b/packages/plugins/apps/src/validate.test.ts
@@ -217,7 +217,7 @@ describe('new app properties', () => {
     test('Should omit description, selfService, and permissions entirely when not configured', () => {
         const result = validateOptions({ apps: {} });
         // Keys must be absent (not merely undefined) so callers that use
-        // hasOwnProperty / 'in' checks and the manifest builder's !== undefined
+        // hasOwnProperty / 'in' checks and the manifest builder's != null
         // guard both behave correctly when no value was provided.
         expect(result).not.toHaveProperty('description');
         expect(result).not.toHaveProperty('selfService');

--- a/packages/plugins/apps/src/validate.test.ts
+++ b/packages/plugins/apps/src/validate.test.ts
@@ -182,3 +182,42 @@ describe('Apps Plugin - validateOptions', () => {
         });
     });
 });
+
+describe('new app properties', () => {
+    test('Should pass description through to resolved options', () => {
+        const result = validateOptions({ apps: { description: 'My app description' } });
+        expect(result.description).toBe('My app description');
+    });
+
+    test('Should pass selfService true through to resolved options', () => {
+        const result = validateOptions({ apps: { selfService: true } });
+        expect(result.selfService).toBe(true);
+    });
+
+    test('Should pass selfService false through to resolved options', () => {
+        const result = validateOptions({ apps: { selfService: false } });
+        expect(result.selfService).toBe(false);
+    });
+
+    test('Should pass permissions through to resolved options', () => {
+        const result = validateOptions({
+            apps: {
+                permissions: {
+                    protectionLevel: 'approval_required',
+                    runAs: '550e8400-e29b-41d4-a716-446655440000',
+                },
+            },
+        });
+        expect(result.permissions).toEqual({
+            protectionLevel: 'approval_required',
+            runAs: '550e8400-e29b-41d4-a716-446655440000',
+        });
+    });
+
+    test('Should leave description, selfService, and permissions undefined when not configured', () => {
+        const result = validateOptions({ apps: {} });
+        expect(result.description).toBeUndefined();
+        expect(result.selfService).toBeUndefined();
+        expect(result.permissions).toBeUndefined();
+    });
+});

--- a/packages/plugins/apps/src/validate.test.ts
+++ b/packages/plugins/apps/src/validate.test.ts
@@ -214,10 +214,13 @@ describe('new app properties', () => {
         });
     });
 
-    test('Should leave description, selfService, and permissions undefined when not configured', () => {
+    test('Should omit description, selfService, and permissions entirely when not configured', () => {
         const result = validateOptions({ apps: {} });
-        expect(result.description).toBeUndefined();
-        expect(result.selfService).toBeUndefined();
-        expect(result.permissions).toBeUndefined();
+        // Keys must be absent (not merely undefined) so callers that use
+        // hasOwnProperty / 'in' checks and the manifest builder's !== undefined
+        // guard both behave correctly when no value was provided.
+        expect(result).not.toHaveProperty('description');
+        expect(result).not.toHaveProperty('selfService');
+        expect(result).not.toHaveProperty('permissions');
     });
 });

--- a/packages/plugins/apps/src/validate.ts
+++ b/packages/plugins/apps/src/validate.ts
@@ -40,6 +40,9 @@ export const validateOptions = (options: Options): AppsOptionsWithDefaults => {
         dryRun: resolvedOptions.dryRun ?? !parseBoolEnv(getDDEnvValue('APPS_UPLOAD_ASSETS'), false),
         identifier: resolvedOptions.identifier?.trim(),
         name: resolvedOptions.name?.trim() || options.metadata?.name?.trim(),
+        description: resolvedOptions.description,
+        selfService: resolvedOptions.selfService,
+        permissions: resolvedOptions.permissions,
         authOverrides: {
             method,
         },

--- a/packages/plugins/apps/src/validate.ts
+++ b/packages/plugins/apps/src/validate.ts
@@ -35,14 +35,18 @@ export const validateOptions = (options: Options): AppsOptionsWithDefaults => {
             getDDEnvValue('APPS_AUTH_METHOD') || resolvedOptions.authOverrides?.method,
         ) || (hasApiKeyAuth(options) ? 'apiKey' : 'oauth');
 
+    // Only spread optional app-property fields when explicitly configured — omitting
+    // them entirely (rather than setting them to undefined) keeps the returned object
+    // shape stable for callers that use hasOwnProperty / 'in' checks. The != null
+    // coercion also guards against null values being passed through to the manifest builder.
     return {
         include: resolvedOptions.include || [],
         dryRun: resolvedOptions.dryRun ?? !parseBoolEnv(getDDEnvValue('APPS_UPLOAD_ASSETS'), false),
         identifier: resolvedOptions.identifier?.trim(),
         name: resolvedOptions.name?.trim() || options.metadata?.name?.trim(),
-        description: resolvedOptions.description,
-        selfService: resolvedOptions.selfService,
-        permissions: resolvedOptions.permissions,
+        ...(resolvedOptions.description != null && { description: resolvedOptions.description }),
+        ...(resolvedOptions.selfService != null && { selfService: resolvedOptions.selfService }),
+        ...(resolvedOptions.permissions != null && { permissions: resolvedOptions.permissions }),
         authOverrides: {
             method,
         },

--- a/packages/plugins/apps/src/vite/handle-upload.ts
+++ b/packages/plugins/apps/src/vite/handle-upload.ts
@@ -47,21 +47,23 @@ function buildManifest(
 
     // Include optional app properties when specified — the server ignores absent fields
     // and leaves the existing values unchanged, so omitting them is always safe.
-    if (options.description !== undefined) {
+    // Use != null throughout to treat both undefined and null as "not configured".
+    if (options.description != null) {
         manifest.description = options.description;
     }
-    if (options.selfService !== undefined) {
+    if (options.selfService != null) {
         manifest.selfService = options.selfService;
     }
-    // Only include permissions if at least one field is set — an empty object {}
-    // would be serialised as `"permissions": {}` and may unintentionally override
-    // server-side values (the server treats any present key as an explicit update).
-    if (
-        options.permissions !== undefined &&
-        (options.permissions.protectionLevel !== undefined ||
-            options.permissions.runAs !== undefined)
-    ) {
-        manifest.permissions = options.permissions;
+    // Only include permissions if at least one subfield is non-null — an empty object {}
+    // or an object with only null subfields must not appear in the manifest, as the server
+    // treats any present key as an explicit update and null subfields are not valid values.
+    const protectionLevel = options.permissions?.protectionLevel ?? null;
+    const runAs = options.permissions?.runAs ?? null;
+    if (protectionLevel != null || runAs != null) {
+        manifest.permissions = {
+            ...(protectionLevel != null && { protectionLevel }),
+            ...(runAs != null && { runAs }),
+        };
     }
 
     return manifest;

--- a/packages/plugins/apps/src/vite/handle-upload.ts
+++ b/packages/plugins/apps/src/vite/handle-upload.ts
@@ -32,24 +32,48 @@ export interface HandleUploadOptions {
     options: AppsOptionsWithDefaults;
 }
 
-function buildManifest(backendFunctions: BackendFunction[]): AppsManifest {
+function buildManifest(
+    backendFunctions: BackendFunction[],
+    options: AppsOptionsWithDefaults,
+): AppsManifest {
     const functions: AppsManifest['backend']['functions'] = {};
     for (const func of backendFunctions) {
         functions[encodeQueryName(func)] = {
             allowedConnectionIds: [...func.allowedConnectionIds],
         };
     }
-    return { backend: { functions } };
+
+    const manifest: AppsManifest = { backend: { functions } };
+
+    // Include optional app properties when specified — the server ignores absent fields
+    // and leaves the existing values unchanged, so omitting them is always safe.
+    if (options.description !== undefined) {
+        manifest.description = options.description;
+    }
+    if (options.selfService !== undefined) {
+        manifest.selfService = options.selfService;
+    }
+    if (options.permissions !== undefined) {
+        manifest.permissions = options.permissions;
+    }
+
+    return manifest;
 }
 
-async function writeManifestFile(backendFunctions: BackendFunction[]): Promise<{
+async function writeManifestFile(
+    backendFunctions: BackendFunction[],
+    options: AppsOptionsWithDefaults,
+): Promise<{
     manifestAsset: Asset;
     cleanup: () => Promise<void>;
 }> {
     const manifestDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'dd-apps-manifest-'));
     const manifestPath = path.join(manifestDir, MANIFEST_FILE_NAME);
     try {
-        await fsp.writeFile(manifestPath, JSON.stringify(buildManifest(backendFunctions), null, 2));
+        await fsp.writeFile(
+            manifestPath,
+            JSON.stringify(buildManifest(backendFunctions, options), null, 2),
+        );
     } catch (error) {
         await rm(manifestDir);
         throw error;
@@ -131,7 +155,7 @@ Either:
             });
         }
 
-        const { manifestAsset, cleanup } = await writeManifestFile(backendFunctions);
+        const { manifestAsset, cleanup } = await writeManifestFile(backendFunctions, options);
         cleanupManifest = cleanup;
         allAssets.push(manifestAsset);
 

--- a/packages/plugins/apps/src/vite/handle-upload.ts
+++ b/packages/plugins/apps/src/vite/handle-upload.ts
@@ -53,7 +53,14 @@ function buildManifest(
     if (options.selfService !== undefined) {
         manifest.selfService = options.selfService;
     }
-    if (options.permissions !== undefined) {
+    // Only include permissions if at least one field is set — an empty object {}
+    // would be serialised as `"permissions": {}` and may unintentionally override
+    // server-side values (the server treats any present key as an explicit update).
+    if (
+        options.permissions !== undefined &&
+        (options.permissions.protectionLevel !== undefined ||
+            options.permissions.runAs !== undefined)
+    ) {
         manifest.permissions = options.permissions;
     }
 


### PR DESCRIPTION
## Motivation
- [APPS-2784](https://datadoghq.atlassian.net/browse/APPS-2784)
- The `app-builder-code` service ([ddoghq/dd-source#8713](https://github.com/ddoghq/dd-source/pull/8713)) now accepts `description`, `selfService`, `permissions.protectionLevel`, and `permissions.runAs` in the uploaded `manifest.json`. Previously there was no way to set these from the build plugin — developers had to configure them manually in the App Builder UI after each deploy.

## Changes

| What changed | File |
|---|---|
| Add `AppsProtectionLevel` type and `description`, `selfService`, `permissions` fields to `AppsOptions` and `AppsManifest` | `src/types.ts` |
| Conditionally pass new optional fields into `AppsOptionsWithDefaults`; omit entirely when unset so callers using `in`/`hasOwnProperty` see a stable shape | `src/validate.ts` |
| Write `description`, `selfService`, `permissions` into `manifest.json` only when configured; reconstruct permissions from non-null subfields only to prevent null values or empty objects reaching the server | `src/vite/handle-upload.ts` |
| Tests: new fields appear in manifest when configured, absent when not, `selfService:false` preserved, `runAs` included, empty `permissions:{}` omitted, null subfields stripped | `src/index.test.ts` |
| Tests: new fields flow through `validateOptions`; keys absent entirely (not `undefined`) when not configured | `src/validate.test.ts` |
| Document `description`, `selfService`, `permissions.protectionLevel`, `permissions.runAs` config options with defaults and behaviour | `README.md` |

## Architecture

Fields configured in `vite.config.ts` flow into the generated `manifest.json` bundle, which `app-builder-code` reads on upload and applies via the appropriate `app-builder-api` endpoints. Omitting any field leaves the existing server-side value unchanged.

```
vite.config.ts (AppsOptions)
  → validate.ts (AppsOptionsWithDefaults)
    → handle-upload.ts buildManifest()
      → manifest.json in bundle
        → app-builder-code (ddoghq/dd-source#8713)
          → app-builder-api /self-service, /protection-level, /identity
```

**Example `vite.config.ts`:**
```ts
datadogVite({
  apps: {
    description: 'My high-code app',
    selfService: true,
    permissions: {
      protectionLevel: 'approval_required',
      runAs: '<service-account-uuid>',   // optional
    },
  },
})
```

## QA Instructions

**Test URL:** local Vite build — no service required for manifest verification.

### 1. Build and test
```bash
yarn
yarn workspace @dd/tests test:unit
# Expected: all tests pass, including two new apps manifest tests ✅ VERIFIED

yarn workspace @dd/apps-plugin typecheck
# Expected: no type errors ✅ VERIFIED
```

### 2. Local manifest verification
In any Vite app using `@datadog/vite-plugin`:
```bash
# Add new fields to vite.config.ts, then build with dryRun (no upload):
DD_APPS_UPLOAD_ASSETS=1 vite build
# Inspect the generated manifest.json inside the archive to confirm new fields appear ✅ VERIFIED
```

### 3. Staging end-to-end
Using the `apps-2780-qa` TD (still live from ddoghq/dd-source#8713) with `dd-auth --actions-api --domain dd.datad0g.com`:
```bash
# Upload bundle with description, selfService:true, protectionLevel:approval_required in manifest.json
curl -s -X POST "https://dd.datad0g.com/api/unstable/app-builder-code/apps/bp-pr446-qa2/upload" \
    -H "test-drive-apps-2780-qa: 1" \
    -F "bundle=@bundle-with-new-fields.zip" \
    -F "name=build-plugins-pr446-qa2"
# Expected: {"application_id":"bp-pr446-qa2","version_id":"439e1dc156164851","app_builder_id":"446f7de3-f4cf-4e1f-9b97-bd8fb35ba653","created":true} ✅ VERIFIED

# Verify properties applied in app-builder-api
curl -s "https://dd.datad0g.com/api/v2/app-builder/apps/446f7de3-f4cf-4e1f-9b97-bd8fb35ba653" \
    -H "test-drive-apps-2780-qa: 1" | jq '{description,selfService,protectionLevel}'
# Expected: {"description":"QA rerun — build-plugins PR #446 post-null-fix","selfService":true,"protectionLevel":"approval_required"} ✅ VERIFIED

# Re-upload bare manifest (no new fields) — existing properties must be preserved
curl -s -X POST "https://dd.datad0g.com/api/unstable/app-builder-code/apps/bp-pr446-qa2/upload" \
    -H "test-drive-apps-2780-qa: 1" -F "bundle=@bare-manifest-bundle.zip"
curl -s "https://dd.datad0g.com/api/v2/app-builder/apps/446f7de3-f4cf-4e1f-9b97-bd8fb35ba653" \
    -H "test-drive-apps-2780-qa: 1" | jq '{description,selfService,protectionLevel}'
# Expected: same values unchanged (backwards compat) ✅ VERIFIED
```

## Blast Radius
- Additive only — new optional fields, no existing behaviour changed
- Omitting any field produces the same manifest as before (backwards compatible)
- Risk: **low**

## Documentation
- [APPS-2784](https://datadoghq.atlassian.net/browse/APPS-2784)
- Backend implementation: [ddoghq/dd-source#8713](https://github.com/ddoghq/dd-source/pull/8713)



[APPS-2784]: https://datadoghq.atlassian.net/browse/APPS-2784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPS-2784]: https://datadoghq.atlassian.net/browse/APPS-2784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
