### PR TITLE
[APPS-2792] Harden local Node execution: signal reporting, shutdown cleanup, edge-case coverage

### DIFF
--- a/packages/plugins/apps/src/vite/local-execution.integration.test.ts
+++ b/packages/plugins/apps/src/vite/local-execution.integration.test.ts
@@ -23,7 +23,11 @@ import type { BackendFunction } from '../backend/types';
 import { generateDevVirtualEntryContent } from '../backend/virtual-entry';
 
 import { getBaseBackendBuildConfig } from './build-config';
-import { executeScriptLocally } from './local-execution';
+import {
+    executeScriptLocally,
+    getMostRecentlyForkedChildForTest,
+    killAllLocalExecutionChildren,
+} from './local-execution';
 
 const log = getMockLogger();
 
@@ -134,5 +138,113 @@ describe('executeScriptLocally (real bundle, no mocks)', () => {
         await expect(executeScriptLocally(code, func, [], log)).rejects.toThrow(
             'deliberate bug in a real bundled backend function',
         );
+    }, 20_000);
+
+    test('returns a clean, actionable error when the backend function returns a non-serializable value (a circular reference), instead of hanging or crashing opaquely', async () => {
+        const workingDir = getTempWorkingDir(`local-exec-poc-circular-${Date.now()}`);
+        const sourceCode = `
+            export async function circular() {
+                const obj = {};
+                obj.self = obj;
+                return obj;
+            }
+        `;
+        const code = await bundleRealBackendFunction(workingDir, 'circular', sourceCode);
+
+        const func: BackendFunction = {
+            relativePath: 'src/circular',
+            name: 'circular',
+            absolutePath: `${workingDir}/src/circular.backend.ts`,
+            allowedConnectionIds: [],
+        };
+
+        await expect(executeScriptLocally(code, func, [], log)).rejects.toThrow(
+            /circular|serializ/i,
+        );
+    }, 20_000);
+
+    test('resolves each concurrent $.Actions call within a single execution to its own correct result, not a mixed-up one', async () => {
+        const workingDir = getTempWorkingDir(`local-exec-poc-concurrent-actions-${Date.now()}`);
+        const sourceCode = `
+            export async function concurrentActions() {
+                const [a, b, c] = await Promise.all([
+                    $.Actions.slack.chat.postMessage({ inputs: { channel: '#a' }, connectionId: 'connection:slack:poc' }),
+                    $.Actions.github.issues.create({ inputs: { title: 'b' }, connectionId: 'connection:slack:poc' }),
+                    $.Actions.jira.jira.createIssue({ inputs: { summary: 'c' }, connectionId: 'connection:slack:poc' }),
+                ]);
+                return { a, b, c };
+            }
+        `;
+        const code = await bundleRealBackendFunction(workingDir, 'concurrentActions', sourceCode);
+
+        const func: BackendFunction = {
+            relativePath: 'src/concurrentActions',
+            name: 'concurrentActions',
+            absolutePath: `${workingDir}/src/concurrentActions.backend.ts`,
+            allowedConnectionIds: ['connection:slack:poc'],
+        };
+
+        const outputs = await executeScriptLocally(code, func, [], log);
+
+        expect(outputs.data).toMatchObject({
+            a: { stub: true, fqn: 'com.datadoghq.slack.chat.postMessage' },
+            b: { stub: true, fqn: 'com.datadoghq.github.issues.create' },
+            c: { stub: true, fqn: 'com.datadoghq.jira.jira.createIssue' },
+        });
+    }, 20_000);
+
+    test('reports the signal when a child process is killed rather than exiting normally (e.g. an OOM-killed or crashed native module), instead of an opaque "code null" error', async () => {
+        const workingDir = getTempWorkingDir(`local-exec-poc-signal-${Date.now()}`);
+        // A function that never resolves -- gives the test time to kill the
+        // child with a signal before it would otherwise finish or time out.
+        const sourceCode = `
+            export async function hangs() {
+                return new Promise(() => {});
+            }
+        `;
+        const code = await bundleRealBackendFunction(workingDir, 'hangs', sourceCode);
+
+        const func: BackendFunction = {
+            relativePath: 'src/hangs',
+            name: 'hangs',
+            absolutePath: `${workingDir}/src/hangs.backend.ts`,
+            allowedConnectionIds: [],
+        };
+
+        const execution = executeScriptLocally(code, func, [], log, 5_000);
+        const child = getMostRecentlyForkedChildForTest();
+        // Give the child a moment to actually start running before killing it,
+        // so this exercises a real in-flight kill, not a race with fork() itself.
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, 200));
+        child?.kill('SIGSEGV');
+
+        await expect(execution).rejects.toThrow(/SIGSEGV/);
+    }, 20_000);
+
+    test('killAllLocalExecutionChildren terminates an in-flight child (dev-server shutdown must not leave orphaned processes)', async () => {
+        const workingDir = getTempWorkingDir(`local-exec-poc-shutdown-${Date.now()}`);
+        const sourceCode = `
+            export async function hangs() {
+                return new Promise(() => {});
+            }
+        `;
+        const code = await bundleRealBackendFunction(workingDir, 'hangs', sourceCode);
+
+        const func: BackendFunction = {
+            relativePath: 'src/hangs',
+            name: 'hangs',
+            absolutePath: `${workingDir}/src/hangs.backend.ts`,
+            allowedConnectionIds: [],
+        };
+
+        const execution = executeScriptLocally(code, func, [], log, 5_000);
+        const child = getMostRecentlyForkedChildForTest();
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, 200));
+
+        expect(child?.killed).toBe(false);
+        killAllLocalExecutionChildren();
+
+        await expect(execution).rejects.toThrow();
+        expect(child?.killed).toBe(true);
     }, 20_000);
 });

--- a/packages/plugins/apps/src/vite/local-execution.ts
+++ b/packages/plugins/apps/src/vite/local-execution.ts
@@ -16,12 +16,38 @@
  */
 
 import type { Logger } from '@dd/core/types';
+import type { ChildProcess } from 'child_process';
 import { fork } from 'child_process';
 import * as path from 'path';
 
 import type { BackendFunction } from '../backend/types';
 
 type BackendOutputs = { data: unknown };
+
+// Tracks every child currently executing a backend function, so the dev
+// server can kill them all on its own shutdown instead of leaving orphaned
+// Node processes behind (see killAllLocalExecutionChildren below). A Set
+// rather than a single reference because multiple executions can be
+// in-flight concurrently -- each gets its own forked child (pooling is
+// deliberately deferred, see the design doc's Timeline section).
+const liveChildren = new Set<ChildProcess>();
+
+/**
+ * Kill every backend-function child process currently executing. Call this
+ * from the dev server's own shutdown handling (SIGINT/SIGTERM/process exit)
+ * once local execution is wired in -- not yet called anywhere, since this
+ * file isn't wired into createDevServerMiddleware yet.
+ */
+export function killAllLocalExecutionChildren(): void {
+    for (const child of liveChildren) {
+        child.kill();
+    }
+}
+
+/** Test-only: exposes the most recently forked child so tests can exercise real signal-based kills. */
+export function getMostRecentlyForkedChildForTest(): ChildProcess | undefined {
+    return Array.from(liveChildren).at(-1);
+}
 
 interface ActionRequestMessage {
     type: 'action-request';
@@ -73,16 +99,25 @@ export function executeScriptLocally(
         // `env`, never inherit process.env wholesale -- see the design doc's
         // Secrets Handling section (never hand secrets to the child).
         const child = fork(LOCAL_EXEC_CHILD_SCRIPT, [], { stdio: 'inherit', env: {} });
+        liveChildren.add(child);
         let settled = false;
 
+        const settle = (fn: () => void) => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            liveChildren.delete(child);
+            fn();
+        };
+
         const timer = setTimeout(() => {
-            if (!settled) {
-                settled = true;
+            settle(() => {
                 child.kill();
                 reject(
                     new Error(`Local execution of "${func.name}" timed out after ${timeoutMs}ms`),
                 );
-            }
+            });
         }, timeoutMs);
 
         child.on('message', (msg: ChildMessage) => {
@@ -105,38 +140,46 @@ export function executeScriptLocally(
                 return;
             }
 
-            if (msg.type === 'result' && !settled) {
-                settled = true;
-                clearTimeout(timer);
-                resolve({ data: msg.result });
+            if (msg.type === 'result') {
+                settle(() => {
+                    clearTimeout(timer);
+                    resolve({ data: msg.result });
+                });
                 return;
             }
 
-            if (msg.type === 'error' && !settled) {
-                settled = true;
-                clearTimeout(timer);
-                reject(new Error(msg.error));
+            if (msg.type === 'error') {
+                settle(() => {
+                    clearTimeout(timer);
+                    reject(new Error(msg.error));
+                });
             }
         });
 
-        child.on('exit', (code) => {
-            if (!settled) {
-                settled = true;
+        child.on('exit', (code, signal) => {
+            settle(() => {
                 clearTimeout(timer);
+                // A signal (not a plain exit code) means the OS terminated the
+                // process directly -- most commonly an OOM kill (SIGKILL) or a
+                // native-module crash (SIGSEGV/SIGABRT). Report it explicitly:
+                // "exited with code null" is meaningless to a developer trying
+                // to tell an OOM apart from a native-module crash.
+                const cause = signal
+                    ? `was killed by signal ${signal}`
+                    : `exited with code ${code}`;
                 reject(
                     new Error(
-                        `Local execution of "${func.name}" exited with code ${code} before reporting a result`,
+                        `Local execution of "${func.name}" ${cause} before reporting a result`,
                     ),
                 );
-            }
+            });
         });
 
         child.on('error', (err) => {
-            if (!settled) {
-                settled = true;
+            settle(() => {
                 clearTimeout(timer);
                 reject(err);
-            }
+            });
         });
 
         child.send({ type: 'execute', scriptBody, backendFunctionArgs: args });


### PR DESCRIPTION
## Motivation

- Milestone 1 of the [local Node execution kickoff plan](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7025394455) — hardens the fork/IPC path #461 prototyped, which only exercised one execution at a time with no edge-case coverage.
- Design doc: [Local Node execution for High Code Apps backend functions](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7012712651) (see "What the POC actually proves, and what it doesn't" in Timeline & Work Breakdown).
- [APPS-2792](https://datadoghq.atlassian.net/browse/APPS-2792)

## Changes

| What changed | File |
|---|---|
| Report the OS signal (e.g. `SIGSEGV`, `SIGKILL`) when a child is killed rather than exiting normally, instead of an opaque "exited with code null" | `packages/plugins/apps/src/vite/local-execution.ts` |
| Track live children in a `Set`; export `killAllLocalExecutionChildren()` for the dev server to call on its own shutdown so in-flight executions don't leave orphaned Node processes | `packages/plugins/apps/src/vite/local-execution.ts` |
| Add `getMostRecentlyForkedChildForTest()` — test-only accessor to exercise real signal-based kills | `packages/plugins/apps/src/vite/local-execution.ts` |
| Add regression coverage for behavior that already worked but had no test: non-serializable return values (circular references) reject cleanly instead of hanging, concurrent `$.Actions` calls within one execution resolve to their own correct results | `packages/plugins/apps/src/vite/local-execution.integration.test.ts` |
| Add tests for the new signal-reporting and shutdown-cleanup behavior, using a real forked child (not mocked) | `packages/plugins/apps/src/vite/local-execution.integration.test.ts` |

## QA Instructions

```bash
yarn install
```

```bash
BUILD_PLUGINS_ENV=test FORCE_COLOR=true JEST_CONFIG_TRANSPILE_ONLY=true VITE_CJS_IGNORE_WARNING=true NODE_OPTIONS="--experimental-vm-modules" yarn workspace @dd/tests exec jest --config jest.config.ts packages/plugins/apps/src/vite/local-execution.integration.test.ts
# Expected: 6 tests passing ✅ VERIFIED
```

```bash
BUILD_PLUGINS_ENV=test FORCE_COLOR=true JEST_CONFIG_TRANSPILE_ONLY=true VITE_CJS_IGNORE_WARNING=true NODE_OPTIONS="--experimental-vm-modules" yarn workspace @dd/tests exec jest --config jest.config.ts packages/plugins/apps
# Expected: 24 test suites, 291 tests, all passing ✅ VERIFIED
```

```bash
cd packages/plugins/apps && npx tsc -b tsconfig.client.json --emitDeclarationOnly && npx tsc --noEmit
# Expected: no output, clean exit ✅ VERIFIED
```

```bash
yarn eslint packages/plugins/apps/src/vite/local-execution.ts packages/plugins/apps/src/vite/local-execution.integration.test.ts
# Expected: no output, clean exit ✅ VERIFIED
```

### Manual QA — not yet possible, same as #461

Same reasoning as #461, which this PR is stacked on: `createDevServerMiddleware` doesn't call anything in `local-execution.ts`, so there's no `npm run dev` request path reaching this code yet — nothing to click through locally or on staging. Did do real local + staging manual QA on the separately-scoped [#460](https://github.com/DataDog/build-plugins/pull/460) (ssr:true + noExternal fix), since that one *is* on a live path today. Manual QA for this file becomes possible once Milestone 2 wires it into the dev server.

## Blast Radius

- This file (`local-execution.ts`) is not wired into `createDevServerMiddleware` yet — Milestone 2, a separate stacked PR — so this change has **zero effect on any currently-shipping behavior**.
- Risk: **low**. Purely additive hardening to code that isn't live yet.
- **`executeActionRemotely` remains a stub** — real wiring is blocked on the single-action execution endpoint decision (design doc's Open Dependency section), not this PR's scope.

## Out of Scope / Follow-ups

| Item | Status | Next step |
|---|---|---|
| Process pooling (reuse instead of fork-per-call) | Deferred | Explicitly deferred per the design doc's Timeline section — the measured fork-per-call latency (p50 36ms) already beats today's cloud round-trip by orders of magnitude; pooling is a Should-have optimization once usage data justifies the added complexity, not a P0 blocker |
| `handleExecuteAction` integration into real `dev-server.ts` | **Done** | [DataDog/build-plugins#473](https://github.com/DataDog/build-plugins/pull/473), stacked on this PR |

## Documentation

- [Kickoff doc](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7025394455) — Milestone 1
- [Design doc](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7012712651)


[APPS-2792]: https://datadoghq.atlassian.net/browse/APPS-2792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

