### PR TITLE
[APPS] fix(apps): wrong connection IDs from mispaired module specifiers

### DIFF
--- a/packages/plugins/apps/src/backend/ast-parsing/module-graph.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/module-graph.test.ts
@@ -270,4 +270,91 @@ describe('Backend Functions - module graph records', () => {
             FOR_OF_CONNECTIONS: { kind: 'unsupported', reason: 'mutated object binding' },
         });
     });
+
+    describe('static dependency pairing', () => {
+        // The caller supplies resolved IDs from the bundler, which reports one
+        // per *unique* dependency in first-occurrence order. Pairing them against
+        // every specifier in the AST slips by one as soon as a specifier repeats,
+        // which attributes an import to the wrong dependency.
+        const cases = [
+            {
+                description: 'pair duplicate imports of the same specifier once',
+                code: `
+                    import { a } from './dup.js';
+                    import { b } from './dup.js';
+                    import { c } from './other.js';
+                `,
+                staticDependencies: ['/project/src/dup.js', '/project/src/other.js'],
+                expected: [
+                    { source: './dup.js', resolvedId: '/project/src/dup.js' },
+                    { source: './other.js', resolvedId: '/project/src/other.js' },
+                ],
+            },
+            {
+                // Rollup keys its resolved-ID list by specifier string, so it
+                // reports two entries here. Rolldown keys by resolved module ID
+                // and reports one — verified against real builds of both — so
+                // this shape still mispairs under Rolldown. Fixing that needs
+                // pairing by path correspondence instead of position.
+                description: 'keep distinct specifiers that resolve to the same module apart',
+                code: `
+                    import { a } from './dup';
+                    import { b } from './dup.js';
+                `,
+                staticDependencies: ['/project/src/dup.js', '/project/src/dup.js'],
+                expected: [
+                    { source: './dup', resolvedId: '/project/src/dup.js' },
+                    { source: './dup.js', resolvedId: '/project/src/dup.js' },
+                ],
+            },
+            {
+                description: 'pair side-effect imports, re-exports and star exports in order',
+                code: `
+                    import './side.js';
+                    import { a } from './dup.js';
+                    import { b } from './dup.js';
+                    export { c } from './reexport.js';
+                    export * from './star.js';
+                    import { z } from './zlast.js';
+                `,
+                staticDependencies: [
+                    '/project/src/side.js',
+                    '/project/src/dup.js',
+                    '/project/src/reexport.js',
+                    '/project/src/star.js',
+                    '/project/src/zlast.js',
+                ],
+                expected: [
+                    { source: './side.js', resolvedId: '/project/src/side.js' },
+                    { source: './dup.js', resolvedId: '/project/src/dup.js' },
+                    { source: './reexport.js', resolvedId: '/project/src/reexport.js' },
+                    { source: './star.js', resolvedId: '/project/src/star.js' },
+                    { source: './zlast.js', resolvedId: '/project/src/zlast.js' },
+                ],
+            },
+        ];
+
+        test.each(cases)('Should $description', ({ code, staticDependencies, expected }) => {
+            const record = createRecord(code, staticDependencies);
+
+            expect(record.staticDependencies).toEqual(expected);
+        });
+
+        test('Should resolve import bindings against the corrected pairing', () => {
+            const record = createRecord(
+                `
+                    import { a } from './dup.js';
+                    import { b } from './dup.js';
+                    import { c } from './other.js';
+                `,
+                ['/project/src/dup.js', '/project/src/other.js'],
+            );
+
+            expect(bindingsByVariableName<ImportBinding>(record.importsByVariable)).toEqual({
+                a: { kind: 'named', importedName: 'a', resolvedId: '/project/src/dup.js' },
+                b: { kind: 'named', importedName: 'b', resolvedId: '/project/src/dup.js' },
+                c: { kind: 'named', importedName: 'c', resolvedId: '/project/src/other.js' },
+            });
+        });
+    });
 });

--- a/packages/plugins/apps/src/backend/ast-parsing/module-graph.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/module-graph.ts
@@ -178,6 +178,27 @@ export function createParsedModuleRecord(
     };
 }
 
+/**
+ * Pairs each static module specifier with the ID the bundler resolved it to.
+ *
+ * The two sequences are matched by position, which is only sound once the
+ * specifiers are deduplicated: bundlers report one entry per *unique* dependency,
+ * so a module importing `'./a'` twice yields two specifiers but one resolved ID,
+ * and zipping the raw list slips by one from that point on — attributing an
+ * import to the wrong dependency and dropping the last one entirely.
+ *
+ * Bundlers disagree on what "unique" means, and this is verified against real
+ * builds rather than assumed: Rollup 4 keys by specifier string, so `'./a'` and
+ * `'./a.js'` stay separate; Rolldown 1.1.5 keys by resolved module ID, so they
+ * collapse into one entry. The two therefore agree exactly when no two
+ * specifiers in a module resolve to the same file, which is the ordinary case.
+ *
+ * Known gap, deliberately not fixed here: under Rolldown a module that imports
+ * one file through two different specifiers still mispairs, because dedup by
+ * specifier yields more entries than the bundler reports. Pairing by path
+ * correspondence rather than position would remove the dependence on either
+ * bundler's dedup rule; that is a larger change than this fix.
+ */
 function collectStaticModuleDependencies(
     ast: Program,
     staticDependencyIds: string[],
@@ -190,8 +211,14 @@ function collectStaticModuleDependencies(
     }));
 }
 
+/**
+ * Unique static module specifiers, in first-occurrence order, matching how
+ * bundlers order the resolved dependency IDs they report.
+ */
 function getStaticModuleSources(ast: Program): string[] {
-    return ast.body.flatMap((node) => {
+    const sources = new Set<string>();
+
+    for (const node of ast.body) {
         if (
             (node.type === 'ImportDeclaration' ||
                 node.type === 'ExportNamedDeclaration' ||
@@ -199,11 +226,11 @@ function getStaticModuleSources(ast: Program): string[] {
             node.source &&
             isStringLiteral(node.source)
         ) {
-            return [node.source.value];
+            sources.add(node.source.value);
         }
+    }
 
-        return [];
-    });
+    return [...sources];
 }
 
 function collectImportBindings(

--- a/packages/plugins/apps/src/vite/backend-connection-id-collector.test.ts
+++ b/packages/plugins/apps/src/vite/backend-connection-id-collector.test.ts
@@ -1,0 +1,176 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import { outputFile, rm } from '@dd/core/helpers/fs';
+import { mkdtemp, realpath } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+import type { Plugin } from 'vite';
+import { build } from 'vite';
+
+import { createBackendConnectionIdCollector } from './backend-connection-id-collector';
+import { getBaseBackendBuildConfig } from './build-config';
+
+const ACTION_CATALOG_ID = '\0action-catalog-stub';
+
+/**
+ * Stands in for `@datadog/action-catalog`, which is not installed in this repo.
+ * The collector only reads the import specifier written in app source, so a
+ * virtual stub is indistinguishable from the real package for this purpose —
+ * and its `\0` prefix means the collector skips the stub module itself.
+ */
+const actionCatalogStub = (): Plugin => ({
+    name: 'action-catalog-stub',
+    enforce: 'pre',
+    resolveId(id) {
+        return id.startsWith('@datadog/action-catalog') ? ACTION_CATALOG_ID : null;
+    },
+    load(id) {
+        return id === ACTION_CATALOG_ID ? 'export function request() { return null; }' : null;
+    },
+});
+
+/**
+ * Runs a real `vite.build()` over on-disk sources so the collector sees exactly
+ * what a bundler hands it — post-`transform`, TypeScript already stripped.
+ *
+ * The unit tests feed the collector hand-written source, which cannot show
+ * whether the constructs it statically matches on (the `@datadog/action-catalog`
+ * import, the call site, the `connectionId` literal) actually survive Vite's
+ * transform pipeline. That is the load-bearing assumption behind reading
+ * `moduleInfo.code` instead of the bundler's AST, so it needs a real build.
+ */
+async function collectConnectionIds(files: Record<string, string>): Promise<string[]> {
+    // `realpath` because macOS hands out `/var/...` temp dirs that Vite reports
+    // as `/private/var/...`; the collector compares module IDs against the build
+    // root as plain strings, so both sides have to agree.
+    const createdRoot = await mkdtemp(path.join(tmpdir(), 'dd-apps-conn-ids-'));
+    const root = await realpath(createdRoot);
+
+    try {
+        for (const [relativePath, contents] of Object.entries(files)) {
+            const absolutePath = path.join(root, relativePath);
+            await outputFile(absolutePath, contents);
+        }
+
+        const entryPath = path.join(root, 'entry.backend.ts');
+        const collector = createBackendConnectionIdCollector(entryPath, root);
+        const stub = actionCatalogStub();
+        const baseConfig = getBaseBackendBuildConfig(root, {}, [collector.plugin, stub]);
+
+        await build({
+            ...baseConfig,
+            build: {
+                ...baseConfig.build,
+                write: false,
+                rollupOptions: {
+                    ...baseConfig.build.rollupOptions,
+                    input: { entry: entryPath },
+                },
+            },
+        });
+
+        return collector.getAllowedConnectionIds();
+    } finally {
+        await rm(root);
+    }
+}
+
+describe('Backend Functions - connection ID collection through a real Vite build', () => {
+    test('Should collect a connection ID written inline in the entry', async () => {
+        const connectionIds = await collectConnectionIds({
+            'entry.backend.ts': `
+                import { request } from '@datadog/action-catalog/http/http';
+
+                export async function run(value: string): Promise<unknown> {
+                    return request({ connectionId: 'conn-inline', inputs: { value } });
+                }
+            `,
+        });
+
+        expect(connectionIds).toEqual(['conn-inline']);
+    });
+
+    test('Should collect connection IDs through transitive app-local modules', async () => {
+        const connectionIds = await collectConnectionIds({
+            'entry.backend.ts': `
+                import { callDeep } from './helpers/deep';
+                import { callNear } from './helpers/near';
+
+                export async function run(): Promise<unknown> {
+                    return Promise.all([callNear(), callDeep()]);
+                }
+            `,
+            'helpers/near.ts': `
+                import { request } from '@datadog/action-catalog/http/http';
+
+                export function callNear() {
+                    return request({ connectionId: 'conn-near', inputs: {} });
+                }
+            `,
+            'helpers/deep.ts': `
+                import { request } from '@datadog/action-catalog/http/http';
+
+                import { DEEP_ID } from './ids';
+
+                export function callDeep() {
+                    return request({ connectionId: DEEP_ID, inputs: {} });
+                }
+            `,
+            'helpers/ids.ts': `
+                export const DEEP_ID = 'conn-deep';
+            `,
+        });
+
+        expect(connectionIds).toEqual(['conn-deep', 'conn-near']);
+    });
+
+    test('Should resolve a connection ID that TypeScript syntax wraps and re-exports', async () => {
+        const connectionIds = await collectConnectionIds({
+            'entry.backend.ts': `
+                import { request } from '@datadog/action-catalog/http/http';
+
+                import { WRAPPED_ID } from './ids';
+
+                export async function run(): Promise<unknown> {
+                    return request({ connectionId: WRAPPED_ID, inputs: {} });
+                }
+            `,
+            'ids.ts': `
+                export { WRAPPED_ID } from './ids-source';
+            `,
+            'ids-source.ts': `
+                export const WRAPPED_ID = 'conn-wrapped' as const;
+            `,
+        });
+
+        expect(connectionIds).toEqual(['conn-wrapped']);
+    });
+
+    test('Should not attribute connection IDs to a module that only shares a specifier prefix', async () => {
+        const connectionIds = await collectConnectionIds({
+            'entry.backend.ts': `
+                import { callUsed } from './helpers/used';
+                import { callUsedToo } from './helpers/used.ts';
+
+                export async function run(): Promise<unknown> {
+                    return Promise.all([callUsed(), callUsedToo()]);
+                }
+            `,
+            'helpers/used.ts': `
+                import { request } from '@datadog/action-catalog/http/http';
+
+                export function callUsed() {
+                    return request({ connectionId: 'conn-used', inputs: {} });
+                }
+
+                export function callUsedToo() {
+                    return request({ connectionId: 'conn-used-too', inputs: {} });
+                }
+            `,
+        });
+
+        expect(connectionIds).toEqual(['conn-used', 'conn-used-too']);
+    });
+});


### PR DESCRIPTION
> **Stacked on [#468](https://github.com/DataDog/build-plugins/pull/468)** — review that first; this PR targets its branch, so the diff here is only the pairing fix.

## Motivation

`collectStaticModuleDependencies` pairs the bundler's resolved dependency IDs against the AST's static specifiers **by index**. But bundlers report one entry per *unique* dependency, so a module that imports the same specifier twice yields more specifiers than IDs and the pairing slips by one from there on.

Reproduced against a real Rollup build — 6 specifiers, 5 resolved IDs, 3 mispaired and 1 dropped:

| specifier | paired to | should be |
| --- | --- | --- |
| `./dup` (2nd) | `reexport.js` | *(collapses into the entry above)* |
| `./reexport` | `star.js` | `reexport.js` |
| `./star` | `zlast.js` | `star.js` |
| `./zlast` | *dropped* | `zlast.js` |

**Why it matters:** these pairings map an action-catalog call back to its module and feed `importsByVariable` / `exportsByName` / `starExports`. A wrong pairing can attribute a `connectionId` to the wrong file or miss it. Since `allowedConnectionIds` is an allowlist, a miss breaks the function at runtime — and the build still exits 0, so it fails **silently**.

Live today on Vite 6/7 with plain Rollup. Unrelated to any bundler compatibility issue; it only shares a code path with #468.

## Changes

Deduplicate the specifiers by source string, preserving first-occurrence order, so both sequences stay in step.

```ts
function getStaticModuleSources(ast: Program): string[] {
    const sources = new Set<string>();
    for (const node of ast.body) {
        // ...import / export-from declarations
        sources.add(node.source.value);
    }
    return [...sources];
}
```

**Known gap, documented rather than hidden.** The two bundlers disagree on what "unique" means — verified against real builds, not assumed:

| One file imported via `./dup.js` *and* `./dup` | Entries reported |
| --- | --- |
| Rollup 4 (Vite 7) | **2** — dedups by specifier string |
| Rolldown 1.1.5 (Vite 8) | **1** — dedups by resolved module ID |

They agree unless one module imports the same file through two different specifiers. In that case this fix is correct under Rollup and **still mispairs under Rolldown**. Closing that needs pairing by *path correspondence* instead of position — a larger change, so it's called out in the code comment and in the test that encodes the Rollup-specific expectation.

I also tried failing closed on a specifier/ID count mismatch. It broke 18 existing tests, because legitimate callers pass partial dependency lists — a build error there would be worse than the narrow remaining gap.

## QA Instructions

No manual QA needed. Four unit cases cover the pairing (three fail without the fix), one asserts `importsByVariable` resolves each binding to the right module, and a new end-to-end test drives connection-ID collection through a real `vite.build()` asserting the exact collected IDs — it passes on `master` unchanged, so it characterises existing behaviour before the fix moves it.

## Blast Radius

Only the Apps backend-function build path — how collected module records map imports to resolved modules, which feeds `allowedConnectionIds`.

**This changes behaviour for existing Vite 6/7 users**, which is the point: allowlists that were silently wrong become correct. Any app whose backend graph imports one specifier twice could previously have had a missing or misattributed connection ID. No dependency or public API changes.

Risk: moderate — it touches the allowlist path, so a mistake has runtime consequences. Mitigated by the tests above plus the end-to-end assertion of exact IDs.

## Documentation

-   [How to reliably make frontend production changes](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2286781319/Frontend+Production+Changesp)
-   [PR Description Guidelines](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/3120334387/PR+Checklist+and+Guidelines+for+Web+UI)
-   [Deploy steps](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/1457750032/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
