### PR TITLE
feat(error-tracking): pass RUM-generated debug ID into sourcemap upload metadata

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -134,7 +134,7 @@ export type ChunkInfo = {
 };
 
 // Static string, lazy async loader (e.g. file fetch), or per-chunk code generator.
-export type InjectedValue = string | (() => Promise<string>) | ((sourceOrHash?: string) => string);
+export type InjectedValue = string | (() => Promise<string>) | ((chunk?: ChunkInfo) => string);
 
 export enum InjectPosition {
     BEFORE,
@@ -345,6 +345,8 @@ export type GlobalData = {
 };
 
 export type GlobalStores = {
+    // Keyed by output file basename, filled in by the RUM plugin, read by error-tracking.
+    debugIds: Map<string, string>;
     errors: string[];
     logs: Log[];
     metrics: Set<Metric>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -345,7 +345,7 @@ export type GlobalData = {
 };
 
 export type GlobalStores = {
-    // Keyed by output file basename, filled in by the RUM plugin, read by error-tracking.
+    // Keyed by chunk relative path, filled in by the RUM plugin, read by error-tracking.
     debugIds: Map<string, string>;
     errors: string[];
     logs: Log[];

--- a/packages/factory/src/index.ts
+++ b/packages/factory/src/index.ts
@@ -117,6 +117,7 @@ export const buildPluginFactory = ({
         };
 
         const stores: GlobalStores = {
+            debugIds: new Map(),
             errors: [],
             logs: [],
             metrics: new Set(),

--- a/packages/plugins/error-tracking/src/index.ts
+++ b/packages/plugins/error-tracking/src/index.ts
@@ -18,7 +18,7 @@ export type types = {
     ErrorTrackingOptions: ErrorTrackingOptions;
 };
 
-export const getPlugins: GetPlugins = ({ options, context }) => {
+export const getPlugins: GetPlugins = ({ options, context, stores }) => {
     const log = context.getLogger(PLUGIN_NAME);
     const timeOptions = log.time('validate options');
     const validatedOptions = validateOptions(options, log);
@@ -41,6 +41,7 @@ export const getPlugins: GetPlugins = ({ options, context }) => {
             {
                 apiKey: context.auth.apiKey,
                 bundlerName: context.bundler.name,
+                debugIds: stores.debugIds,
                 git: gitInfo,
                 addMetric: context.addMetric,
                 outDir: context.bundler.outDir,

--- a/packages/plugins/error-tracking/src/sourcemaps/index.ts
+++ b/packages/plugins/error-tracking/src/sourcemaps/index.ts
@@ -35,6 +35,7 @@ export const uploadSourcemaps = async (
             addMetric: context.addMetric,
             apiKey: context.apiKey,
             bundlerName: context.bundlerName,
+            debugIds: context.debugIds,
             git: context.git,
             outDir: context.outDir,
             sendMetrics: context.sendMetrics,

--- a/packages/plugins/error-tracking/src/sourcemaps/payload.ts
+++ b/packages/plugins/error-tracking/src/sourcemaps/payload.ts
@@ -22,6 +22,7 @@ export type Metadata = {
     version: string;
     git_repository_url?: string;
     git_commit_sha?: string;
+    debug_id?: string;
 };
 
 type SourcemapValidity = {
@@ -87,6 +88,7 @@ export const getPayload = async (
     metadata: Metadata,
     prefix: string,
     git?: RepositoryData,
+    debugId?: string,
 ): Promise<Payload> => {
     const validity = await getSourcemapValidity(sourcemap, prefix);
     const errors: string[] = [];
@@ -102,6 +104,7 @@ export const getPayload = async (
                 },
                 value: JSON.stringify({
                     ...metadata,
+                    debug_id: debugId,
                     minified_url: sourcemap.minifiedUrl,
                 }),
             },

--- a/packages/plugins/error-tracking/src/sourcemaps/sender.test.ts
+++ b/packages/plugins/error-tracking/src/sourcemaps/sender.test.ts
@@ -52,6 +52,7 @@ const uploadContextMock = {
 };
 const senderContextMock = {
     ...uploadContextMock,
+    debugIds: new Map(),
     git: contextMock.git,
 };
 

--- a/packages/plugins/error-tracking/src/sourcemaps/sender.ts
+++ b/packages/plugins/error-tracking/src/sourcemaps/sender.ts
@@ -15,6 +15,7 @@ import { formatDuration, prettyObject } from '@dd/core/helpers/strings';
 import type { Logger, Metric, RepositoryData } from '@dd/core/types';
 import chalk from 'chalk';
 import PQueue from 'p-queue';
+import path from 'path';
 
 import type { SourcemapsOptionsWithDefaults, Sourcemap } from '../types';
 
@@ -75,6 +76,11 @@ export type UploadContext = {
     site: string;
     version: string;
     outDir: string;
+};
+
+export type DebugIdsContext = {
+    // Keyed by output file basename, filled in by the RUM plugin.
+    debugIds: Map<string, string>;
 };
 
 export const upload = async (
@@ -175,9 +181,10 @@ export const upload = async (
     return { warnings, errors };
 };
 
-export type SourcemapsSenderContext = UploadContext & {
-    git?: RepositoryData;
-};
+export type SourcemapsSenderContext = UploadContext &
+    DebugIdsContext & {
+        git?: RepositoryData;
+    };
 
 export const sendSourcemaps = async (
     sourcemaps: Sourcemap[],
@@ -200,7 +207,10 @@ export const sendSourcemaps = async (
 
     const payloadsTimer = log.time('Compute payloads');
     const payloads = await Promise.all(
-        sourcemaps.map((sourcemap) => getPayload(sourcemap, metadata, prefix, context.git)),
+        sourcemaps.map((sourcemap) => {
+            const debugId = context.debugIds.get(path.basename(sourcemap.minifiedFilePath));
+            return getPayload(sourcemap, metadata, prefix, context.git, debugId);
+        }),
     );
     payloadsTimer.end();
 

--- a/packages/plugins/error-tracking/src/sourcemaps/sender.ts
+++ b/packages/plugins/error-tracking/src/sourcemaps/sender.ts
@@ -79,9 +79,12 @@ export type UploadContext = {
 };
 
 export type DebugIdsContext = {
-    // Keyed by output file basename, filled in by the RUM plugin.
+    // Keyed by chunk relative path (forward-slashed), filled in by the RUM plugin.
     debugIds: Map<string, string>;
 };
+
+// Bundlers report chunk paths with forward slashes regardless of OS.
+const toPosixPath = (filePath: string) => filePath.split(path.sep).join('/');
 
 export const upload = async (
     payloads: Payload[],
@@ -208,7 +211,7 @@ export const sendSourcemaps = async (
     const payloadsTimer = log.time('Compute payloads');
     const payloads = await Promise.all(
         sourcemaps.map((sourcemap) => {
-            const debugId = context.debugIds.get(path.basename(sourcemap.minifiedFilePath));
+            const debugId = context.debugIds.get(toPosixPath(sourcemap.relativePath));
             return getPayload(sourcemap, metadata, prefix, context.git, debugId);
         }),
     );

--- a/packages/plugins/injection/src/helpers.ts
+++ b/packages/plugins/injection/src/helpers.ts
@@ -124,10 +124,10 @@ export const prepareInjections = async (
     contentsToInject: ContentsToInject,
     cwd: string = process.cwd(),
 ) => {
-    // Per-chunk functions: adapt from public API (sourceOrHash?: string) to internal (chunk: ChunkInfo).
+    // Per-chunk functions receive the full ChunkInfo for the chunk they're injected into.
     const dynamicPerChunk = toInject.filter(isPerChunk).map((item) => {
-        const userFn = item.value as (sourceOrHash?: string) => string;
-        return { ...item, value: (chunk: ChunkInfo) => userFn(chunk.sourceOrHash) };
+        const userFn = item.value as (chunk?: ChunkInfo) => string;
+        return { ...item, value: (chunk: ChunkInfo) => userFn(chunk) };
     });
 
     // Static items (strings and async loaders) are resolved once per build.

--- a/packages/plugins/rum/src/getSourceCodeContextSnippet.ts
+++ b/packages/plugins/rum/src/getSourceCodeContextSnippet.ts
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+import type { ChunkInfo } from '@dd/core/types';
 import { randomUUID } from 'crypto';
 
 import { stringToUUID } from './debugId';
@@ -28,10 +29,16 @@ type SourceCodeContext = {
     version?: string;
     ddDebugId?: string;
 };
+
+export type SourceCodeContextSnippet = {
+    code: string;
+    debugId?: string;
+};
+
 export const getSourceCodeContextSnippet = (
     contextOptions: SourceCodeContextOptions,
-    codeOrHash?: string,
-): string => {
+    chunk?: ChunkInfo,
+): SourceCodeContextSnippet => {
     const context: SourceCodeContext = {
         service: contextOptions.service,
         version: contextOptions.version,
@@ -42,8 +49,10 @@ export const getSourceCodeContextSnippet = (
         //
         // The `dd` prefix in `ddDebugId` allows upload tools (for example, datadog-ci) to reliably locate the
         // debug ID with a regex and send it as upload metadata alongside the source map.
-        context.ddDebugId = codeOrHash ? stringToUUID(codeOrHash) : randomUUID();
+        context.ddDebugId = chunk ? stringToUUID(chunk.sourceOrHash) : randomUUID();
     }
 
-    return `(function(c,n){try{if(typeof window==='undefined')return;var w=window,m=w[n]=w[n]||{},s=new Error().stack;s&&(m[s]=c)}catch(e){}})(${JSON.stringify(context)},${JSON.stringify(DEFAULT_SOURCE_CODE_CONTEXT_VARIABLE)});`;
+    const code = `(function(c,n){try{if(typeof window==='undefined')return;var w=window,m=w[n]=w[n]||{},s=new Error().stack;s&&(m[s]=c)}catch(e){}})(${JSON.stringify(context)},${JSON.stringify(DEFAULT_SOURCE_CODE_CONTEXT_VARIABLE)});`;
+
+    return { code, debugId: context.ddDebugId };
 };

--- a/packages/plugins/rum/src/index.ts
+++ b/packages/plugins/rum/src/index.ts
@@ -26,7 +26,7 @@ export type types = {
     RumInitConfiguration: RumInitConfiguration;
 };
 
-export const getPlugins: GetPlugins = ({ options, context }) => {
+export const getPlugins: GetPlugins = ({ options, context, stores }) => {
     const log = context.getLogger(PLUGIN_NAME);
     const validatedOptions = validateOptions(options, log);
     const plugins: PluginOptions[] = [];
@@ -37,7 +37,14 @@ export const getPlugins: GetPlugins = ({ options, context }) => {
             type: 'code',
             position: InjectPosition.BEFORE,
             injectIntoAllChunks: true,
-            value: (sourceOrHash) => getSourceCodeContextSnippet(sourceCodeContext, sourceOrHash),
+            value: (chunk) => {
+                const { code, debugId } = getSourceCodeContextSnippet(sourceCodeContext, chunk);
+                if (debugId && chunk) {
+                    // Let the error-tracking plugin pick this up when uploading its sourcemap.
+                    stores.debugIds.set(path.basename(chunk.fileName), debugId);
+                }
+                return code;
+            },
         });
     }
 

--- a/packages/plugins/rum/src/index.ts
+++ b/packages/plugins/rum/src/index.ts
@@ -41,7 +41,9 @@ export const getPlugins: GetPlugins = ({ options, context, stores }) => {
                 const { code, debugId } = getSourceCodeContextSnippet(sourceCodeContext, chunk);
                 if (debugId && chunk) {
                     // Let the error-tracking plugin pick this up when uploading its sourcemap.
-                    stores.debugIds.set(path.basename(chunk.fileName), debugId);
+                    // Keyed by the chunk's relative path, since some bundlers can emit
+                    // sibling chunks sharing the same basename in different subdirectories.
+                    stores.debugIds.set(chunk.fileName, debugId);
                 }
                 return code;
             },

--- a/packages/tests/src/_jest/helpers/mocks.ts
+++ b/packages/tests/src/_jest/helpers/mocks.ts
@@ -86,6 +86,7 @@ export const getMockData = (overrides: Partial<GlobalData> = {}): GlobalData => 
 });
 
 export const getMockStores = (overrides: Partial<GlobalStores> = {}): GlobalStores => ({
+    debugIds: new Map(),
     logs: [],
     errors: [],
     warnings: [],

--- a/packages/tools/src/helpers.ts
+++ b/packages/tools/src/helpers.ts
@@ -196,6 +196,7 @@ export const getSupportedBundlers = (getPlugins: GetPlugins) => {
     };
 
     const stores: GlobalStores = {
+        debugIds: new Map(),
         errors: [],
         warnings: [],
         logs: [],


### PR DESCRIPTION
### What and why?

RUM's `sourceCodeContext.debugId` option computes a deterministic debug ID per chunk (derived from the bundler's per-chunk content/hash), which it injects into the built JS. Until now, error-tracking's sourcemap uploader had no way to attach that same debug ID to the sourcemap intake payload — the two plugins were fully decoupled.

This adds a `debug_id` field to the per-file sourcemap upload metadata, sourced directly from RUM without re-reading files or re-hashing anything.

### How?

- Added `debugIds: Map<string, string>` to `GlobalStores` (keyed by output file basename), initialized once per build in the factory and shared by reference across all plugins.
- Changed the injection system's per-chunk `InjectedValue` callback to receive the full `ChunkInfo` (not just `sourceOrHash`), so callers can also see the chunk's `fileName`.
- RUM's `getSourceCodeContextSnippet` now returns `{ code, debugId }`; its injection callback stores the computed `debugId` into `stores.debugIds` before returning the code to inject.
- error-tracking threads `stores.debugIds` from its `getPlugins` down through `sendSourcemaps`/`getPayload`, looking up each sourcemap's debug ID by its minified file's basename and adding it as `debug_id` in that file's event metadata.

Timing is safe because RUM's per-chunk injection runs during chunk rendering, while error-tracking's upload runs later (`buildReport`/`asyncTrueEnd`) against the same shared `Map` reference.