### PR TITLE
feat(vite): support Vite 8 (bump peerDependency range)

### DIFF
--- a/packages/published/vite-plugin/package.json
+++ b/packages/published/vite-plugin/package.json
@@ -90,7 +90,7 @@
         "@babel/parser": "^7.24.5",
         "@babel/traverse": "^7.24.5",
         "@babel/types": "^7.24.5",
-        "vite": ">= 5.x <= 7.x"
+        "vite": ">= 5.x <= 8.x"
     },
     "peerDependenciesMeta": {
         "@babel/parser": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1898,7 +1898,7 @@ __metadata:
     "@babel/parser": ^7.24.5
     "@babel/traverse": ^7.24.5
     "@babel/types": ^7.24.5
-    vite: ">= 5.x <= 7.x"
+    vite: ">= 5.x <= 8.x"
   dependenciesMeta:
     "@napi-rs/keyring":
       optional: true


### PR DESCRIPTION
### What and why?

Officially support **Vite 8** in `@datadog/vite-plugin` with a minimal diff.

- Bumps the `vite` peerDependency range from `">= 5.x <= 7.x"` to `">= 5.x <= 8.x"`.
- Supersedes #425 (51 files / ~+1967 lines, mostly a Vite 8 fixture project + lockfile churn) with a tiny, fast-to-ship change.
- Closes #423.

Rather than committing a heavy fixture + integration test to prove compatibility, Vite 8 was validated **locally** (see below). Validation showed the peer bump alone is sufficient — no source, rollup, or JSON-import changes were required.

### How?

- Changed `peerDependencies.vite` in `packages/published/vite-plugin/package.json`.
- Ran `yarn install`; the resulting `yarn.lock` diff is limited to the same single workspace peer line.

**Local Vite 8 validation (not committed):**
- Built the plugin (`yarn workspace @datadog/vite-plugin build`), then `npm pack`ed it (so the tarball honors `publishConfig` exports) and installed it into a throwaway `/tmp` Vite **8.1.4** (rolldown) smoke project running a real `vite build`.
- Result: the plugin loads, the unplugin factory initializes, all custom hooks execute (bundler report, build report, true-end), and the build completes and emits reports. The only surfaced error was `fetch failed` when submitting analytics with a fake API key — expected and harmless.

**Explicitly out of scope** (kept out to preserve a minimal diff): the `vite_react_router_project` fixture, the `vite8.test.ts` integration test, the repo-wide `rollup` 4.62.0 bump / `@types/estree` resolution, and any dev/test Vite version changes.

**Verification:** `typecheck` clean, `build` clean, `yarn cli integrity` regenerated nothing, working tree clean (diff is 2 files, +2/−2).
