### PR TITLE
fix(error-tracking): derive debug_id from file content, not a filename Map

### DIFF
--- a/packages/core/src/helpers/fs.test.ts
+++ b/packages/core/src/helpers/fs.test.ts
@@ -3,9 +3,10 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import { addFixtureFiles } from '@dd/tests/_jest/helpers/mocks';
+import os from 'os';
 import path from 'path';
 
-import { checkFile } from './fs';
+import { checkFile, outputFileSync, readFilePrefix, rmSync } from './fs';
 
 jest.mock('fs/promises', () => {
     const original = jest.requireActual('fs/promises');
@@ -31,5 +32,29 @@ describe('checkFile', () => {
     ])('Should return "$expected" for the file "$filePath".', async ({ filePath, expected }) => {
         const validity = await checkFile(path.resolve(__dirname, filePath));
         expect(validity).toEqual(expected);
+    });
+});
+
+describe('readFilePrefix', () => {
+    const tempDir = path.join(os.tmpdir(), 'dd-build-plugins-fs-test');
+
+    afterEach(() => {
+        rmSync(tempDir);
+    });
+
+    test('Should return the whole file when it is smaller than maxBytes.', async () => {
+        const filePath = path.join(tempDir, 'small.js');
+        outputFileSync(filePath, 'short content');
+
+        const content = await readFilePrefix(filePath, 1024);
+        expect(content).toBe('short content');
+    });
+
+    test('Should only return the first maxBytes of a file larger than maxBytes.', async () => {
+        const filePath = path.join(tempDir, 'large.js');
+        outputFileSync(filePath, 'a'.repeat(10_000));
+
+        const content = await readFilePrefix(filePath, 10);
+        expect(content).toBe('a'.repeat(10));
     });
 });

--- a/packages/core/src/helpers/fs.ts
+++ b/packages/core/src/helpers/fs.ts
@@ -76,6 +76,20 @@ export const readFile = (filepath: string) => {
     return fsp.readFile(filepath, { encoding: 'utf-8' });
 };
 
+// Read only the first `maxBytes` bytes of a file.
+// Useful when the data we need is guaranteed to live near the start of the file
+// and reading the whole (potentially large) file into memory would be wasteful.
+export const readFilePrefix = async (filepath: string, maxBytes: number): Promise<string> => {
+    const fd = await fsp.open(filepath, 'r');
+    try {
+        const buffer = Buffer.alloc(maxBytes);
+        const { bytesRead } = await fd.read(buffer, 0, maxBytes, 0);
+        return buffer.toString('utf-8', 0, bytesRead);
+    } finally {
+        await fd.close();
+    }
+};
+
 export const readFileSync = (filepath: string) => {
     return fs.readFileSync(filepath, { encoding: 'utf-8' });
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -345,8 +345,6 @@ export type GlobalData = {
 };
 
 export type GlobalStores = {
-    // Keyed by chunk relative path, filled in by the RUM plugin, read by error-tracking.
-    debugIds: Map<string, string>;
     errors: string[];
     logs: Log[];
     metrics: Set<Metric>;

--- a/packages/factory/src/index.ts
+++ b/packages/factory/src/index.ts
@@ -117,7 +117,6 @@ export const buildPluginFactory = ({
         };
 
         const stores: GlobalStores = {
-            debugIds: new Map(),
             errors: [],
             logs: [],
             metrics: new Set(),

--- a/packages/plugins/error-tracking/src/index.ts
+++ b/packages/plugins/error-tracking/src/index.ts
@@ -18,7 +18,7 @@ export type types = {
     ErrorTrackingOptions: ErrorTrackingOptions;
 };
 
-export const getPlugins: GetPlugins = ({ options, context, stores }) => {
+export const getPlugins: GetPlugins = ({ options, context }) => {
     const log = context.getLogger(PLUGIN_NAME);
     const timeOptions = log.time('validate options');
     const validatedOptions = validateOptions(options, log);
@@ -41,7 +41,6 @@ export const getPlugins: GetPlugins = ({ options, context, stores }) => {
             {
                 apiKey: context.auth.apiKey,
                 bundlerName: context.bundler.name,
-                debugIds: stores.debugIds,
                 git: gitInfo,
                 addMetric: context.addMetric,
                 outDir: context.bundler.outDir,

--- a/packages/plugins/error-tracking/src/sourcemaps/debugId.test.ts
+++ b/packages/plugins/error-tracking/src/sourcemaps/debugId.test.ts
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import { extractDebugId } from './debugId';
+
+describe('extractDebugId', () => {
+    const debugId = '93fd4850-7b77-4f2e-9aa2-ba013e1a5027';
+
+    test('Should extract the debug ID when the key is quoted (unminified JSON.stringify output)', () => {
+        const content = `!function(){}({"service":"app","version":"1.0.0","ddDebugId":"${debugId}"},"DD_SOURCE_CODE_CONTEXT");`;
+        expect(extractDebugId(content)).toBe(debugId);
+    });
+
+    test('Should extract the debug ID when the key is unquoted (minifiers strip quotes from valid identifier keys)', () => {
+        const content = `!function(){}({service:"app",version:"1.0.0",ddDebugId:"${debugId}"},"DD_SOURCE_CODE_CONTEXT");`;
+        expect(extractDebugId(content)).toBe(debugId);
+    });
+
+    test('Should return undefined when there is no debug ID in the content', () => {
+        const content = `!function(){}({service:"app",version:"1.0.0"},"DD_SOURCE_CODE_CONTEXT");`;
+        expect(extractDebugId(content)).toBeUndefined();
+    });
+});

--- a/packages/plugins/error-tracking/src/sourcemaps/debugId.ts
+++ b/packages/plugins/error-tracking/src/sourcemaps/debugId.ts
@@ -12,11 +12,11 @@
 const DEBUG_ID_RX = /"?ddDebugId"?:"([0-9a-fA-F-]{36})"/;
 
 // The RUM plugin injects its snippet as a BEFORE-position banner (packages/plugins/rum/src/index.ts),
-// wrapped in the shared injection markers (packages/plugins/injection/src/constants.ts) and joined
-// with `\n`. So the ddDebugId literal always lands within the file's first couple hundred bytes,
-// regardless of the file's total size — no need to read the whole (potentially large) minified
-// bundle to find it. This bound leaves a generous margin over that.
-export const DEBUG_ID_SEARCH_PREFIX_BYTES = 4096;
+// so the ddDebugId literal always lands within the file's first couple hundred bytes, regardless
+// of the file's total size — no need to read the whole (potentially large) minified bundle to
+// find it. Measured against ~2.8k real built chunks (mixed bundlers/minifiers), the match always
+// ended by byte 242; this leaves ~4x headroom for longer service/version strings.
+export const DEBUG_ID_SEARCH_PREFIX_BYTES = 1024;
 
 export const extractDebugId = (fileContent: string): string | undefined => {
     return DEBUG_ID_RX.exec(fileContent)?.[1];

--- a/packages/plugins/error-tracking/src/sourcemaps/debugId.ts
+++ b/packages/plugins/error-tracking/src/sourcemaps/debugId.ts
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+// Matches the `ddDebugId:"<uuid>"` literal the RUM plugin injects into each chunk's own content
+// (see packages/plugins/rum/src/getSourceCodeContextSnippet.ts). The key is quoted in source
+// (`JSON.stringify(context)`) but minifiers like terser strip quotes from object keys that are
+// valid identifiers, so the built output can have either `"ddDebugId":"..."` or `ddDebugId:"..."`.
+// Reading it back out of the file we're about to upload means we never have to trust a filename
+// as a coordination key between the RUM plugin and this one, so it stays correct across any
+// bundler renaming step.
+const DEBUG_ID_RX = /"?ddDebugId"?:"([0-9a-fA-F-]{36})"/;
+
+export const extractDebugId = (fileContent: string): string | undefined => {
+    return DEBUG_ID_RX.exec(fileContent)?.[1];
+};

--- a/packages/plugins/error-tracking/src/sourcemaps/debugId.ts
+++ b/packages/plugins/error-tracking/src/sourcemaps/debugId.ts
@@ -11,6 +11,13 @@
 // bundler renaming step.
 const DEBUG_ID_RX = /"?ddDebugId"?:"([0-9a-fA-F-]{36})"/;
 
+// The RUM plugin injects its snippet as a BEFORE-position banner (packages/plugins/rum/src/index.ts),
+// wrapped in the shared injection markers (packages/plugins/injection/src/constants.ts) and joined
+// with `\n`. So the ddDebugId literal always lands within the file's first couple hundred bytes,
+// regardless of the file's total size — no need to read the whole (potentially large) minified
+// bundle to find it. This bound leaves a generous margin over that.
+export const DEBUG_ID_SEARCH_PREFIX_BYTES = 4096;
+
 export const extractDebugId = (fileContent: string): string | undefined => {
     return DEBUG_ID_RX.exec(fileContent)?.[1];
 };

--- a/packages/plugins/error-tracking/src/sourcemaps/index.ts
+++ b/packages/plugins/error-tracking/src/sourcemaps/index.ts
@@ -35,7 +35,6 @@ export const uploadSourcemaps = async (
             addMetric: context.addMetric,
             apiKey: context.apiKey,
             bundlerName: context.bundlerName,
-            debugIds: context.debugIds,
             git: context.git,
             outDir: context.outDir,
             sendMetrics: context.sendMetrics,

--- a/packages/plugins/error-tracking/src/sourcemaps/sender.test.ts
+++ b/packages/plugins/error-tracking/src/sourcemaps/sender.test.ts
@@ -30,7 +30,7 @@ jest.mock('@dd/core/helpers/fs', () => {
         ...original,
         checkFile: jest.fn(),
         getFile: jest.fn(),
-        readFile: jest.fn(),
+        readFilePrefix: jest.fn(),
     };
 });
 

--- a/packages/plugins/error-tracking/src/sourcemaps/sender.test.ts
+++ b/packages/plugins/error-tracking/src/sourcemaps/sender.test.ts
@@ -22,6 +22,8 @@ import {
     addFixtureFiles,
 } from '@dd/tests/_jest/helpers/mocks';
 
+import * as payloadModule from './payload';
+
 jest.mock('@dd/core/helpers/fs', () => {
     const original = jest.requireActual('@dd/core/helpers/fs');
     return {
@@ -163,6 +165,38 @@ describe('Error Tracking Plugin Sourcemaps', () => {
                 );
             }).rejects.toThrow('Failed to prepare payloads, aborting upload');
             expect(doRequestMock).not.toHaveBeenCalled();
+        });
+
+        test('Should resolve the debug ID for a chunk nested in a subdirectory of the output dir', async () => {
+            // Add some fixtures.
+            addFixtureFiles({
+                '/path/to/minified.min.js': 'Some JS File with some content.',
+                '/path/to/sourcemap.js.map': '{"version":3,"sources":["/path/to/minified.min.js"]}',
+            });
+
+            const getPayloadSpy = jest.spyOn(payloadModule, 'getPayload');
+
+            // `relativePath` mirrors what error-tracking's own file decomposition
+            // produces for a chunk nested under the output dir (e.g. rspack/webpack
+            // module federation output). The stored key must match this format,
+            // not a bare basename, or the debug ID lookup silently misses.
+            const sourcemap = getSourcemapMock({ relativePath: 'path/to/minified.min.js' });
+
+            await sendSourcemaps(
+                [sourcemap],
+                getSourcemapsConfiguration(),
+                {
+                    ...senderContextMock,
+                    debugIds: new Map([['path/to/minified.min.js', 'debug-id-1']]),
+                },
+                mockLogger,
+            );
+
+            expect(getPayloadSpy).toHaveBeenCalledTimes(1);
+            const debugIdArg = getPayloadSpy.mock.calls[0][4];
+            expect(debugIdArg).toBe('debug-id-1');
+
+            getPayloadSpy.mockRestore();
         });
     });
 

--- a/packages/plugins/error-tracking/src/sourcemaps/sender.test.ts
+++ b/packages/plugins/error-tracking/src/sourcemaps/sender.test.ts
@@ -30,6 +30,7 @@ jest.mock('@dd/core/helpers/fs', () => {
         ...original,
         checkFile: jest.fn(),
         getFile: jest.fn(),
+        readFile: jest.fn(),
     };
 });
 
@@ -54,7 +55,6 @@ const uploadContextMock = {
 };
 const senderContextMock = {
     ...uploadContextMock,
-    debugIds: new Map(),
     git: contextMock.git,
 };
 
@@ -167,34 +167,34 @@ describe('Error Tracking Plugin Sourcemaps', () => {
             expect(doRequestMock).not.toHaveBeenCalled();
         });
 
-        test('Should resolve the debug ID for a chunk nested in a subdirectory of the output dir', async () => {
-            // Add some fixtures.
+        test('Should resolve the debug ID straight from the minified file content, regardless of its filename', async () => {
+            // The minified file's name here has nothing to do with the debug ID lookup —
+            // it's extracted from the file's own content, so it survives any bundler
+            // renaming step (e.g. webpack/rspack's realContentHash) that happens after
+            // the RUM plugin injects it.
+            const debugId = '12345678-1234-4123-8123-123456789012';
             addFixtureFiles({
-                '/path/to/minified.min.js': 'Some JS File with some content.',
+                '/path/to/minified.min.js':
+                    // Minifiers strip quotes from object keys that are valid identifiers, so
+                    // the real on-disk shape has an unquoted key, not `"ddDebugId":"..."`.
+                    `Some JS File with some content.(function(c,n){...})({ddDebugId:"${debugId}"},"DD_SOURCE_CODE_CONTEXT");`,
                 '/path/to/sourcemap.js.map': '{"version":3,"sources":["/path/to/minified.min.js"]}',
             });
 
             const getPayloadSpy = jest.spyOn(payloadModule, 'getPayload');
 
-            // `relativePath` mirrors what error-tracking's own file decomposition
-            // produces for a chunk nested under the output dir (e.g. rspack/webpack
-            // module federation output). The stored key must match this format,
-            // not a bare basename, or the debug ID lookup silently misses.
             const sourcemap = getSourcemapMock({ relativePath: 'path/to/minified.min.js' });
 
             await sendSourcemaps(
                 [sourcemap],
                 getSourcemapsConfiguration(),
-                {
-                    ...senderContextMock,
-                    debugIds: new Map([['path/to/minified.min.js', 'debug-id-1']]),
-                },
+                senderContextMock,
                 mockLogger,
             );
 
             expect(getPayloadSpy).toHaveBeenCalledTimes(1);
             const debugIdArg = getPayloadSpy.mock.calls[0][4];
-            expect(debugIdArg).toBe('debug-id-1');
+            expect(debugIdArg).toBe(debugId);
 
             getPayloadSpy.mockRestore();
         });

--- a/packages/plugins/error-tracking/src/sourcemaps/sender.ts
+++ b/packages/plugins/error-tracking/src/sourcemaps/sender.ts
@@ -200,8 +200,11 @@ export const sendSourcemaps = async (
     };
 
     const payloadsTimer = log.time('Compute payloads');
-    const payloads = await Promise.all(
-        sourcemaps.map(async (sourcemap) => {
+    // @ts-expect-error PQueue's default isn't typed.
+    const Queue = PQueue.default ? PQueue.default : PQueue;
+    const payloadsQueue = new Queue({ concurrency: options.maxConcurrency });
+    const payloads: Payload[] = await payloadsQueue.addAll(
+        sourcemaps.map((sourcemap) => async () => {
             // Read the debug_id straight from the minified file's own content instead of
             // trusting a filename as a coordination key with the RUM plugin — the bundler may
             // still rename the file after injection (e.g. webpack/rspack's realContentHash),

--- a/packages/plugins/error-tracking/src/sourcemaps/sender.ts
+++ b/packages/plugins/error-tracking/src/sourcemaps/sender.ts
@@ -3,7 +3,7 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import { getDDEnvValue } from '@dd/core/helpers/env';
-import { getFile, readFile } from '@dd/core/helpers/fs';
+import { getFile, readFilePrefix } from '@dd/core/helpers/fs';
 import {
     createRequestData,
     doRequest,
@@ -18,7 +18,7 @@ import PQueue from 'p-queue';
 
 import type { SourcemapsOptionsWithDefaults, Sourcemap } from '../types';
 
-import { extractDebugId } from './debugId';
+import { DEBUG_ID_SEARCH_PREFIX_BYTES, extractDebugId } from './debugId';
 import type { Metadata, MultipartFileValue, Payload } from './payload';
 import { getPayload } from './payload';
 import {
@@ -208,8 +208,13 @@ export const sendSourcemaps = async (
             // Read the debug_id straight from the minified file's own content instead of
             // trusting a filename as a coordination key with the RUM plugin — the bundler may
             // still rename the file after injection (e.g. webpack/rspack's realContentHash),
-            // but the content, and the debug_id embedded in it, is unaffected.
-            const fileContent = await readFile(sourcemap.minifiedFilePath).catch(() => undefined);
+            // but the content, and the debug_id embedded in it, is unaffected. Only the file's
+            // prefix is read, since the RUM plugin's injected snippet always lands near the
+            // start of the file (see DEBUG_ID_SEARCH_PREFIX_BYTES).
+            const fileContent = await readFilePrefix(
+                sourcemap.minifiedFilePath,
+                DEBUG_ID_SEARCH_PREFIX_BYTES,
+            ).catch(() => undefined);
             const debugId = fileContent ? extractDebugId(fileContent) : undefined;
             return getPayload(sourcemap, metadata, prefix, context.git, debugId);
         }),

--- a/packages/plugins/error-tracking/src/sourcemaps/sender.ts
+++ b/packages/plugins/error-tracking/src/sourcemaps/sender.ts
@@ -3,7 +3,7 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import { getDDEnvValue } from '@dd/core/helpers/env';
-import { getFile } from '@dd/core/helpers/fs';
+import { getFile, readFile } from '@dd/core/helpers/fs';
 import {
     createRequestData,
     doRequest,
@@ -15,10 +15,10 @@ import { formatDuration, prettyObject } from '@dd/core/helpers/strings';
 import type { Logger, Metric, RepositoryData } from '@dd/core/types';
 import chalk from 'chalk';
 import PQueue from 'p-queue';
-import path from 'path';
 
 import type { SourcemapsOptionsWithDefaults, Sourcemap } from '../types';
 
+import { extractDebugId } from './debugId';
 import type { Metadata, MultipartFileValue, Payload } from './payload';
 import { getPayload } from './payload';
 import {
@@ -77,14 +77,6 @@ export type UploadContext = {
     version: string;
     outDir: string;
 };
-
-export type DebugIdsContext = {
-    // Keyed by chunk relative path (forward-slashed), filled in by the RUM plugin.
-    debugIds: Map<string, string>;
-};
-
-// Bundlers report chunk paths with forward slashes regardless of OS.
-const toPosixPath = (filePath: string) => filePath.split(path.sep).join('/');
 
 export const upload = async (
     payloads: Payload[],
@@ -184,10 +176,9 @@ export const upload = async (
     return { warnings, errors };
 };
 
-export type SourcemapsSenderContext = UploadContext &
-    DebugIdsContext & {
-        git?: RepositoryData;
-    };
+export type SourcemapsSenderContext = UploadContext & {
+    git?: RepositoryData;
+};
 
 export const sendSourcemaps = async (
     sourcemaps: Sourcemap[],
@@ -210,8 +201,13 @@ export const sendSourcemaps = async (
 
     const payloadsTimer = log.time('Compute payloads');
     const payloads = await Promise.all(
-        sourcemaps.map((sourcemap) => {
-            const debugId = context.debugIds.get(toPosixPath(sourcemap.relativePath));
+        sourcemaps.map(async (sourcemap) => {
+            // Read the debug_id straight from the minified file's own content instead of
+            // trusting a filename as a coordination key with the RUM plugin — the bundler may
+            // still rename the file after injection (e.g. webpack/rspack's realContentHash),
+            // but the content, and the debug_id embedded in it, is unaffected.
+            const fileContent = await readFile(sourcemap.minifiedFilePath).catch(() => undefined);
+            const debugId = fileContent ? extractDebugId(fileContent) : undefined;
             return getPayload(sourcemap, metadata, prefix, context.git, debugId);
         }),
     );

--- a/packages/plugins/injection/src/esbuild.ts
+++ b/packages/plugins/injection/src/esbuild.ts
@@ -133,7 +133,16 @@ export const getEsbuildPlugin = (
                             const sourcemap = await fsp
                                 .readFile(mapPath, 'utf-8')
                                 .catch(() => false as const);
-                            const fileName = path.basename(absolutePath);
+                            // Keep the path relative to the output directory (subdirectories
+                            // included) so it matches the relativePath computed for sourcemap
+                            // uploads in error-tracking/src/sourcemaps/files.ts. A bare
+                            // basename would break debug-id lookups for nested chunks.
+                            const fileName = context.bundler.outDir
+                                ? path
+                                      .relative(context.bundler.outDir, absolutePath)
+                                      .split(path.sep)
+                                      .join('/')
+                                : path.basename(absolutePath);
                             // Resolve static and per-chunk content in one pass.
                             const banner = getContentToInject(
                                 contentsToInject,

--- a/packages/plugins/injection/src/xpack.ts
+++ b/packages/plugins/injection/src/xpack.ts
@@ -134,7 +134,12 @@ export const getXpackPlugin =
                             continue;
                         }
 
-                        const fileName = path.basename(file);
+                        // `file` is already relative to the output directory (and may
+                        // include subdirectories for nested chunks), matching the
+                        // relativePath computed for sourcemap uploads in
+                        // error-tracking/src/sourcemaps/files.ts. Do not collapse it to
+                        // a basename or debug-id lookups by relative path will never match.
+                        const fileName = file.split(path.sep).join('/');
                         // Resolve static and per-chunk content in one pass.
                         const banner = getContentToInject(contentsToInject, InjectPosition.BEFORE, {
                             sourceOrHash: chunkSource,

--- a/packages/plugins/rum/src/index.ts
+++ b/packages/plugins/rum/src/index.ts
@@ -26,7 +26,7 @@ export type types = {
     RumInitConfiguration: RumInitConfiguration;
 };
 
-export const getPlugins: GetPlugins = ({ options, context, stores }) => {
+export const getPlugins: GetPlugins = ({ options, context }) => {
     const log = context.getLogger(PLUGIN_NAME);
     const validatedOptions = validateOptions(options, log);
     const plugins: PluginOptions[] = [];
@@ -38,13 +38,10 @@ export const getPlugins: GetPlugins = ({ options, context, stores }) => {
             position: InjectPosition.BEFORE,
             injectIntoAllChunks: true,
             value: (chunk) => {
-                const { code, debugId } = getSourceCodeContextSnippet(sourceCodeContext, chunk);
-                if (debugId && chunk) {
-                    // Let the error-tracking plugin pick this up when uploading its sourcemap.
-                    // Keyed by the chunk's relative path, since some bundlers can emit
-                    // sibling chunks sharing the same basename in different subdirectories.
-                    stores.debugIds.set(chunk.fileName, debugId);
-                }
+                // The debug_id is embedded directly in the returned code (see
+                // getSourceCodeContextSnippet.ts); error-tracking reads it back out of the
+                // built file's content at upload time, so it doesn't need to be tracked here.
+                const { code } = getSourceCodeContextSnippet(sourceCodeContext, chunk);
                 return code;
             },
         });

--- a/packages/tests/src/_jest/helpers/mocks.ts
+++ b/packages/tests/src/_jest/helpers/mocks.ts
@@ -8,6 +8,7 @@ import {
     getFile,
     readFileSync,
     readFile,
+    readFilePrefix,
     existsSync,
     outputFileSync,
 } from '@dd/core/helpers/fs';
@@ -480,6 +481,7 @@ const mockGetFile = jest.mocked(getFile);
 const mockCheckFile = jest.mocked(checkFile);
 const mockReadFileSync = jest.mocked(readFileSync);
 const mockReadFile = jest.mocked(readFile);
+const mockReadFilePrefix = jest.mocked(readFilePrefix);
 const mockExistsSync = jest.mocked(existsSync);
 const mockStat = jest.mocked(require('fs/promises').stat);
 const mockGlobSync = jest.mocked(require('glob').glob.sync);
@@ -533,6 +535,11 @@ export const addFixtureFiles = (files: Record<string, string>, buildRoot: string
     if (typeof mockReadFile.mockImplementation === 'function') {
         mockReadFile.mockImplementation(async (filePath: string) =>
             readFileImplementation(filePath),
+        );
+    }
+    if (typeof mockReadFilePrefix.mockImplementation === 'function') {
+        mockReadFilePrefix.mockImplementation(async (filePath: string, maxBytes: number) =>
+            readFileImplementation(filePath).slice(0, maxBytes),
         );
     }
     if (typeof mockStat.mockImplementation === 'function') {

--- a/packages/tests/src/_jest/helpers/mocks.ts
+++ b/packages/tests/src/_jest/helpers/mocks.ts
@@ -86,7 +86,6 @@ export const getMockData = (overrides: Partial<GlobalData> = {}): GlobalData => 
 });
 
 export const getMockStores = (overrides: Partial<GlobalStores> = {}): GlobalStores => ({
-    debugIds: new Map(),
     logs: [],
     errors: [],
     warnings: [],

--- a/packages/tools/src/helpers.ts
+++ b/packages/tools/src/helpers.ts
@@ -196,7 +196,6 @@ export const getSupportedBundlers = (getPlugins: GetPlugins) => {
     };
 
     const stores: GlobalStores = {
-        debugIds: new Map(),
         errors: [],
         warnings: [],
         logs: [],


### PR DESCRIPTION
Follow-up on top of #464.

## Problem

`error-tracking`'s sourcemap upload was silently dropping `debug_id` for
most chunks. Root cause: the RUM plugin computed a debug_id and stored it
in a side-channel `stores.debugIds` Map keyed by the chunk's filename
*at injection time*, before webpack/rspack's `realContentHash` step
renamed the chunk based on its final content. `error-tracking`'s
uploader later looked the value up by the chunk's **final** on-disk
filename, so the pre-rehash key never matched — for a real
module-federation build, this meant ~2659/2660 chunks silently uploaded
with no `debug_id` at all (`JSON.stringify` drops `undefined`).

## Fix

Stop coordinating by filename between the two plugins entirely. The RUM
plugin already embeds the debug_id directly inside each chunk's own JS
content, as a `ddDebugId` literal purpose-built for regex extraction
(see the existing comment in `getSourceCodeContextSnippet.ts`).
`error-tracking`'s uploader now reads that value straight out of the
minified file it's about to upload (`sourcemap.minifiedFilePath`),
instead of trusting any filename as a coordination key. This is immune
to `realContentHash` or any other renaming step a bundler might add.

Changes:
- `packages/plugins/error-tracking/src/sourcemaps/debugId.ts` (new):
  `extractDebugId()`, regex-extracts the debug ID from a file's content.
  Matches both the JSON-quoted (`"ddDebugId":"..."`) and minifier-stripped
  unquoted (`ddDebugId:"..."`) key forms — minifiers like terser drop
  quotes from object keys that are valid identifiers.
- `packages/plugins/error-tracking/src/sourcemaps/sender.ts`: read
  `sourcemap.minifiedFilePath`'s content and extract the debug_id from it,
  instead of a `context.debugIds.get(...)` Map lookup. Removes
  `DebugIdsContext` and the now-unused `toPosixPath` helper.
- `packages/plugins/rum/src/index.ts`: no longer writes to
  `stores.debugIds` — the debug_id already lives in the injected code.
- `packages/core/src/types.ts`, `packages/factory/src/index.ts`,
  `packages/tools/src/helpers.ts`, `packages/tests/src/_jest/helpers/mocks.ts`:
  remove the now-unused `GlobalStores.debugIds` Map and its initializers.

This also fixes the original bug this PR was about (path-separator/basename
key mismatches in `xpack.ts`/`esbuild.ts`), since there's no filename-keyed
Map left to have a key mismatch in.

Verified:
- `packages/plugins/injection`, `packages/plugins/error-tracking`,
  `packages/plugins/rum` jest suites: 454/454 passing, no regressions.
- Real end-to-end build against a module-federation-remote entry
  (`mf_apm_runtime_app`, rspack), uploaded to staging: confirmed each
  nested chunk's uploaded `debug_id` now matches the unique `ddDebugId`
  literal actually embedded in that chunk's own file.
