### PR TITLE
[APPS-2777] Fix: use app_builder_url from API response (fixes custom domain orgs)

### DIFF
--- a/packages/plugins/apps/src/upload.test.ts
+++ b/packages/plugins/apps/src/upload.test.ts
@@ -278,7 +278,7 @@ describe('Apps Plugin - upload', () => {
             );
         });
 
-        test('Should not log an available-at message when app_builder_url is absent', async () => {
+        test('Should warn (not error) when app_builder_url is absent from the upload response', async () => {
             // Skip the release call entirely — this test only cares about the upload log.
             getDDEnvValueMock.mockImplementation((key) =>
                 key === 'APPS_PUBLISH' ? 'false' : undefined,
@@ -289,13 +289,19 @@ describe('Apps Plugin - upload', () => {
                 app_builder_id: 'builder123',
             } as any);
 
-            const { errors } = await uploadArchive(archive, context, logger);
+            const { errors, warnings } = await uploadArchive(archive, context, logger);
 
+            // The upload itself succeeded — a missing display URL must never fail the build.
             expect(errors).toHaveLength(0);
             const uploadLog = mockLogFn.mock.calls.find(([message]) =>
                 message.startsWith('Your application is available at'),
             );
             expect(uploadLog).toBeUndefined();
+            // But it also must not go silent — surfaced as a warning so it's visible in CI
+            // output (see handle-upload.ts, which logs and aggregates `warnings` without
+            // failing the build, unlike `errors`).
+            expect(warnings).toHaveLength(1);
+            expect(warnings[0]).toContain('Could not resolve the App Builder URL');
 
             // Reset — other tests in this file rely on getDDEnvValueMock's default
             // (undefined) behavior and beforeEach doesn't reset this particular mock.
@@ -397,6 +403,35 @@ describe('Apps Plugin - upload', () => {
             );
             expect(releaseLog?.[0]).toContain('https://dd.datad0g.com/app-builder/apps/builder123');
             expect(releaseLog?.[0]).not.toContain('?viewMode');
+        });
+
+        test('Should warn (not error) when app_builder_url is absent from the release response', async () => {
+            doAuthenticatedRequestMock
+                .mockResolvedValueOnce({
+                    version_id: 'v123',
+                    application_id: 'app123',
+                    app_builder_id: 'builder123',
+                    app_builder_url:
+                        'https://app.datadoghq.com/app-builder/apps/edit/builder123?viewMode=preview',
+                })
+                // The backend couldn't resolve the org's app URL for this release — a real,
+                // designed-for degradation path (e.g. a transient org-lookup failure), not a
+                // hypothetical. The release itself still succeeded.
+                .mockResolvedValueOnce({});
+
+            const { errors, warnings } = await uploadArchive(archive, context, logger);
+
+            // The release itself succeeded — a missing display URL must never fail the build.
+            expect(errors).toHaveLength(0);
+            const releaseLog = mockLogFn.mock.calls.find(([message]) =>
+                message.startsWith('Published uploaded version'),
+            );
+            // Still confirms the release happened, just without a trailing URL line.
+            expect(releaseLog?.[0]).toContain('to live.');
+            expect(releaseLog?.[0]).not.toContain('\n');
+            // Surfaced as a warning rather than a blank/malformed log line.
+            expect(warnings).toHaveLength(1);
+            expect(warnings[0]).toContain('Could not resolve the App Builder URL');
         });
 
         test.each(['false', '0', 'False', 'FALSE', 'off', 'no'])(

--- a/packages/plugins/apps/src/upload.test.ts
+++ b/packages/plugins/apps/src/upload.test.ts
@@ -300,14 +300,37 @@ describe('Apps Plugin - upload', () => {
             // But it also must not go silent — surfaced as a warning so it's visible in CI
             // output (see handle-upload.ts, which logs and aggregates `warnings` without
             // failing the build, unlike `errors`). Names the app by its display name (not
-            // context.identifier, which is an opaque hash — see identifier.ts) so there's a
-            // concrete next step (find it in the apps list), not just a generic warning.
+            // context.identifier, which is an opaque hash — see identifier.ts) and includes
+            // the app_builder_id, so there's a concrete, unambiguous next step (find it in
+            // the apps list, disambiguated by ID if names collide), not just a generic warning.
             expect(warnings).toHaveLength(1);
             expect(warnings[0]).toContain('Could not resolve the App Builder URL');
             expect(warnings[0]).toContain(context.name);
+            expect(warnings[0]).toContain('builder123');
 
             // Reset — other tests in this file rely on getDDEnvValueMock's default
             // (undefined) behavior and beforeEach doesn't reset this particular mock.
+            getDDEnvValueMock.mockReset();
+        });
+
+        test('Should omit the app ID suffix when app_builder_id is also absent', async () => {
+            getDDEnvValueMock.mockImplementation((key) =>
+                key === 'APPS_PUBLISH' ? 'false' : undefined,
+            );
+            // Matches the backend's own no-op-path edge case (app-builder-code's
+            // TestAppBuilderURL_EmptyAppBuilderID) — both app_builder_id and
+            // app_builder_url absent, not just the URL.
+            doAuthenticatedRequestMock.mockResolvedValueOnce({
+                version_id: 'v123',
+                application_id: 'app123',
+            } as any);
+
+            const { warnings } = await uploadArchive(archive, context, logger);
+
+            expect(warnings).toHaveLength(1);
+            expect(warnings[0]).toContain(context.name);
+            expect(warnings[0]).not.toContain('app ID');
+
             getDDEnvValueMock.mockReset();
         });
 
@@ -419,8 +442,9 @@ describe('Apps Plugin - upload', () => {
                 })
                 // The backend couldn't resolve the org's app URL for this release — a real,
                 // designed-for degradation path (e.g. a transient org-lookup failure), not a
-                // hypothetical. The release itself still succeeded.
-                .mockResolvedValueOnce({});
+                // hypothetical. The release itself still succeeded. app_builder_id is still
+                // present, though — it's set from the DB independently of the URL lookup.
+                .mockResolvedValueOnce({ app_builder_id: 'builder123' });
 
             const { errors, warnings } = await uploadArchive(archive, context, logger);
 
@@ -433,10 +457,11 @@ describe('Apps Plugin - upload', () => {
             expect(releaseLog?.[0]).toContain('to live.');
             expect(releaseLog?.[0]).not.toContain('\n');
             // Surfaced as a warning rather than a blank/malformed log line — names the app
-            // by its display name so there's a concrete next step (find it in the apps list).
+            // by its display name and includes the app_builder_id for unambiguous lookup.
             expect(warnings).toHaveLength(1);
             expect(warnings[0]).toContain('Could not resolve the App Builder URL');
             expect(warnings[0]).toContain(context.name);
+            expect(warnings[0]).toContain('builder123');
         });
 
         test.each(['false', '0', 'False', 'FALSE', 'off', 'no'])(

--- a/packages/plugins/apps/src/upload.test.ts
+++ b/packages/plugins/apps/src/upload.test.ts
@@ -229,6 +229,8 @@ describe('Apps Plugin - upload', () => {
                 version_id: 'v123',
                 application_id: 'app123',
                 app_builder_id: 'builder123',
+                app_builder_url:
+                    'https://app.datadoghq.com/app-builder/apps/edit/builder123?viewMode=preview',
             } as any);
 
             const { errors, warnings } = await uploadArchive(archive, context, logger);
@@ -248,9 +250,56 @@ describe('Apps Plugin - upload', () => {
                 onRetry: expect.any(Function),
             });
             expect(mockLogFn).toHaveBeenCalledWith(
-                expect.stringContaining('Your application is available at'),
+                expect.stringContaining(
+                    'https://app.datadoghq.com/app-builder/apps/edit/builder123?viewMode=preview',
+                ),
                 'info',
             );
+        });
+
+        test('Should use app_builder_url from upload response', async () => {
+            doAuthenticatedRequestMock.mockResolvedValueOnce({
+                version_id: 'v123',
+                application_id: 'app123',
+                app_builder_id: 'builder123',
+                app_builder_url:
+                    'https://dd.datad0g.com/app-builder/apps/edit/builder123?viewMode=preview',
+            } as any);
+
+            await uploadArchive(archive, context, logger);
+
+            // Uses the exact URL from the response — proves it's not reconstructed from
+            // context.site (datadoghq.com), which would produce a different domain.
+            expect(mockLogFn).toHaveBeenCalledWith(
+                expect.stringContaining(
+                    'https://dd.datad0g.com/app-builder/apps/edit/builder123?viewMode=preview',
+                ),
+                'info',
+            );
+        });
+
+        test('Should not log an available-at message when app_builder_url is absent', async () => {
+            // Skip the release call entirely — this test only cares about the upload log.
+            getDDEnvValueMock.mockImplementation((key) =>
+                key === 'APPS_PUBLISH' ? 'false' : undefined,
+            );
+            doAuthenticatedRequestMock.mockResolvedValueOnce({
+                version_id: 'v123',
+                application_id: 'app123',
+                app_builder_id: 'builder123',
+            } as any);
+
+            const { errors } = await uploadArchive(archive, context, logger);
+
+            expect(errors).toHaveLength(0);
+            const uploadLog = mockLogFn.mock.calls.find(([message]) =>
+                message.startsWith('Your application is available at'),
+            );
+            expect(uploadLog).toBeUndefined();
+
+            // Reset — other tests in this file rely on getDDEnvValueMock's default
+            // (undefined) behavior and beforeEach doesn't reset this particular mock.
+            getDDEnvValueMock.mockReset();
         });
 
         test('Should upload archive using the supplied request function', async () => {
@@ -258,6 +307,8 @@ describe('Apps Plugin - upload', () => {
                 version_id: 'v123',
                 application_id: 'app123',
                 app_builder_id: 'builder123',
+                app_builder_url:
+                    'https://app.datadoghq.com/app-builder/apps/edit/builder123?viewMode=preview',
             } as any);
 
             const { errors, warnings } = await uploadArchive(
@@ -286,8 +337,12 @@ describe('Apps Plugin - upload', () => {
                     version_id: 'v123',
                     application_id: 'app123',
                     app_builder_id: 'builder123',
+                    app_builder_url:
+                        'https://app.datadoghq.com/app-builder/apps/edit/builder123?viewMode=preview',
                 })
-                .mockResolvedValueOnce({});
+                .mockResolvedValueOnce({
+                    app_builder_url: 'https://app.datadoghq.com/app-builder/apps/builder123',
+                });
 
             const { errors, warnings } = await uploadArchive(archive, context, logger);
 
@@ -301,10 +356,47 @@ describe('Apps Plugin - upload', () => {
                 getData: expect.any(Function),
                 onRetry: expect.any(Function),
             });
-            expect(mockLogFn).toHaveBeenCalledWith(
-                expect.stringContaining('Your application is available at'),
-                'info',
+            // Pin down which log is which by its distinguishing message prefix — proves not
+            // just that a matching call exists somewhere, but that the upload log specifically
+            // carries ?viewMode=preview and the release log specifically doesn't.
+            const uploadLog = mockLogFn.mock.calls.find(([message]) =>
+                message.startsWith('Your application is available at'),
             );
+            const releaseLog = mockLogFn.mock.calls.find(([message]) =>
+                message.startsWith('Published uploaded version'),
+            );
+            expect(uploadLog?.[0]).toContain(
+                'https://app.datadoghq.com/app-builder/apps/edit/builder123?viewMode=preview',
+            );
+            expect(releaseLog?.[0]).toContain(
+                'https://app.datadoghq.com/app-builder/apps/builder123',
+            );
+            expect(releaseLog?.[0]).not.toContain('?viewMode');
+        });
+
+        test('Should use app_builder_url from release response', async () => {
+            doAuthenticatedRequestMock
+                .mockResolvedValueOnce({
+                    version_id: 'v123',
+                    application_id: 'app123',
+                    app_builder_id: 'builder123',
+                    app_builder_url:
+                        'https://dd.datad0g.com/app-builder/apps/edit/builder123?viewMode=preview',
+                })
+                .mockResolvedValueOnce({
+                    app_builder_url: 'https://dd.datad0g.com/app-builder/apps/builder123',
+                });
+
+            await uploadArchive(archive, context, logger);
+
+            // Match the release log by its distinguishing message prefix — proves the
+            // published URL reflects the custom domain from the release response (not
+            // context.site) and carries no ?viewMode (unlike the upload log).
+            const releaseLog = mockLogFn.mock.calls.find(([message]) =>
+                message.startsWith('Published uploaded version'),
+            );
+            expect(releaseLog?.[0]).toContain('https://dd.datad0g.com/app-builder/apps/builder123');
+            expect(releaseLog?.[0]).not.toContain('?viewMode');
         });
 
         test.each(['false', '0', 'False', 'FALSE', 'off', 'no'])(
@@ -317,6 +409,8 @@ describe('Apps Plugin - upload', () => {
                     version_id: 'v123',
                     application_id: 'app123',
                     app_builder_id: 'builder123',
+                    app_builder_url:
+                        'https://app.datadoghq.com/app-builder/apps/edit/builder123?viewMode=preview',
                 });
 
                 const { errors } = await uploadArchive(archive, context, logger);
@@ -342,6 +436,8 @@ describe('Apps Plugin - upload', () => {
                 version_id: 'v123',
                 application_id: 'app123',
                 app_builder_id: 'builder123',
+                app_builder_url:
+                    'https://app.datadoghq.com/app-builder/apps/edit/builder123?viewMode=preview',
             });
 
             const { errors, warnings } = await uploadArchive(archive, context, logger);

--- a/packages/plugins/apps/src/upload.test.ts
+++ b/packages/plugins/apps/src/upload.test.ts
@@ -299,9 +299,12 @@ describe('Apps Plugin - upload', () => {
             expect(uploadLog).toBeUndefined();
             // But it also must not go silent — surfaced as a warning so it's visible in CI
             // output (see handle-upload.ts, which logs and aggregates `warnings` without
-            // failing the build, unlike `errors`).
+            // failing the build, unlike `errors`). Names the app by its display name (not
+            // context.identifier, which is an opaque hash — see identifier.ts) so there's a
+            // concrete next step (find it in the apps list), not just a generic warning.
             expect(warnings).toHaveLength(1);
             expect(warnings[0]).toContain('Could not resolve the App Builder URL');
+            expect(warnings[0]).toContain(context.name);
 
             // Reset — other tests in this file rely on getDDEnvValueMock's default
             // (undefined) behavior and beforeEach doesn't reset this particular mock.
@@ -429,9 +432,11 @@ describe('Apps Plugin - upload', () => {
             // Still confirms the release happened, just without a trailing URL line.
             expect(releaseLog?.[0]).toContain('to live.');
             expect(releaseLog?.[0]).not.toContain('\n');
-            // Surfaced as a warning rather than a blank/malformed log line.
+            // Surfaced as a warning rather than a blank/malformed log line — names the app
+            // by its display name so there's a concrete next step (find it in the apps list).
             expect(warnings).toHaveLength(1);
             expect(warnings[0]).toContain('Could not resolve the App Builder URL');
+            expect(warnings[0]).toContain(context.name);
         });
 
         test.each(['false', '0', 'False', 'FALSE', 'off', 'no'])(

--- a/packages/plugins/apps/src/upload.ts
+++ b/packages/plugins/apps/src/upload.ts
@@ -123,6 +123,14 @@ Would have uploaded ${summary}`,
 
         if (response.app_builder_url) {
             log.info(`Your application is available at:\n  ${cyan(response.app_builder_url)}`);
+        } else {
+            // The backend couldn't resolve this org's App Builder URL (e.g. a transient
+            // lookup failure) — the upload itself still succeeded, so this doesn't fail the
+            // build, but it's surfaced as a warning rather than going silent.
+            const message =
+                'Could not resolve the App Builder URL for this upload — check the App Builder UI directly to view your app.';
+            warnings.push(message);
+            log.warn(message);
         }
 
         const shouldPublish = parseBoolEnv(getDDEnvValue('APPS_PUBLISH'), true);
@@ -149,9 +157,17 @@ Would have uploaded ${summary}`,
                 },
             });
 
-            log.info(
-                `Published uploaded version ${bold(response.version_id)} to live.\n  ${cyan(releaseResponse.app_builder_url)}`,
-            );
+            if (releaseResponse.app_builder_url) {
+                log.info(
+                    `Published uploaded version ${bold(response.version_id)} to live.\n  ${cyan(releaseResponse.app_builder_url)}`,
+                );
+            } else {
+                log.info(`Published uploaded version ${bold(response.version_id)} to live.`);
+                const message =
+                    'Could not resolve the App Builder URL for this release — check the App Builder UI directly to view your app.';
+                warnings.push(message);
+                log.warn(message);
+            }
         } else if (response.version_id && !shouldPublish) {
             log.info(`Uploaded version ${bold(response.version_id)} as a draft (publish skipped).`);
         }

--- a/packages/plugins/apps/src/upload.ts
+++ b/packages/plugins/apps/src/upload.ts
@@ -126,9 +126,10 @@ Would have uploaded ${summary}`,
         } else {
             // The backend couldn't resolve this org's App Builder URL (e.g. a transient
             // lookup failure) — the upload itself still succeeded, so this doesn't fail the
-            // build, but it's surfaced as a warning rather than going silent.
-            const message =
-                'Could not resolve the App Builder URL for this upload — check the App Builder UI directly to view your app.';
+            // build. Point at the apps list by name (not context.identifier, which is an
+            // opaque hash in the default case — see identifier.ts's buildIdentifier — and
+            // not something anyone would recognize or search for).
+            const message = `Could not resolve the App Builder URL for this upload — find "${context.name}" in your App Builder apps list to view it.`;
             warnings.push(message);
             log.warn(message);
         }
@@ -163,8 +164,7 @@ Would have uploaded ${summary}`,
                 );
             } else {
                 log.info(`Published uploaded version ${bold(response.version_id)} to live.`);
-                const message =
-                    'Could not resolve the App Builder URL for this release — check the App Builder UI directly to view your app.';
+                const message = `Could not resolve the App Builder URL for this release — find "${context.name}" in your App Builder apps list to view it.`;
                 warnings.push(message);
                 log.warn(message);
             }

--- a/packages/plugins/apps/src/upload.ts
+++ b/packages/plugins/apps/src/upload.ts
@@ -17,6 +17,19 @@ import { APPS_API_PATH, ARCHIVE_FILENAME } from './constants';
 
 type DataResponse = Awaited<ReturnType<typeof createRequestData>>;
 
+// Only the fields this file actually reads. app_builder_url is deliberately optional on both:
+// see buildMissingAppUrlWarning's callers for what happens when the backend can't resolve it.
+type UploadApiResponse = {
+    app_builder_id?: string;
+    app_builder_url?: string;
+    version_id?: string;
+};
+
+type ReleaseApiResponse = {
+    app_builder_id?: string;
+    app_builder_url?: string;
+};
+
 export type UploadContext = {
     bundlerName: string;
     doAuthenticatedRequest: DoAuthenticatedRequest;
@@ -118,7 +131,7 @@ Would have uploaded ${summary}`,
     }
 
     try {
-        const response: any = await doAuthenticatedRequest({
+        const response = await doAuthenticatedRequest<UploadApiResponse>({
             url: intakeUrl,
             method: 'POST',
             type: 'json',
@@ -155,7 +168,7 @@ Would have uploaded ${summary}`,
 
         if (response.version_id && shouldPublish) {
             const releaseUrl = getReleaseUrl(context.site, context.identifier);
-            const releaseResponse: any = await doAuthenticatedRequest({
+            const releaseResponse = await doAuthenticatedRequest<ReleaseApiResponse>({
                 url: releaseUrl,
                 method: 'PUT',
                 type: 'json',

--- a/packages/plugins/apps/src/upload.ts
+++ b/packages/plugins/apps/src/upload.ts
@@ -41,6 +41,19 @@ export const getReleaseUrl = (site: string, appId: string) => {
     return `https://api.${site}/${APPS_API_PATH}/${appId}/release/live`;
 };
 
+// Builds the warning shown when the backend couldn't resolve an org's App Builder URL.
+// Names the app (context.name — always human-readable, unlike context.identifier's opaque
+// hash) and its app_builder_id when present, which disambiguates same-named apps and lets
+// anyone who knows their org's domain construct the link directly.
+const buildMissingAppUrlWarning = (
+    action: 'upload' | 'release',
+    name: string,
+    appBuilderId?: string,
+) => {
+    const idSuffix = appBuilderId ? ` (app ID: ${appBuilderId})` : '';
+    return `Could not resolve the App Builder URL for this ${action} — find "${name}"${idSuffix} in your App Builder apps list to view it.`;
+};
+
 export const getData =
     (archivePath: string, defaultHeaders: Record<string, string> = {}, name: string) =>
     async (): Promise<DataResponse> => {
@@ -126,10 +139,14 @@ Would have uploaded ${summary}`,
         } else {
             // The backend couldn't resolve this org's App Builder URL (e.g. a transient
             // lookup failure) — the upload itself still succeeded, so this doesn't fail the
-            // build. Point at the apps list by name (not context.identifier, which is an
-            // opaque hash in the default case — see identifier.ts's buildIdentifier — and
-            // not something anyone would recognize or search for).
-            const message = `Could not resolve the App Builder URL for this upload — find "${context.name}" in your App Builder apps list to view it.`;
+            // build. Uses context.name, not context.identifier, since the latter is an
+            // opaque hash in the default case (see identifier.ts's buildIdentifier) — not
+            // something anyone would recognize or search for.
+            const message = buildMissingAppUrlWarning(
+                'upload',
+                context.name,
+                response.app_builder_id,
+            );
             warnings.push(message);
             log.warn(message);
         }
@@ -164,7 +181,11 @@ Would have uploaded ${summary}`,
                 );
             } else {
                 log.info(`Published uploaded version ${bold(response.version_id)} to live.`);
-                const message = `Could not resolve the App Builder URL for this release — find "${context.name}" in your App Builder apps list to view it.`;
+                const message = buildMissingAppUrlWarning(
+                    'release',
+                    context.name,
+                    releaseResponse.app_builder_id,
+                );
                 warnings.push(message);
                 log.warn(message);
             }

--- a/packages/plugins/apps/src/upload.ts
+++ b/packages/plugins/apps/src/upload.ts
@@ -121,17 +121,15 @@ Would have uploaded ${summary}`,
 
         log.debug(`Uploaded ${summary}\n`);
 
-        if (response.app_builder_id) {
-            const appBuilderUrl = `https://app.${context.site}/app-builder/apps/${response.app_builder_id}`;
-
-            log.info(`Your application is available at:\n  ${cyan(appBuilderUrl)}`);
+        if (response.app_builder_url) {
+            log.info(`Your application is available at:\n  ${cyan(response.app_builder_url)}`);
         }
 
         const shouldPublish = parseBoolEnv(getDDEnvValue('APPS_PUBLISH'), true);
 
         if (response.version_id && shouldPublish) {
             const releaseUrl = getReleaseUrl(context.site, context.identifier);
-            await doAuthenticatedRequest({
+            const releaseResponse: any = await doAuthenticatedRequest({
                 url: releaseUrl,
                 method: 'PUT',
                 type: 'json',
@@ -150,7 +148,10 @@ Would have uploaded ${summary}`,
                     log.warn(message);
                 },
             });
-            log.info(`Published uploaded version ${bold(response.version_id)} to live.`);
+
+            log.info(
+                `Published uploaded version ${bold(response.version_id)} to live.\n  ${cyan(releaseResponse.app_builder_url)}`,
+            );
         } else if (response.version_id && !shouldPublish) {
             log.info(`Uploaded version ${bold(response.version_id)} as a draft (publish skipped).`);
         }


### PR DESCRIPTION
## Motivation

- The plugin constructed the App Builder URL by hardcoding `https://app.${site}/...`, which produces the wrong host for orgs with custom domains (e.g. `dd.datad0g.com`) — users on those orgs got a broken link printed after upload/release.
- The backend now returns `app_builder_url` directly in the upload and release API responses, resolved from the org's actual configured web domain (see backend fix below), so the plugin no longer needs to guess the domain.
- Jira: [APPS-2777](https://datadoghq.atlassian.net/browse/APPS-2777)

## Changes

| What changed | File |
|---|---|
| Upload log uses `response.app_builder_url` (server-provided, edit view + `?viewMode=preview`) instead of constructing `https://app.${site}/app-builder/apps/${id}` | `packages/plugins/apps/src/upload.ts` |
| Release log uses `releaseResponse.app_builder_url` (server-provided, published view, no query string) instead of a hardcoded message with no URL | `packages/plugins/apps/src/upload.ts` |
| When `app_builder_url` is missing from either response, surfaces a `warnings` entry instead of going silent (upload) or printing a blank line (release, which previously had no guard at all) | `packages/plugins/apps/src/upload.ts` |
| Warnings are aggregated and logged by `handle-upload.ts` without failing the build | `packages/plugins/apps/src/vite/handle-upload.ts` |
| The warning names the app by its display name (`context.name`), not `context.identifier` — the latter is a SHA-256 hash in the default case (see `identifier.ts`'s `buildIdentifier`) and not something a human would recognize or search for | `packages/plugins/apps/src/upload.ts` |
| The warning also includes `app_builder_id` for unambiguous lookup — disambiguates same-named apps, and is usable directly by anyone who already knows their org's domain | `packages/plugins/apps/src/upload.ts` |
| Added/updated tests: `?viewMode=preview` present on upload / absent on release (default + custom-domain fixtures), warning text and `app_builder_id` inclusion when the URL is missing, and the edge case where `app_builder_id` is *also* absent (mirrors the backend's `TestAppBuilderURL_EmptyAppBuilderID`) | `packages/plugins/apps/src/upload.test.ts` |
| `response`/`releaseResponse` typed via `doAuthenticatedRequest<T>()`'s generic instead of `any`, matching `vite/dev-server.ts`'s existing pattern — catches typos/renames on `app_builder_url`/`app_builder_id`/`version_id` at compile time. Caught by automated PR review | `packages/plugins/apps/src/upload.ts` |

## QA Instructions

### Automated

```bash
yarn workspace @dd/apps-plugin run typecheck
# Expected: no type errors ✅ VERIFIED

yarn eslint packages/plugins/apps/src/upload.ts packages/plugins/apps/src/upload.test.ts
# Expected: no lint errors ✅ VERIFIED

yarn test:unit --testPathPatterns=upload.test
# Expected: 26/26 tests passing ✅ VERIFIED

yarn test:unit
# Expected: full repo suite unaffected — 77/77 suites, 1850/1851 tests (1 pre-existing unrelated skip) ✅ VERIFIED
```

CI on this PR: Unit tests ✅ VERIFIED, Linting ✅ VERIFIED, End to End ✅ VERIFIED.

### Manual QA

This is a CLI/build-time plugin, not a hosted service, so there's no "test URL" to browse to. Three passes instead, each isolating a different part of the path — real plugin code vs. real network:

| Pass | Plugin code | Network | What it confirms |
|---|---|---|---|
| 1. Real scaffold, fully live | Real project from `npm init @datadog/apps`, local build linked in | Live staging test drive (`dd-auth` credentials) | The exact documented customer flow, end-to-end: real scaffold → real build → real backend → correct URL |
| 2. Plugin wiring | Real `@datadog/vite-plugin`, real `vite build` | Mocked (`nock`) | The missing-URL warning reaches the console through the real logger, not just unit tests |
| 3. Backend only | curl, and separately the raw `uploadArchive()` function | Live staging test drive | Original data point, before pass 1 existed |

**1. Real scaffold, fully live** — the [High Code Apps "Getting started" guide](https://datadoghq.atlassian.net/wiki/x/Mgi9gQE)'s documented flow, run for real: scaffold a project the way any customer would, link this branch's build into it instead of the npm-published version, and publish exactly as documented. Exact commands, in order (`npm 10.9.2`, `node v22.13.1`):

**Steps 1-5 — scaffold, build, and link this branch's plugin in.** The doc's own literal scaffolding syntax — `npm init @datadog/apps test-app --template vite-react -y` — failed here: npm's own `init`/`-y` flag handling mangles the args before they reach `create-apps` ("Unknown Syntax Error: Command not found"). `npm create ... --` forces npm to pass everything after `--` through untouched, which works — that's the one deviation from the doc's exact text below:
```bash
# 1. Scaffold:
mkdir -p /tmp/dd-apps-scaffold-test && cd /tmp/dd-apps-scaffold-test
npm create @datadog/apps@latest -- test-app --template vite-react -y

# 2. Build this branch's plugin:
cd ~/dd/build-plugins/packages/published/vite-plugin
NO_TYPES=1 yarn build

# 3. Swap this package's `exports` to point at the built dist/src instead of raw src/index.ts —
#    required before linking, otherwise the consuming project gets un-transpiled TS:
cd ~/dd/build-plugins
yarn cli prepare-link

# 4. Register the built package as linkable:
cd ~/dd/build-plugins/packages/published/vite-plugin
npm link

# 5. Link it into the scaffolded app, in place of the npm-published @datadog/vite-plugin:
cd /tmp/dd-apps-scaffold-test/test-app
npm link @datadog/vite-plugin
# Verify it actually points at the local build, not node_modules:
node -e "console.log(require.resolve('@datadog/vite-plugin'))"
# → /Users/.../build-plugins/packages/published/vite-plugin/dist/src/index.js
```

**Step 6 — edit `test-app/vite.config.ts`.** Not shell commands, so it's its own step: two changes, everything else (identifier, name, `logLevel: 'debug'` default, etc.) left exactly as scaffolded.

Change 6a — point at staging instead of prod:
```diff
             auth: {
-                site: 'datadoghq.com',
+                site: 'datad0g.com',
                 apiKey: process.env.DD_API_KEY,
                 appKey: process.env.DD_APP_KEY,
             },
```

Change 6b — route traffic to this branch's test drive instead of shared staging. Add this block right after the imports at the top of the file, before the `hasDatadogApiKeys` line. **This is TD-only plumbing, not something a real app needs** — a real app talking to real staging/prod skips this entirely:
```ts
// TD-only routing, not something a real app needs: sends every api.datad0g.com
// request through this branch's app-builder-code test drive instead of shared
// staging. A real app talking to real staging/prod would not do this.
const realFetch = globalThis.fetch;
globalThis.fetch = (url, init) => {
    const urlStr = url.toString();
    if (urlStr.includes('api.datad0g.com')) {
        const headers = new Headers(init?.headers);
        headers.set('test-drive-apps2787-real-cli-qa', '1');   // ← your test drive's name here
        console.log(`>>> [test-drive routing] ${init?.method ?? 'GET'} ${urlStr}`);
        return realFetch(url, { ...init, headers });
    }
    return realFetch(url, init);
};
```

**Steps 7-8 — publish, then clean up.** Step 7 is the doc's own command, verbatim, no modification:
```bash
# 7. Publish:
dd-auth --domain dd.datad0g.com -- npm run upload

# Upload  → https://dd.datad0g.com/app-builder/apps/edit/7c782a98-d310-413b-82c0-85756c584bd8?viewMode=preview  ✅ VERIFIED
# Release → https://dd.datad0g.com/app-builder/apps/7c782a98-d310-413b-82c0-85756c584bd8                        ✅ VERIFIED

# Re-run after a9294fb2 (typed response) + ddoghq/dd-source#12477's fd8a801 (scheme-less URL
# fix). Redeployed the test drive first (rapid td update; turbo hit a rollout timeout, fell
# back to the documented full-CI update) so this exercised the actual current backend tip:
# Upload  → https://dd.datad0g.com/app-builder/apps/edit/6f2f81ad-1ed7-4e0a-a68f-1e01387f6b2a?viewMode=preview  ✅ VERIFIED
# Release → https://dd.datad0g.com/app-builder/apps/6f2f81ad-1ed7-4e0a-a68f-1e01387f6b2a                        ✅ VERIFIED

# 8. Cleanup:
cd ~/dd/build-plugins/packages/published/vite-plugin && npm unlink
cd ~/dd/build-plugins && yarn cli prepare-link --revert   # undoes step 3's exports swap
rm -rf /tmp/dd-apps-scaffold-test
```

`vite.config.ts` ships with `logLevel: 'debug'` by default, which is also how the success line's exact wording got confirmed (see the `logLevel` finding in pass 2).

**2. Real plugin/build wiring, mocked network** — done before pass 1's scaffold test existed, using a minimal hand-built fixture project instead of a real scaffold, with the network mocked (`nock`) instead of a live test drive, specifically to isolate the missing-URL warning path in one run. Exact commands:

```bash
# Fixture: index.js/index.html/greet.backend.js copied from
# packages/tests/src/e2e/appsPlugin/project (the existing e2e test's own fixture), into
# ~/dd/build-plugins/.scratch-real-cli-test/. A single script,
# .scratch-real-cli-test/run.mjs, takes a scenario arg, sets up nock against
# https://api.datadoghq.com's upload/release routes, then runs a real `vite build` using
# the built @datadog/vite-plugin (auth: dummy apiKey/appKey — nock never checks them).
cd ~/dd/build-plugins

node .scratch-real-cli-test/run.mjs resolved
# → nothing printed at all (see the logLevel finding below)

node .scratch-real-cli-test/run.mjs omitted
# [warn|vite|apps] Could not resolve the App Builder URL for this upload — find
#   "e2e-real-cli-test-app" (app ID: builder-real-cli-test) in your App Builder apps list
#   to view it.                                                                            ✅ VERIFIED
# [warn|vite|apps] Could not resolve the App Builder URL for this release — find
#   "e2e-real-cli-test-app" (app ID: builder-real-cli-test) in your App Builder apps list
#   to view it.                                                                            ✅ VERIFIED
# [warn|vite|apps] Warnings while uploading assets:
#     - Could not resolve the App Builder URL for this upload — ...
#     - Could not resolve the App Builder URL for this release — ...                      ✅ VERIFIED
```

**Finding, not a regression**: the success line (`Your application is available at: ...`) uses `log.info`, and the plugin's own internal default `logLevel` is `'warn'` (`packages/factory/src/validate.ts`) — with that bare default it never prints. In practice this rarely bites anyone: `npm init @datadog/apps`'s generated `vite.config.ts` already sets `logLevel: 'debug'` explicitly (confirmed in pass 1), so every newly-scaffolded app shows this line unless someone removes that option. This predates APPS-2777 (confirmed via `git log -p` on that line); it isn't something this PR introduced. See Out of Scope.

**3. Real backend integration via curl** — the first verification done, before either build-driven pass above; full commands are in [ddoghq/dd-source#12477](https://github.com/ddoghq/dd-source/pull/12477)'s QA section. Kept here as the original data point:

```
Upload  → https://dd.datad0g.com/app-builder/apps/edit/{id}?viewMode=preview        ✅ VERIFIED
Release → https://dd.datad0g.com/app-builder/apps/{id} (no /edit/, no query string)  ✅ VERIFIED
```

Mutation-tested the fix by locally reintroducing the old bug (query-string leak, hardcoded domain) and confirming the relevant tests fail, then reverting and confirming they pass — see commit history for detail.

## Blast Radius

- Affects only the `@dd/apps-plugin` package's post-upload/post-release console log message — no change to what gets uploaded, no change to request payloads, no change to error/warning handling.
- No feature flag — this is a log-message fix in an npm package; it takes effect for all users on their next upgrade.
- Depends on [ddoghq/dd-source#12477](https://github.com/ddoghq/dd-source/pull/12477) being deployed for the printed URL to be correct for custom-subdomain orgs when called via a direct API host (this plugin's traffic pattern). Until then, `app_builder_url` reflects `api.{site}` rather than the org's real web domain — a regression from this plugin's pre-fix behavior for standard (non-custom-domain) orgs specifically. **Should not merge/release ahead of #12477.**
- Risk: low — purely a display change, covered by 24 unit tests; full E2E suite (326 tests across all plugins) passed unaffected on this PR's CI run.

## Out of Scope / Follow-ups

| Item | Status | Next step |
|---|---|---|
| The E2E test's mocked upload/release responses (`packages/tests/src/e2e/appsPlugin/appsPlugin.spec.ts`) don't include `app_builder_url`, so the E2E suite doesn't exercise the new log content — only unit tests do | independent | Low priority. Could update the nock mocks for closer parity with production, but the E2E suite has no mechanism to capture CLI log output today, so there's nothing for it to assert against without further investment |
| The success message (`Your application is available at: ...`) is `log.info`, silent under the plugin's own internal default `logLevel: 'warn'` — pre-existing since APPS-2777, not introduced here, but discovered while QA'ing this PR | independent (pre-existing), working as intended | Two independent confirmations this is intentional, not a gap: the [High Code Apps "Getting started" guide](https://datadoghq.atlassian.net/wiki/x/Mgi9gQE)'s CI/CD section recommends `logLevel: 'info'` for deployed apps, and `npm init @datadog/apps`'s generated `vite.config.ts` already ships with `logLevel: 'debug'` by default (verified in Manual QA pass 1). The plugin's bare internal default only matters for hand-written configs that opt out of both. No code change proposed |

## Documentation

- Backend PR (original, superseded approach): [ddoghq/dd-source#1038](https://github.com/ddoghq/dd-source/pull/1038)
- Backend PR (corrected — resolves org config, not request host): [ddoghq/dd-source#12477](https://github.com/ddoghq/dd-source/pull/12477)
- Jira (this PR): [APPS-2777](https://datadoghq.atlassian.net/browse/APPS-2777)
- Jira (backend correction): [APPS-2787](https://datadoghq.atlassian.net/browse/APPS-2787)
- [High Code Apps "Getting started" guide](https://datadoghq.atlassian.net/wiki/x/Mgi9gQE) — documents the `dd-auth --domain <site> -- npm run upload` flow this PR's console output feeds into, and the `logLevel: 'info'` recommendation referenced above

[APPS-2777]: https://datadoghq.atlassian.net/browse/APPS-2777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ










