### PR TITLE
ci: enforce yarn cache immutability to catch stale/missing cache entries

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -37,7 +37,7 @@ jobs:
           node-version-file: "package.json"
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable --immutable-cache
       - name: Bump version
         run: yarn version:all ${{ inputs.version }}
       - name: Add files

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
           api_key: ${{secrets.DATADOG_API_KEY}}
           site: datadoghq.com
 
-      - run: yarn install
+      - run: yarn install --immutable --immutable-cache
 
       - name: Build all plugins
         if: steps.cache-build.outputs.cache-hit != 'true'
@@ -96,7 +96,7 @@ jobs:
           api_key: ${{secrets.DATADOG_API_KEY}}
           site: datadoghq.com
 
-      - run: yarn install
+      - run: yarn install --immutable --immutable-cache
 
       - name: Install playwright
         run: yarn workspace @dd/tests playwright install --with-deps
@@ -165,7 +165,7 @@ jobs:
             'packages/plugins/**', 'packages/published/**',
             'packages/tools/src/**', 'yarn.lock') }}
 
-      - run: yarn install
+      - run: yarn install --immutable --immutable-cache
 
       # Pre build the rollup plugin so it can be used in the following step.
       - name: Build rollup's plugin


### PR DESCRIPTION
### What and why?

CI's `yarn install` steps ran without `--immutable`/`--immutable-cache`, so Yarn would silently fetch any package missing from the committed `.yarn/cache` (falling back to the network) instead of failing. Combined with the "no diff" check in the `lint` job only covering `git diff --exit-code` (tracked-file drift, not new untracked files), a `.yarn/cache` entry could go missing from a commit entirely without any CI job ever noticing.

This is exactly what happened in #454's underlying commit ([238cf08a](https://github.com/DataDog/build-plugins/commit/238cf08a3b8c4b7deeb035d5d0d1cd2d0898f445)): a patched dependency was added to `yarn.lock`, but its `.yarn/cache` zip was never committed, and CI stayed green because installs just quietly re-fetched it from the registry. The same gap also let the `bump.yaml` workflow's own `yarn install` step succeed while silently regenerating a cache zip, which then broke the "Push commit" step with a confusing `UnicodeDecodeError` deep inside `Asana/push-signed-commits` instead of failing clearly, early, and by itself.

Verified locally: removing the missing cache zip and running `yarn install --immutable --immutable-cache` fails with `Cache entry required but missing for @jridgewell/remapping@patch:...`, reproducing the exact gap. With the entry present, the flags have no effect on a normal install.

### How?

Add `--immutable --immutable-cache` to every `yarn install` call in `ci.yaml` and `bump.yaml`:
- `--immutable`: fail if `yarn.lock` would need to change.
- `--immutable-cache`: fail if the `.yarn/cache` folder would need to be created/modified, i.e. if it's missing an entry `yarn.lock` requires.