### PR TITLE
fix(apps): surface full API error details, not just title/detail

### DIFF
--- a/packages/core/src/helpers/request.test.ts
+++ b/packages/core/src/helpers/request.test.ts
@@ -126,7 +126,7 @@ describe('Request Helpers', () => {
             await expect(async () => {
                 await doRequest({ ...requestOpts, retries: 0 });
             }).rejects.toThrow(
-                'HTTP 404 Not Found\napp not found: app with id dd3cc768-529c-48bc-9ffb-f42775a5348a not found',
+                'HTTP 404 Not Found\nstatus: 404, id: 96c4b47f-d967-41d5-8d66-a1d6782118ae, title: app not found, detail: app with id dd3cc768-529c-48bc-9ffb-f42775a5348a not found',
             );
             expect(scope.isDone()).toBe(true);
         });
@@ -139,7 +139,7 @@ describe('Request Helpers', () => {
 
             await expect(async () => {
                 await doRequest({ ...requestOpts, retries: 0 });
-            }).rejects.toThrow('HTTP 404 Not Found\napp not found');
+            }).rejects.toThrow('HTTP 404 Not Found\ntitle: app not found');
             expect(scope.isDone()).toBe(true);
         });
 
@@ -157,7 +157,7 @@ describe('Request Helpers', () => {
             await expect(async () => {
                 await doRequest({ ...requestOpts, retries: 0 });
             }).rejects.toThrow(
-                'HTTP 404 Not Found\napp not found: app with id abc not found\npermission denied: user lacks required scope',
+                'HTTP 404 Not Found\ntitle: app not found, detail: app with id abc not found\ntitle: permission denied, detail: user lacks required scope',
             );
             expect(scope.isDone()).toBe(true);
         });
@@ -171,6 +171,30 @@ describe('Request Helpers', () => {
             await expect(async () => {
                 await doRequest({ ...requestOpts, retries: 0 });
             }).rejects.toThrow('HTTP 404 Not Found\ndetail: something went wrong');
+            expect(scope.isDone()).toBe(true);
+        });
+
+        test('Should include JSON API error fields beyond title and detail', async () => {
+            const { doRequest } = await import('@dd/core/helpers/request');
+            const scope = nock(API_URL)
+                .post(API_PATH)
+                .reply(403, {
+                    errors: [
+                        {
+                            status: '403',
+                            code: 'forbidden',
+                            title: 'access denied',
+                            detail: 'user lacks required scope',
+                            meta: { requiredScope: 'apps_write' },
+                        },
+                    ],
+                });
+
+            await expect(async () => {
+                await doRequest({ ...requestOpts, retries: 0 });
+            }).rejects.toThrow(
+                'HTTP 403 Forbidden\nstatus: 403, code: forbidden, title: access denied, detail: user lacks required scope, meta: {"requiredScope":"apps_write"}',
+            );
             expect(scope.isDone()).toBe(true);
         });
 

--- a/packages/core/src/helpers/request.ts
+++ b/packages/core/src/helpers/request.ts
@@ -11,18 +11,12 @@ const formatErrorEntry = (e: unknown): string => {
     if (e === null || typeof e !== 'object') {
         return '';
     }
-    const title = 'title' in e && typeof e.title === 'string' ? e.title : undefined;
-    const detail = 'detail' in e && typeof e.detail === 'string' ? e.detail : undefined;
-    if (title && detail) {
-        return `${title}: ${detail}`;
-    }
-    if (title) {
-        return title;
-    }
-    if (detail) {
-        return `detail: ${detail}`;
-    }
-    return '';
+    return Object.entries(e)
+        .map(
+            ([key, value]) =>
+                `${key}: ${typeof value === 'string' ? value : JSON.stringify(value)}`,
+        )
+        .join(', ');
 };
 
 const parseErrorDetails = (bodyText: string): string => {

--- a/packages/plugins/apps/src/vite/handle-upload.ts
+++ b/packages/plugins/apps/src/vite/handle-upload.ts
@@ -198,7 +198,13 @@ Either:
 
         if (uploadErrors.length > 0) {
             const listOfErrors = uploadErrors
-                .map((error) => error.cause || error.stack || error.message || error)
+                .map((error) => {
+                    // error.cause carries the actionable detail (e.g. ENOTFOUND, ECONNREFUSED)
+                    // for network-level failures, where fetch's own message is just "fetch failed".
+                    const cause = error.cause instanceof Error ? error.cause.message : error.cause;
+                    const message = error.message || error.stack || String(error);
+                    return cause ? `${cause}\n${message}` : message;
+                })
                 .join('\n    - ');
             throw new Error(`    - ${listOfErrors}`);
         }


### PR DESCRIPTION
## Summary
- `formatErrorEntry` in the shared request helper only surfaced an API error's `title`/`detail` fields, dropping others (`status`, `code`, `meta`, etc). It now serializes every field of the error object, so a 403 (or other) error from the apps upload/release endpoints prints its full payload.
- `handle-upload.ts` prioritized `error.stack` over `error.message` when listing upload errors, burying the clean parsed message under stack-trace noise. It now prefers `message`, printing `error.cause` on its own line first when present — network-level failures (DNS/TLS/connection errors) throw with `message` set to the generic `"fetch failed"` and the actionable detail (e.g. `ENOTFOUND`) in `cause` — falling back to `stack`/the error itself otherwise.

## Test plan
- [x] `yarn test:unit packages/core/src/helpers/request.test.ts` — updated assertions for the new full-field format, added a case covering extra fields beyond title/detail
- [x] `yarn test:unit packages/plugins/apps` — 271 passed
- [x] `yarn typecheck:all`
- [x] `yarn cli integrity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)