### PR TITLE
[APPS] fix(apps): build backend functions under Vite 8 / Rolldown

### DIFF
--- a/packages/plugins/apps/src/index.test.ts
+++ b/packages/plugins/apps/src/index.test.ts
@@ -41,17 +41,24 @@ function extractViteTransform(plugins: PluginOptions[]) {
 }
 
 function emitModuleParsed(
-    config: { plugins?: Array<{ moduleParsed?: (moduleInfo: unknown) => void }> },
+    config: {
+        plugins?: Array<{
+            moduleParsed?: (this: { parse: typeof parseAst }, moduleInfo: unknown) => void;
+        }>;
+    },
     id: string,
     code: string,
     importedIds: string[] = [],
 ) {
     for (const plugin of config.plugins ?? []) {
-        plugin.moduleParsed?.({
-            id,
-            ast: parseAst(code),
-            importedIds,
-        });
+        plugin.moduleParsed?.call(
+            { parse: parseAst },
+            {
+                id,
+                code,
+                importedIds,
+            },
+        );
     }
 }
 

--- a/packages/plugins/apps/src/vite/backend-module-graph-collector.test.ts
+++ b/packages/plugins/apps/src/vite/backend-module-graph-collector.test.ts
@@ -6,40 +6,52 @@ import { parseAst } from 'rollup/parseAst';
 
 import { createBackendModuleGraphCollector } from './backend-module-graph-collector';
 
-describe('Backend Functions - backend module graph collector', () => {
-    test('Should collect parsed local module records from Rollup moduleParsed hooks', () => {
-        const collector = createBackendModuleGraphCollector('/project');
-        const moduleParsed = collector.plugin.moduleParsed as (moduleInfo: unknown) => void;
+type FakeModuleInfo = { id: string; code?: string | null };
 
-        moduleParsed({
-            id: '/project/src/backend/actions.backend.js?import',
-            ast: parseAst(`
-                import { getEcho } from './helpers/http.js';
-                export function run() {
-                    return getEcho();
-                }
-            `),
-            importedIds: ['/project/src/backend/helpers/http.js?import'],
-            importedIdResolutions: [{ id: '/project/src/backend/helpers/http.js?import' }],
-        });
-        moduleParsed({
-            id: '/project/node_modules/package/index.js',
-            ast: parseAst('export const value = true;'),
-            importedIds: [],
-            importedIdResolutions: [],
-        });
-        moduleParsed({
-            id: '\0virtual-helper.js',
-            ast: parseAst('export const value = true;'),
-            importedIds: [],
-            importedIdResolutions: [],
-        });
-        moduleParsed({
-            id: 'virtual:dd-backend-dev:example.js',
-            ast: parseAst('export const value = true;'),
-            importedIds: [],
-            importedIdResolutions: [],
-        });
+/**
+ * Invokes the hook with a plugin context exposing `parse`, which is where it gets
+ * its parser. `rollup/parseAst` is what Rollup's real context uses.
+ */
+const getEmit = (collector: ReturnType<typeof createBackendModuleGraphCollector>) => {
+    const moduleParsed = collector.plugin.moduleParsed as (
+        this: { parse: typeof parseAst },
+        moduleInfo: unknown,
+    ) => void;
+
+    // Fills the remaining fields in place rather than spreading into a new
+    // object: a spread would drop (or trigger) an `ast` getter, and one case
+    // below depends on that getter surviving intact.
+    return (moduleInfo: FakeModuleInfo, importedIds: string[] = []) =>
+        moduleParsed.call(
+            { parse: parseAst },
+            Object.assign(moduleInfo, {
+                importedIds,
+                importedIdResolutions: importedIds.map((id) => ({ id })),
+            }),
+        );
+};
+
+describe('Backend Functions - backend module graph collector', () => {
+    test('Should collect parsed local module records from moduleParsed hooks', () => {
+        const collector = createBackendModuleGraphCollector('/project');
+        const emit = getEmit(collector);
+
+        emit(
+            {
+                id: '/project/src/backend/actions.backend.js?import',
+                code: `
+                    import { getEcho } from './helpers/http.js';
+                    export function run() {
+                        return getEcho();
+                    }
+                `,
+            },
+            ['/project/src/backend/helpers/http.js?import'],
+        );
+        emit({ id: '/project/node_modules/package/index.js', code: 'export const value = true;' });
+        emit({ id: '\0virtual-helper.js', code: 'export const value = true;' });
+        emit({ id: 'virtual:dd-backend-dev:example.js', code: 'export const value = true;' });
+        emit({ id: '/project/src/backend/external.js', code: null });
 
         expect([...collector.getModuleRecords().keys()]).toEqual([
             '/project/src/backend/actions.backend.js',
@@ -54,5 +66,29 @@ describe('Backend Functions - backend module graph collector', () => {
                 },
             ],
         });
+    });
+
+    test('Should collect records under a bundler that does not support ModuleInfo#ast', () => {
+        const collector = createBackendModuleGraphCollector('/project');
+        const emit = getEmit(collector);
+
+        // Rolldown, the bundler Vite 8 uses by default, keeps `ast` on its
+        // Rollup-compat object but stubs the getter to throw. Reading the
+        // property at all is the failure, so it must throw rather than be absent.
+        const moduleInfo: FakeModuleInfo = Object.defineProperty(
+            { id: '/project/src/backend/actions.backend.ts', code: 'export const id = "conn-1";' },
+            'ast',
+            {
+                get() {
+                    throw new Error('UNSUPPORTED: ModuleInfo#ast');
+                },
+                enumerable: true,
+            },
+        );
+
+        expect(() => emit(moduleInfo)).not.toThrow();
+        expect([...collector.getModuleRecords().keys()]).toEqual([
+            '/project/src/backend/actions.backend.ts',
+        ]);
     });
 });

--- a/packages/plugins/apps/src/vite/backend-module-graph-collector.test.ts
+++ b/packages/plugins/apps/src/vite/backend-module-graph-collector.test.ts
@@ -6,29 +6,30 @@ import { parseAst } from 'rollup/parseAst';
 
 import { createBackendModuleGraphCollector } from './backend-module-graph-collector';
 
-type FakeModuleInfo = { id: string; code?: string | null };
+type FakeModuleInfo = { id: string; code: string | null };
 
 /**
- * Invokes the hook with a plugin context exposing `parse`, which is where it gets
- * its parser. `rollup/parseAst` is what Rollup's real context uses.
+ * Calls the `moduleParsed` hook with a plugin context exposing `parse`, which is
+ * where it takes its parser from. `rollup/parseAst` is what Rollup's real
+ * context supplies. The hook reads only the few `ModuleInfo` fields these fakes
+ * model, so building a complete one would be noise.
  */
-const getEmit = (collector: ReturnType<typeof createBackendModuleGraphCollector>) => {
-    const moduleParsed = collector.plugin.moduleParsed as (
-        this: { parse: typeof parseAst },
-        moduleInfo: unknown,
-    ) => void;
+const getModuleParsedHook = (collector: ReturnType<typeof createBackendModuleGraphCollector>) => {
+    const hook = collector.plugin.moduleParsed;
+    if (typeof hook !== 'function') {
+        throw new Error('Expected "moduleParsed" to be a function hook.');
+    }
 
-    // Fills the remaining fields in place rather than spreading into a new
-    // object: a spread would drop (or trigger) an `ast` getter, and one case
-    // below depends on that getter surviving intact.
-    return (moduleInfo: FakeModuleInfo, importedIds: string[] = []) =>
-        moduleParsed.call(
-            { parse: parseAst },
-            Object.assign(moduleInfo, {
-                importedIds,
-                importedIdResolutions: importedIds.map((id) => ({ id })),
-            }),
-        );
+    return (moduleInfo: object) => Reflect.apply(hook, { parse: parseAst }, [moduleInfo]);
+};
+
+const getEmit = (collector: ReturnType<typeof createBackendModuleGraphCollector>) => {
+    const callHook = getModuleParsedHook(collector);
+
+    return (moduleInfo: FakeModuleInfo, importedIds: string[] = []) => {
+        const importedIdResolutions = importedIds.map((id) => ({ id }));
+        callHook({ ...moduleInfo, importedIds, importedIdResolutions });
+    };
 };
 
 describe('Backend Functions - backend module graph collector', () => {
@@ -70,23 +71,28 @@ describe('Backend Functions - backend module graph collector', () => {
 
     test('Should collect records under a bundler that does not support ModuleInfo#ast', () => {
         const collector = createBackendModuleGraphCollector('/project');
-        const emit = getEmit(collector);
+        const callHook = getModuleParsedHook(collector);
 
-        // Rolldown, the bundler Vite 8 uses by default, keeps `ast` on its
-        // Rollup-compat object but stubs the getter to throw. Reading the
-        // property at all is the failure, so it must throw rather than be absent.
-        const moduleInfo: FakeModuleInfo = Object.defineProperty(
-            { id: '/project/src/backend/actions.backend.ts', code: 'export const id = "conn-1";' },
-            'ast',
-            {
-                get() {
-                    throw new Error('UNSUPPORTED: ModuleInfo#ast');
-                },
-                enumerable: true,
+        // Rolldown, Vite 8's default bundler, keeps `ast` on its Rollup-compat
+        // object but stubs the getter to throw. Reading the property at all is
+        // the failure, so it has to throw rather than be absent — which is also
+        // why this is assembled in place instead of going through `getEmit`,
+        // whose spread would trigger the getter during setup.
+        const moduleInfo = {
+            id: '/project/src/backend/actions.backend.ts',
+            code: 'export const id = "conn-1";',
+            importedIds: [],
+            importedIdResolutions: [],
+        };
+        Object.defineProperty(moduleInfo, 'ast', {
+            get() {
+                throw new Error('UNSUPPORTED: ModuleInfo#ast');
             },
-        );
+            enumerable: true,
+        });
 
-        expect(() => emit(moduleInfo)).not.toThrow();
+        callHook(moduleInfo);
+
         expect([...collector.getModuleRecords().keys()]).toEqual([
             '/project/src/backend/actions.backend.ts',
         ]);

--- a/packages/plugins/apps/src/vite/backend-module-graph-collector.test.ts
+++ b/packages/plugins/apps/src/vite/backend-module-graph-collector.test.ts
@@ -20,22 +20,27 @@ const getModuleParsedHook = (collector: ReturnType<typeof createBackendModuleGra
         throw new Error('Expected "moduleParsed" to be a function hook.');
     }
 
-    return (moduleInfo: object) => Reflect.apply(hook, { parse: parseAst }, [moduleInfo]);
+    const parse = jest.fn(parseAst);
+    const callHook = (moduleInfo: object) => Reflect.apply(hook, { parse }, [moduleInfo]);
+
+    return { callHook, parse };
 };
 
 const getEmit = (collector: ReturnType<typeof createBackendModuleGraphCollector>) => {
-    const callHook = getModuleParsedHook(collector);
+    const { callHook, parse } = getModuleParsedHook(collector);
 
-    return (moduleInfo: FakeModuleInfo, importedIds: string[] = []) => {
+    const emit = (moduleInfo: FakeModuleInfo, importedIds: string[] = []) => {
         const importedIdResolutions = importedIds.map((id) => ({ id }));
         callHook({ ...moduleInfo, importedIds, importedIdResolutions });
     };
+
+    return { emit, parse };
 };
 
 describe('Backend Functions - backend module graph collector', () => {
     test('Should collect parsed local module records from moduleParsed hooks', () => {
         const collector = createBackendModuleGraphCollector('/project');
-        const emit = getEmit(collector);
+        const { emit, parse } = getEmit(collector);
 
         emit(
             {
@@ -67,11 +72,15 @@ describe('Backend Functions - backend module graph collector', () => {
                 },
             ],
         });
+        // Filtering happens before the parse, so the skipped modules above never
+        // reach the parser. Without that ordering every `node_modules` module in
+        // the backend graph would be parsed just to be discarded.
+        expect(parse).toHaveBeenCalledTimes(1);
     });
 
     test('Should collect records under a bundler that does not support ModuleInfo#ast', () => {
         const collector = createBackendModuleGraphCollector('/project');
-        const callHook = getModuleParsedHook(collector);
+        const { callHook } = getModuleParsedHook(collector);
 
         // Rolldown, Vite 8's default bundler, keeps `ast` on its Rollup-compat
         // object but stubs the getter to throw. Reading the property at all is

--- a/packages/plugins/apps/src/vite/backend-module-graph-collector.ts
+++ b/packages/plugins/apps/src/vite/backend-module-graph-collector.ts
@@ -9,6 +9,7 @@ import {
     createParsedModuleRecord,
     type ParsedModuleRecord,
     shouldTraverseCollectedModule,
+    unsupportedModuleGraphDependency,
 } from '../backend/ast-parsing/module-graph';
 
 const VIRTUAL_MODULE_ID_RE = /^(?:\0|virtual:)/;
@@ -44,12 +45,23 @@ export function createBackendModuleGraphCollector(buildRoot: string): BackendMod
 
                 // Parse the source instead of reading `moduleInfo.ast`: Rolldown,
                 // the bundler Vite 8 uses by default, stubs that getter to throw
-                // `UNSUPPORTED: ModuleInfo#ast`. Using the context's own parser
-                // is also correct by construction — it already accepted this
-                // exact source to compute `importedIds` — and needs no
-                // TypeScript support, since `moduleParsed` runs after
-                // `transform`, so types and JSX are already gone.
-                const parsed = this.parse(moduleInfo.code);
+                // `UNSUPPORTED: ModuleInfo#ast`.
+                //
+                // No TypeScript-capable parser is needed because `moduleParsed`
+                // runs after `transform`, so types and JSX are already compiled
+                // away. Note that `this.parse` is the bundler's parser but not
+                // its parser *configuration* — Rollup binds no options to it,
+                // while its own module parse passes `{ jsx }`. Our nested build
+                // never enables `jsx`, so the two agree today; fail closed rather
+                // than silently if they ever diverge, since a module we cannot
+                // parse may hide a connection ID.
+                let parsed;
+                try {
+                    parsed = this.parse(moduleInfo.code);
+                } catch {
+                    throw unsupportedModuleGraphDependency(moduleId, 'unparseable module source');
+                }
+
                 const record = createParsedModuleRecord(
                     moduleId,
                     buildRoot,

--- a/packages/plugins/apps/src/vite/backend-module-graph-collector.ts
+++ b/packages/plugins/apps/src/vite/backend-module-graph-collector.ts
@@ -37,20 +37,18 @@ export function createBackendModuleGraphCollector(buildRoot: string): BackendMod
                     return;
                 }
 
-                // Parse the source instead of reading `moduleInfo.ast`: Rolldown,
-                // the bundler Vite 8 uses by default, stubs that getter to throw
-                // `UNSUPPORTED: ModuleInfo#ast`. `code` is null for external and
-                // synthetic modules.
-                //
-                // `this.parse` is the bundler's own parser, which already parsed
-                // this exact source to compute `importedIds` — so whatever the
-                // bundler accepted parses here too, and no TypeScript-capable
-                // parser is needed (`moduleParsed` runs after `transform`, so
-                // types and JSX are already gone).
+                // External and synthetic modules have no source to parse.
                 if (typeof moduleInfo.code !== 'string') {
                     return;
                 }
 
+                // Parse the source instead of reading `moduleInfo.ast`: Rolldown,
+                // the bundler Vite 8 uses by default, stubs that getter to throw
+                // `UNSUPPORTED: ModuleInfo#ast`. Using the context's own parser
+                // is also correct by construction — it already accepted this
+                // exact source to compute `importedIds` — and needs no
+                // TypeScript support, since `moduleParsed` runs after
+                // `transform`, so types and JSX are already gone.
                 const parsed = this.parse(moduleInfo.code);
                 const record = createParsedModuleRecord(
                     moduleId,
@@ -58,6 +56,8 @@ export function createBackendModuleGraphCollector(buildRoot: string): BackendMod
                     parsed,
                     getStaticDependencyIds(moduleInfo).map(normalizeViteModuleId),
                 );
+                // Only null when the traversal predicate rejects, which the guard
+                // above already covered; kept to narrow the nullable return type.
                 if (!record) {
                     return;
                 }

--- a/packages/plugins/apps/src/vite/backend-module-graph-collector.ts
+++ b/packages/plugins/apps/src/vite/backend-module-graph-collector.ts
@@ -58,8 +58,12 @@ export function createBackendModuleGraphCollector(buildRoot: string): BackendMod
                 let parsed;
                 try {
                     parsed = this.parse(moduleInfo.code);
-                } catch {
-                    throw unsupportedModuleGraphDependency(moduleId, 'unparseable module source');
+                } catch (error) {
+                    const reason = error instanceof Error ? error.message : String(error);
+                    throw unsupportedModuleGraphDependency(
+                        moduleId,
+                        `unparseable module source (${reason})`,
+                    );
                 }
 
                 const record = createParsedModuleRecord(
@@ -88,7 +92,11 @@ function normalizeViteModuleId(id: string): string {
 }
 
 function getStaticDependencyIds(moduleInfo: ModuleInfo): string[] {
-    return moduleInfo.importedIdResolutions?.map(({ id }) => id) ?? [...moduleInfo.importedIds];
+    const resolutions = moduleInfo.importedIdResolutions;
+    if (resolutions?.length) {
+        return resolutions.map(({ id }) => id);
+    }
+    return [...moduleInfo.importedIds];
 }
 
 function isViteVirtualModuleId(id: string): boolean {

--- a/packages/plugins/apps/src/vite/backend-module-graph-collector.ts
+++ b/packages/plugins/apps/src/vite/backend-module-graph-collector.ts
@@ -92,11 +92,7 @@ function normalizeViteModuleId(id: string): string {
 }
 
 function getStaticDependencyIds(moduleInfo: ModuleInfo): string[] {
-    const resolutions = moduleInfo.importedIdResolutions;
-    if (resolutions?.length) {
-        return resolutions.map(({ id }) => id);
-    }
-    return [...moduleInfo.importedIds];
+    return moduleInfo.importedIdResolutions?.map(({ id }) => id) ?? [...moduleInfo.importedIds];
 }
 
 function isViteVirtualModuleId(id: string): boolean {

--- a/packages/plugins/apps/src/vite/backend-module-graph-collector.ts
+++ b/packages/plugins/apps/src/vite/backend-module-graph-collector.ts
@@ -2,13 +2,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import type { BaseNode } from 'estree';
 import type { ModuleInfo } from 'rollup';
 import type { Plugin } from 'vite';
 
 import {
     createParsedModuleRecord,
     type ParsedModuleRecord,
+    shouldTraverseCollectedModule,
 } from '../backend/ast-parsing/module-graph';
 
 const VIRTUAL_MODULE_ID_RE = /^(?:\0|virtual:)/;
@@ -30,10 +30,32 @@ export function createBackendModuleGraphCollector(buildRoot: string): BackendMod
                     return;
                 }
 
+                // `createParsedModuleRecord` applies this same predicate, but
+                // only after the AST exists. Checking it here keeps us from
+                // parsing every `node_modules` module just to discard it.
+                if (!shouldTraverseCollectedModule(moduleId, buildRoot)) {
+                    return;
+                }
+
+                // Parse the source instead of reading `moduleInfo.ast`: Rolldown,
+                // the bundler Vite 8 uses by default, stubs that getter to throw
+                // `UNSUPPORTED: ModuleInfo#ast`. `code` is null for external and
+                // synthetic modules.
+                //
+                // `this.parse` is the bundler's own parser, which already parsed
+                // this exact source to compute `importedIds` — so whatever the
+                // bundler accepted parses here too, and no TypeScript-capable
+                // parser is needed (`moduleParsed` runs after `transform`, so
+                // types and JSX are already gone).
+                if (typeof moduleInfo.code !== 'string') {
+                    return;
+                }
+
+                const parsed = this.parse(moduleInfo.code);
                 const record = createParsedModuleRecord(
                     moduleId,
                     buildRoot,
-                    moduleInfo.ast as BaseNode,
+                    parsed,
                     getStaticDependencyIds(moduleInfo).map(normalizeViteModuleId),
                 );
                 if (!record) {

--- a/packages/plugins/apps/src/vite/dev-server.test.ts
+++ b/packages/plugins/apps/src/vite/dev-server.test.ts
@@ -113,17 +113,24 @@ function mockBuildResult(code: string) {
 }
 
 function emitModuleParsed(
-    config: { plugins?: Array<{ moduleParsed?: (moduleInfo: unknown) => void }> },
+    config: {
+        plugins?: Array<{
+            moduleParsed?: (this: { parse: typeof parseAst }, moduleInfo: unknown) => void;
+        }>;
+    },
     id: string,
     code: string,
     importedIds: string[] = [],
 ) {
     for (const plugin of config.plugins ?? []) {
-        plugin.moduleParsed?.({
-            id,
-            ast: parseAst(code),
-            importedIds,
-        });
+        plugin.moduleParsed?.call(
+            { parse: parseAst },
+            {
+                id,
+                code,
+                importedIds,
+            },
+        );
     }
 }
 

--- a/packages/plugins/apps/src/vite/index.test.ts
+++ b/packages/plugins/apps/src/vite/index.test.ts
@@ -48,16 +48,23 @@ function mockBuildResult() {
 }
 
 function emitModuleParsed(
-    config: { plugins?: Array<{ moduleParsed?: (moduleInfo: unknown) => void }> },
+    config: {
+        plugins?: Array<{
+            moduleParsed?: (this: { parse: typeof parseAst }, moduleInfo: unknown) => void;
+        }>;
+    },
     id: string,
     code: string,
 ) {
     for (const plugin of config.plugins ?? []) {
-        plugin.moduleParsed?.({
-            id,
-            ast: parseAst(code),
-            importedIds: [],
-        });
+        plugin.moduleParsed?.call(
+            { parse: parseAst },
+            {
+                id,
+                code,
+                importedIds: [],
+            },
+        );
     }
 }
 


### PR DESCRIPTION
## Motivation

Vite 8 switches its bundler to **Rolldown**, which stubs `ModuleInfo#ast` to throw (its AST lives in Rust memory — a deliberate, permanent API boundary):

```
Error: UNSUPPORTED: ModuleInfo#ast     plugin: 'datadog-apps-plugin'  hook: 'closeBundle'
```

The Apps backend collector read that property to derive each backend function's `allowedConnectionIds`. So **any app with a `.backend.ts` fails to build on Vite 8** — and fails confusingly: the client bundle prints `✓ built`, then the plugin's nested backend build dies in `closeBundle` with nothing pointing at Vite, Rolldown, or your file.

`@datadog/vite-plugin@3.2.8` declares `vite: ">= 5.x <= 8.x"`, so npm installs it on Vite 8 while this documented feature is broken. Trigger is Rolldown, not the Vite major — `rolldown-vite` on Vite 7 hits it too.

## Changes

Parse `moduleInfo.code` with the plugin context's own `parse` instead of reading the bundler's pre-built AST. Rolldown withholds only the AST; the source and resolved dependency IDs are still there.

```diff
-                    moduleInfo.ast as BaseNode,
+                    parsed,
```

One file, ~34 changed lines. Three things worth knowing while reading it:

1. **No new dependencies.** `moduleParsed` runs after `transform`, so types and JSX are already compiled away — no TypeScript-capable parser needed. No lockfile or published-package changes.
2. **The parse is wrapped to fail closed.** `this.parse` is the bundler's parser but *not* its parser configuration — Rollup binds `{ jsx }` to its internal parse but not to `PluginContext.parse`, so it can throw on source the bundler accepted. Latent today, but a module we can't parse could hide a connection ID, so it raises the existing `unsupportedModuleGraphDependency` rather than an opaque `Expression expected`.
3. **`shouldTraverseCollectedModule` moved ahead of the parse.** Reading the old AST was free; parsing isn't. Without this we'd parse every `node_modules` module just to discard it.

The `typeof moduleInfo.code !== 'string'` guard is required to compile (`code` is `string | null`), not defensive padding.

<details>
<summary>Two alternatives implemented and rejected</summary>

- **`@typescript-eslint/typescript-estree`** — eagerly requires `typescript` (an *optional* peer), so it needed a deferred `require` to avoid dragging `typescript` into every consumer of every published plugin. ~50 lines of loader machinery plus a dependency on all five published packages, for capability this path never exercises.
- **Vite's `parseAst` export** — Vite maps its `require` condition to a reduced CJS entry that **omits `parseAst`**, which would break consumers of this plugin's CJS build.

</details>

## QA Instructions

Verified with a real scaffolded app whose backend function calls `@datadog/action-catalog`, with the connection ID in a separate module so resolution must walk the module graph. Every cell measured — pre-fix is published `3.2.8`, post-fix is this PR:

| Path | V7 pre | V7 post | V8 pre | V8 post |
|---|---|---|---|---|
| `vite build` + manifest allowlist | ✅ | ✅ | ❌ | ✅ |
| Dev server → function executes | ✅ | ✅ | ❌ | ✅ |
| Upload → published live | ✅ | ✅ | ❌ | ✅ |

Both ❌ paths fail with `UNSUPPORTED: ModuleInfo#ast`; pre-fix on Vite 8 the upload never reaches the network because `closeBundle` throws first. Vite 7 unchanged throughout. Full logs, versions and method in the [verification comment](https://github.com/DataDog/build-plugins/pull/468#issuecomment-5109354290).

## Blast Radius

Only the Apps backend-function build path. The Apps plugin already refuses non-Vite bundlers, and builds without a `.backend.ts` never reach this code. No dependency changes.

Risk is moderate rather than low for one reason: this collector produces a security-relevant **allowlist**, and silently collecting fewer connection IDs would break backend functions at runtime while the build still succeeded. Hence the fail-closed parse, the untouched specifier pairing, and QA that asserts exact collected IDs rather than exit codes.

## Documentation

-   [How to reliably make frontend production changes](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2286781319/Frontend+Production+Changesp)
-   [PR Description Guidelines](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/3120334387/PR+Checklist+and+Guidelines+for+Web+UI)
-   [Deploy steps](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/1457750032/)

---

**Not here, deliberately:** a separate specifier-mispairing bug affecting Vite 6/7 today ([#469](https://github.com/DataDog/build-plugins/pull/469), stacked); narrowing the Vite peer range (unnecessary now that Vite 8 works); adding Rolldown to the automated test matrix (repo pins `vite@6.3.5` — the verification above was manual); the `create-apps` bump (different repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
