### PR TITLE
fix(apps): pair static module specifiers with resolved IDs by unique source

### DIFF
--- a/packages/plugins/apps/src/backend/ast-parsing/module-graph.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/module-graph.test.ts
@@ -270,4 +270,86 @@ describe('Backend Functions - module graph records', () => {
             FOR_OF_CONNECTIONS: { kind: 'unsupported', reason: 'mutated object binding' },
         });
     });
+
+    describe('static dependency pairing', () => {
+        // The caller supplies resolved IDs from the bundler, which reports one
+        // per *unique* specifier string in first-occurrence order. Pairing them
+        // against every specifier in the AST slips by one as soon as a specifier
+        // repeats, which attributes an import to the wrong dependency.
+        const cases = [
+            {
+                description: 'pair duplicate imports of the same specifier once',
+                code: `
+                    import { a } from './dup.js';
+                    import { b } from './dup.js';
+                    import { c } from './other.js';
+                `,
+                staticDependencies: ['/project/src/dup.js', '/project/src/other.js'],
+                expected: [
+                    { source: './dup.js', resolvedId: '/project/src/dup.js' },
+                    { source: './other.js', resolvedId: '/project/src/other.js' },
+                ],
+            },
+            {
+                description: 'keep distinct specifiers that resolve to the same module apart',
+                code: `
+                    import { a } from './dup';
+                    import { b } from './dup.js';
+                `,
+                staticDependencies: ['/project/src/dup.js', '/project/src/dup.js'],
+                expected: [
+                    { source: './dup', resolvedId: '/project/src/dup.js' },
+                    { source: './dup.js', resolvedId: '/project/src/dup.js' },
+                ],
+            },
+            {
+                description: 'pair side-effect imports, re-exports and star exports in order',
+                code: `
+                    import './side.js';
+                    import { a } from './dup.js';
+                    import { b } from './dup.js';
+                    export { c } from './reexport.js';
+                    export * from './star.js';
+                    import { z } from './zlast.js';
+                `,
+                staticDependencies: [
+                    '/project/src/side.js',
+                    '/project/src/dup.js',
+                    '/project/src/reexport.js',
+                    '/project/src/star.js',
+                    '/project/src/zlast.js',
+                ],
+                expected: [
+                    { source: './side.js', resolvedId: '/project/src/side.js' },
+                    { source: './dup.js', resolvedId: '/project/src/dup.js' },
+                    { source: './reexport.js', resolvedId: '/project/src/reexport.js' },
+                    { source: './star.js', resolvedId: '/project/src/star.js' },
+                    { source: './zlast.js', resolvedId: '/project/src/zlast.js' },
+                ],
+            },
+        ];
+
+        test.each(cases)('Should $description', ({ code, staticDependencies, expected }) => {
+            const record = createRecord(code, staticDependencies);
+
+            expect(record.staticDependencies).toEqual(expected);
+        });
+
+        test('Should resolve import bindings against the corrected pairing', () => {
+            const record = createRecord(
+                `
+                    import { a } from './dup.js';
+                    import { b } from './dup.js';
+                    import { c } from './other.js';
+                `,
+                ['/project/src/dup.js', '/project/src/other.js'],
+            );
+
+            expect(bindingsByVariableName<ImportBinding>(record.importsByVariable)).toEqual({
+                a: { kind: 'named', importedName: 'a', resolvedId: '/project/src/dup.js' },
+                b: { kind: 'named', importedName: 'b', resolvedId: '/project/src/dup.js' },
+                c: { kind: 'named', importedName: 'c', resolvedId: '/project/src/other.js' },
+            });
+        });
+    });
 });

--- a/packages/plugins/apps/src/backend/ast-parsing/module-graph.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/module-graph.ts
@@ -178,6 +178,17 @@ export function createParsedModuleRecord(
     };
 }
 
+/**
+ * Pairs every static module specifier with the ID the bundler resolved it to.
+ *
+ * Bundlers report one resolved ID per *unique* specifier string, in
+ * first-occurrence order: two imports of `'./a'` collapse into a single entry,
+ * while `'./a'` and `'./a.ts'` stay separate even though they resolve to the
+ * same file. Zipping the raw specifier list against the resolved IDs therefore
+ * slips by one as soon as a module imports the same specifier twice, which
+ * silently attributes an import to the wrong dependency and can drop the last
+ * one entirely. Deduplicating the specifiers first keeps both sequences in step.
+ */
 function collectStaticModuleDependencies(
     ast: Program,
     staticDependencyIds: string[],
@@ -191,7 +202,9 @@ function collectStaticModuleDependencies(
 }
 
 function getStaticModuleSources(ast: Program): string[] {
-    return ast.body.flatMap((node) => {
+    const sources = new Set<string>();
+
+    for (const node of ast.body) {
         if (
             (node.type === 'ImportDeclaration' ||
                 node.type === 'ExportNamedDeclaration' ||
@@ -199,11 +212,11 @@ function getStaticModuleSources(ast: Program): string[] {
             node.source &&
             isStringLiteral(node.source)
         ) {
-            return [node.source.value];
+            sources.add(node.source.value);
         }
+    }
 
-        return [];
-    });
+    return [...sources];
 }
 
 function collectImportBindings(

--- a/packages/plugins/apps/src/vite/backend-connection-id-collector.test.ts
+++ b/packages/plugins/apps/src/vite/backend-connection-id-collector.test.ts
@@ -1,0 +1,176 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import { outputFile, rm } from '@dd/core/helpers/fs';
+import { mkdtemp, realpath } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+import type { Plugin } from 'vite';
+import { build } from 'vite';
+
+import { createBackendConnectionIdCollector } from './backend-connection-id-collector';
+import { getBaseBackendBuildConfig } from './build-config';
+
+const ACTION_CATALOG_ID = '\0action-catalog-stub';
+
+/**
+ * Stands in for `@datadog/action-catalog`, which is not installed in this repo.
+ * The collector only reads the import specifier written in app source, so a
+ * virtual stub is indistinguishable from the real package for this purpose —
+ * and its `\0` prefix means the collector skips the stub module itself.
+ */
+const actionCatalogStub = (): Plugin => ({
+    name: 'action-catalog-stub',
+    enforce: 'pre',
+    resolveId(id) {
+        return id.startsWith('@datadog/action-catalog') ? ACTION_CATALOG_ID : null;
+    },
+    load(id) {
+        return id === ACTION_CATALOG_ID ? 'export function request() { return null; }' : null;
+    },
+});
+
+/**
+ * Runs a real `vite.build()` over on-disk sources so the collector sees exactly
+ * what a bundler hands it — post-`transform`, TypeScript already stripped.
+ *
+ * The unit tests feed the collector hand-written source, which cannot show
+ * whether the constructs it statically matches on (the `@datadog/action-catalog`
+ * import, the call site, the `connectionId` literal) actually survive Vite's
+ * transform pipeline. That is the load-bearing assumption behind reading
+ * `moduleInfo.code` instead of the bundler's AST, so it needs a real build.
+ */
+async function collectConnectionIds(files: Record<string, string>): Promise<string[]> {
+    // `realpath` because macOS hands out `/var/...` temp dirs that Vite reports
+    // as `/private/var/...`; the collector compares module IDs against the build
+    // root as plain strings, so both sides have to agree.
+    const createdRoot = await mkdtemp(path.join(tmpdir(), 'dd-apps-conn-ids-'));
+    const root = await realpath(createdRoot);
+
+    try {
+        for (const [relativePath, contents] of Object.entries(files)) {
+            const absolutePath = path.join(root, relativePath);
+            await outputFile(absolutePath, contents);
+        }
+
+        const entryPath = path.join(root, 'entry.backend.ts');
+        const collector = createBackendConnectionIdCollector(entryPath, root);
+        const stub = actionCatalogStub();
+        const baseConfig = getBaseBackendBuildConfig(root, {}, [collector.plugin, stub]);
+
+        await build({
+            ...baseConfig,
+            build: {
+                ...baseConfig.build,
+                write: false,
+                rollupOptions: {
+                    ...baseConfig.build.rollupOptions,
+                    input: { entry: entryPath },
+                },
+            },
+        });
+
+        return collector.getAllowedConnectionIds();
+    } finally {
+        await rm(root);
+    }
+}
+
+describe('Backend Functions - connection ID collection through a real Vite build', () => {
+    test('Should collect a connection ID written inline in the entry', async () => {
+        const connectionIds = await collectConnectionIds({
+            'entry.backend.ts': `
+                import { request } from '@datadog/action-catalog/http/http';
+
+                export async function run(value: string): Promise<unknown> {
+                    return request({ connectionId: 'conn-inline', inputs: { value } });
+                }
+            `,
+        });
+
+        expect(connectionIds).toEqual(['conn-inline']);
+    });
+
+    test('Should collect connection IDs through transitive app-local modules', async () => {
+        const connectionIds = await collectConnectionIds({
+            'entry.backend.ts': `
+                import { callDeep } from './helpers/deep';
+                import { callNear } from './helpers/near';
+
+                export async function run(): Promise<unknown> {
+                    return Promise.all([callNear(), callDeep()]);
+                }
+            `,
+            'helpers/near.ts': `
+                import { request } from '@datadog/action-catalog/http/http';
+
+                export function callNear() {
+                    return request({ connectionId: 'conn-near', inputs: {} });
+                }
+            `,
+            'helpers/deep.ts': `
+                import { request } from '@datadog/action-catalog/http/http';
+
+                import { DEEP_ID } from './ids';
+
+                export function callDeep() {
+                    return request({ connectionId: DEEP_ID, inputs: {} });
+                }
+            `,
+            'helpers/ids.ts': `
+                export const DEEP_ID = 'conn-deep';
+            `,
+        });
+
+        expect(connectionIds).toEqual(['conn-deep', 'conn-near']);
+    });
+
+    test('Should resolve a connection ID that TypeScript syntax wraps and re-exports', async () => {
+        const connectionIds = await collectConnectionIds({
+            'entry.backend.ts': `
+                import { request } from '@datadog/action-catalog/http/http';
+
+                import { WRAPPED_ID } from './ids';
+
+                export async function run(): Promise<unknown> {
+                    return request({ connectionId: WRAPPED_ID, inputs: {} });
+                }
+            `,
+            'ids.ts': `
+                export { WRAPPED_ID } from './ids-source';
+            `,
+            'ids-source.ts': `
+                export const WRAPPED_ID = 'conn-wrapped' as const;
+            `,
+        });
+
+        expect(connectionIds).toEqual(['conn-wrapped']);
+    });
+
+    test('Should not attribute connection IDs to a module that only shares a specifier prefix', async () => {
+        const connectionIds = await collectConnectionIds({
+            'entry.backend.ts': `
+                import { callUsed } from './helpers/used';
+                import { callUsedToo } from './helpers/used.ts';
+
+                export async function run(): Promise<unknown> {
+                    return Promise.all([callUsed(), callUsedToo()]);
+                }
+            `,
+            'helpers/used.ts': `
+                import { request } from '@datadog/action-catalog/http/http';
+
+                export function callUsed() {
+                    return request({ connectionId: 'conn-used', inputs: {} });
+                }
+
+                export function callUsedToo() {
+                    return request({ connectionId: 'conn-used-too', inputs: {} });
+                }
+            `,
+        });
+
+        expect(connectionIds).toEqual(['conn-used', 'conn-used-too']);
+    });
+});


### PR DESCRIPTION
## What

`collectStaticModuleDependencies` pairs the resolved dependency IDs the bundler supplies against the static module specifiers found in the AST. It zipped them positionally against *every* specifier — but bundlers report one resolved ID per **unique** specifier string, in first-occurrence order.

So the moment a module imports the same specifier twice, the pairing slips by one: every later specifier is attributed to the wrong dependency, and the last one is dropped. Reproduced against real Rollup output — 6 specifiers, 5 resolved IDs, 3 mispaired:

| specifier | paired to | should be |
| --- | --- | --- |
| `./side` | `side.js` | ✅ |
| `./dup` | `dup.js` | ✅ |
| `./dup` | `reexport.js` | (collapses into the entry above) |
| `./reexport` | `star.js` | `reexport.js` |
| `./star` | `zlast.js` | `star.js` |
| `./zlast` | *dropped* | `zlast.js` |

## Why it matters

These pairings are what map an action-catalog call back to the module it came from, and they feed `importsByVariable`, `exportsByName` and `starExports`. A wrong pairing can attribute a `connectionId` to the wrong file or miss it entirely — and it does so silently, because the build still succeeds. Since `allowedConnectionIds` is an allowlist, a missed ID is a functional break and a wrong one is worse.

This is present today on Vite 6/7 with plain Rollup. It is not related to any bundler compatibility issue.

## Fix

Deduplicate the specifiers by source string, preserving first-occurrence order, so both sequences stay in step.

The deduplication is deliberately by **specifier**, not by resolved ID: `'./dup'` and `'./dup.js'` resolve to the same file but the bundler still reports two entries, and a test pins that they stay separate.

## Testing

- Three pairing cases in `module-graph.test.ts` (duplicate specifiers, distinct specifiers resolving to the same module, and the full side-effect/re-export/star-export ordering case), following that file's existing `parseAst` idiom.
- One test asserting the downstream consequence: `importsByVariable` resolves each binding to the right module.
- Verified all four fail against the current implementation (3 of them; the same-module case passes both ways by design, as the guard against over-deduplicating).
- **New end-to-end test** (`backend-connection-id-collector.test.ts`) driving connection ID collection through a real `vite.build()` and asserting the exact collected IDs — inline literals, transitive constants across modules, and a value behind an `as const` plus a re-export chain. It passes on `master` unchanged, so it is a characterization test: it pins current correct behaviour before anything moves.

That last test closes a real coverage gap. The existing `ast-parsing/` tests feed ASTs in directly, and the `apps_backend_project` integration fixture contains no action-catalog usage at all, so nothing exercised the collector's actual output end to end.

`yarn test:unit`, `yarn typecheck:all`, `yarn format` and `yarn cli integrity` all clean.

## Follow-up

A second PR stacked on this one fixes the Rolldown/Vite 8 incompatibility in the same collector (it reads `moduleInfo.ast`, which Rolldown stubs to throw). Kept separate because this fix stands on its own, changes behaviour for existing users, and shouldn't be blocked on the dependency discussion in that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
