### PR TITLE
[APPS-2792] Wire local Node execution into the real dev server

### DIFF
--- a/packages/plugins/apps/package.json
+++ b/packages/plugins/apps/package.json
@@ -19,6 +19,12 @@
                 "format": [
                     "esm"
                 ]
+            },
+            "local-exec-child": {
+                "entry": "./src/vite/local-exec-child.js",
+                "format": [
+                    "cjs"
+                ]
             }
         }
     },

--- a/packages/plugins/apps/src/vite/dev-server.test.ts
+++ b/packages/plugins/apps/src/vite/dev-server.test.ts
@@ -208,7 +208,34 @@ describe('Dev Server Middleware', () => {
             expect(res.end).toHaveBeenCalled();
         });
 
-        test('Should handle /__dd/executeAction POST', async () => {
+        test('Should handle /__dd/executeAction POST by running the bundle locally, not via the Datadog API', async () => {
+            mockBuildWithParsedBackend(
+                'export async function main($) { return { echo: $.backendFunctionArgs }; }',
+            );
+
+            // No nock scope registered -- if the middleware still called the
+            // Datadog API for this endpoint, the request would fail outright
+            // (nock throws on unmocked requests by default), so an unmocked
+            // 200 here already proves local execution, not the cloud path.
+            const req = createMockRequest('/__dd/executeAction', {
+                functionName: encodeQueryName(mockFunctions[0]),
+                args: ['world'],
+            });
+            const res = createMockResponse();
+            const next = jest.fn();
+
+            middleware(req, res, next);
+            expect(next).not.toHaveBeenCalled();
+
+            await res.done;
+
+            expect(res.statusCode).toBe(200);
+            const body = JSON.parse(res.getBody());
+            expect(body.success).toBe(true);
+            expect(body.result).toEqual({ data: { echo: ['world'] } });
+        }, 20_000);
+
+        test('Should handle /__dd/executeActionViaCloud POST', async () => {
             mockBuildWithParsedBackend();
 
             // Mock the Datadog API via nock.
@@ -225,7 +252,7 @@ describe('Dev Server Middleware', () => {
                     },
                 });
 
-            const req = createMockRequest('/__dd/executeAction', {
+            const req = createMockRequest('/__dd/executeActionViaCloud', {
                 functionName: encodeQueryName(mockFunctions[0]),
                 args: ['world'],
             });
@@ -321,7 +348,7 @@ describe('Dev Server Middleware', () => {
         });
     });
 
-    describe('executeAction handler', () => {
+    describe('executeAction handler (local execution)', () => {
         const middleware = createDevServerMiddleware(
             mockViteBuild,
             () => mockFunctions,
@@ -353,6 +380,105 @@ describe('Dev Server Middleware', () => {
             expect(res.statusCode).toBe(404);
         });
 
+        test('Should run the bundle in a real forked child process and return its result', async () => {
+            mockBuildWithParsedBackend(
+                'export async function main($) { return { doubled: $.backendFunctionArgs[0] * 2 }; }',
+            );
+
+            const req = createMockRequest('/__dd/executeAction', {
+                functionName: encodeQueryName(mockFunctions[0]),
+                args: [21],
+            });
+            const res = createMockResponse();
+
+            middleware(req, res, jest.fn());
+            await res.done;
+
+            expect(res.statusCode).toBe(200);
+            const body = JSON.parse(res.getBody());
+            expect(body.success).toBe(true);
+            expect(body.result).toEqual({ data: { doubled: 42 } });
+        }, 20_000);
+
+        test('Should propagate a real crash in the bundled function as a 500, not a hang', async () => {
+            mockBuildWithParsedBackend(
+                "export async function main() { throw new Error('deliberate crash'); }",
+            );
+
+            const req = createMockRequest('/__dd/executeAction', {
+                functionName: encodeQueryName(mockFunctions[0]),
+                args: [],
+            });
+            const res = createMockResponse();
+
+            middleware(req, res, jest.fn());
+            await res.done;
+
+            expect(res.statusCode).toBe(500);
+            const body = JSON.parse(res.getBody());
+            expect(body.success).toBe(false);
+            expect(body.error).toContain('deliberate crash');
+        }, 20_000);
+
+        test('Should work without any Datadog credentials configured, unlike executeActionViaCloud', async () => {
+            const noAuthMiddleware = createDevServerMiddleware(
+                mockViteBuild,
+                () => mockFunctions,
+                mockOauthOnlyAuth,
+                undefined,
+                '/project',
+                mockLog,
+            );
+            mockBuildWithParsedBackend('export async function main() { return { ok: true }; }');
+
+            const req = createMockRequest('/__dd/executeAction', {
+                functionName: encodeQueryName(mockFunctions[0]),
+                args: [],
+            });
+            const res = createMockResponse();
+
+            noAuthMiddleware(req, res, jest.fn());
+            await res.done;
+
+            expect(res.statusCode).toBe(200);
+            const body = JSON.parse(res.getBody());
+            expect(body.success).toBe(true);
+            expect(body.result).toEqual({ data: { ok: true } });
+        }, 20_000);
+    });
+
+    describe('executeActionViaCloud handler', () => {
+        const middleware = createDevServerMiddleware(
+            mockViteBuild,
+            () => mockFunctions,
+            mockAuth,
+            getApiKeyRequest(),
+            '/project',
+            mockLog,
+        );
+
+        test('Should return 400 for missing functionRef', async () => {
+            const req = createMockRequest('/__dd/executeActionViaCloud', {});
+            const res = createMockResponse();
+
+            middleware(req, res, jest.fn());
+            await res.done;
+
+            expect(res.statusCode).toBe(400);
+        });
+
+        test('Should return 404 for unknown function', async () => {
+            const req = createMockRequest('/__dd/executeActionViaCloud', {
+                functionName: 'nonexistent.nonexistent',
+            });
+            const res = createMockResponse();
+
+            middleware(req, res, jest.fn());
+            await res.done;
+
+            expect(res.statusCode).toBe(404);
+        });
+
         /*
          * The nock mock replies with 403 to simulate the upstream Datadog API
          * rejecting the request (e.g. bad credentials). The middleware still
@@ -369,7 +495,7 @@ describe('Dev Server Middleware', () => {
                 .post('/api/v2/app-builder/queries/preview-async')
                 .reply(403, 'Forbidden');
 
-            const req = createMockRequest('/__dd/executeAction', {
+            const req = createMockRequest('/__dd/executeActionViaCloud', {
                 functionName: encodeQueryName(mockFunctions[0]),
                 args: [],
             });
@@ -421,7 +547,7 @@ describe('Dev Server Middleware', () => {
                     data: { attributes: { done: true, outputs: { data: { value: 42 } } } },
                 });
 
-            const req = createMockRequest('/__dd/executeAction', {
+            const req = createMockRequest('/__dd/executeActionViaCloud', {
                 functionName: encodeQueryName(mockFunctions[0]),
                 args: ['hello', 42],
             });
@@ -469,7 +595,7 @@ describe('Dev Server Middleware', () => {
                     data: { attributes: { done: true, outputs: { data: { ok: true } } } },
                 });
 
-            const req = createMockRequest('/__dd/executeAction', {
+            const req = createMockRequest('/__dd/executeActionViaCloud', {
                 functionName: encodeQueryName(mockFunctions[0]),
                 args: [],
             });
@@ -495,7 +621,7 @@ describe('Dev Server Middleware', () => {
                 mockLog,
             );
 
-            const req = createMockRequest('/__dd/executeAction', {
+            const req = createMockRequest('/__dd/executeActionViaCloud', {
                 functionName: encodeQueryName(mockFunctions[0]),
                 args: [],
             });
@@ -546,7 +672,7 @@ describe('Dev Server Middleware', () => {
                 });
 
             const trickyArgs = ["don't break", "'); alert(1); //", '😀'];
-            const req = createMockRequest('/__dd/executeAction', {
+            const req = createMockRequest('/__dd/executeActionViaCloud', {
                 functionName: encodeQueryName(mockFunctions[0]),
                 args: trickyArgs,
             });
@@ -605,7 +731,7 @@ describe('Dev Server Middleware', () => {
                     data: { attributes: { done: true, outputs: { data: { ok: true } } } },
                 });
 
-            const req = createMockRequest('/__dd/executeAction', {
+            const req = createMockRequest('/__dd/executeActionViaCloud', {
                 functionName: encodeQueryName(functionsWithAllowlist[1]),
                 args: [],
             });
@@ -660,7 +786,7 @@ describe('Dev Server Middleware', () => {
                     data: { attributes: { done: true, outputs: { data: { ok: true } } } },
                 });
 
-            const req = createMockRequest('/__dd/executeAction', {
+            const req = createMockRequest('/__dd/executeActionViaCloud', {
                 functionName: encodeQueryName(mockFunctions[0]),
                 args: [],
             });
@@ -687,7 +813,7 @@ describe('Dev Server Middleware', () => {
                     errors: [{ title: 'ExecutionFailed', detail: 'Script threw an error' }],
                 });
 
-            const req = createMockRequest('/__dd/executeAction', {
+            const req = createMockRequest('/__dd/executeActionViaCloud', {
                 functionName: encodeQueryName(mockFunctions[0]),
                 args: [],
             });
@@ -715,7 +841,7 @@ describe('Dev Server Middleware', () => {
                     data: { attributes: { done: true, outputs: { data: { ok: true } } } },
                 });
 
-            const req = createMockRequest('/__dd/executeAction', {
+            const req = createMockRequest('/__dd/executeActionViaCloud', {
                 functionName: encodeQueryName(mockFunctions[0]),
                 args: [],
             });

--- a/packages/plugins/apps/src/vite/dev-server.ts
+++ b/packages/plugins/apps/src/vite/dev-server.ts
@@ -18,6 +18,7 @@ import { generateDevVirtualEntryContent } from '../backend/virtual-entry';
 
 import { createBackendConnectionIdCollector } from './backend-connection-id-collector';
 import { getBaseBackendBuildConfig } from './build-config';
+import { executeScriptLocally } from './local-execution';
 
 interface BundleResult {
     func: BackendFunction;
@@ -308,9 +309,52 @@ async function handleDebugBundle(
 }
 
 /**
- * Handle POST /__dd/executeAction — bundles a backend function and executes it via Datadog API.
+ * Handle POST /__dd/executeAction — bundles a backend function and runs it
+ * locally in a forked Node child process (see local-execution.ts). This is
+ * the new default per the local Node execution design doc: `npm run dev`
+ * unconditionally uses local execution, no customer-facing toggle.
+ *
+ * NOTE: `$.Actions` calls are currently stubbed (see local-execution.ts's
+ * executeActionRemotely) -- the single-action execution endpoint this needs
+ * doesn't exist publicly yet (design doc's "Open Dependency" section). Real
+ * action results are only available via /__dd/executeActionViaCloud below
+ * until that resolves.
  */
 async function handleExecuteAction(
+    req: IncomingMessage,
+    res: ServerResponse,
+    functionsByName: Map<string, BackendFunction>,
+    bundle: BundleFn,
+    log: Logger,
+): Promise<void> {
+    try {
+        const { func, code, args } = await validateAndBundle(req, functionsByName, bundle);
+        const displayName = formatRef(func);
+
+        log.debug(`Executing action locally: ${displayName} with args`);
+
+        const result = await executeScriptLocally(code, func, args, log);
+
+        res.statusCode = 200;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ success: true, result } satisfies ExecuteActionResponse));
+    } catch (error: unknown) {
+        const statusCode = error instanceof HttpError ? error.statusCode : 500;
+        const message = error instanceof Error ? error.message : 'Internal server error';
+        log.debug(`Error handling executeAction: ${message}`);
+        sendError(res, statusCode, message);
+    }
+}
+
+/**
+ * Handle POST /__dd/executeActionViaCloud — bundles a backend function and
+ * executes it via Datadog's cloud API (today's `preview-async` + long-poll
+ * round trip), unchanged from before local execution existed. Preserves this
+ * path for pre-publish parity verification (the design doc's "Mode B") --
+ * not yet wired to an `npm run dev:verify` script (that requires changes to
+ * the create-apps scaffolding templates, outside this package's scope).
+ */
+async function handleExecuteActionViaCloud(
     req: IncomingMessage,
     res: ServerResponse,
     functionsByName: Map<string, BackendFunction>,
@@ -323,7 +367,7 @@ async function handleExecuteAction(
         const { func, code, args } = await validateAndBundle(req, functionsByName, bundle);
         const displayName = formatRef(func);
 
-        log.debug(`Executing action: ${displayName} with args`);
+        log.debug(`Executing action via cloud: ${displayName} with args`);
 
         const result = await executeScriptViaDatadog(
             code,
@@ -340,7 +384,7 @@ async function handleExecuteAction(
     } catch (error: unknown) {
         const statusCode = error instanceof HttpError ? error.statusCode : 500;
         const message = error instanceof Error ? error.message : 'Internal server error';
-        log.debug(`Error handling executeAction: ${message}`);
+        log.debug(`Error handling executeActionViaCloud: ${message}`);
         sendError(res, statusCode, message);
     }
 }
@@ -380,7 +424,7 @@ export function createDevServerMiddleware(
 
     if (!doAuthenticatedRequest) {
         log.warn(
-            `Auth credentials not configured. The /__dd/executeAction endpoint will be unavailable. ${AUTH_GUIDANCE}`,
+            `Auth credentials not configured. The /__dd/executeActionViaCloud endpoint will be unavailable. ${AUTH_GUIDANCE}`,
         );
     }
 
@@ -397,11 +441,19 @@ export function createDevServerMiddleware(
                 sendError(res, 500, 'Unexpected error');
             });
         } else if (req.url === '/__dd/executeAction') {
+            // Local execution doesn't need Datadog credentials today --
+            // `$.Actions` calls are stubbed until the single-action execution
+            // endpoint exists (see local-execution.ts). Unlike the cloud path
+            // below, this endpoint works without any auth configured.
+            handleExecuteAction(req, res, functionsByName, bundle, log).catch(() => {
+                sendError(res, 500, 'Unexpected error');
+            });
+        } else if (req.url === '/__dd/executeActionViaCloud') {
             if (!doAuthenticatedRequest) {
                 sendError(res, 400, `Auth credentials not configured. ${AUTH_GUIDANCE}`);
                 return;
             }
-            handleExecuteAction(
+            handleExecuteActionViaCloud(
                 req,
                 res,
                 functionsByName,

--- a/packages/plugins/apps/src/vite/index.ts
+++ b/packages/plugins/apps/src/vite/index.ts
@@ -23,6 +23,7 @@ import type { AppsOptionsWithDefaults } from '../types';
 import { buildBackendFunctions } from './build-backend-functions';
 import { createDevServerMiddleware } from './dev-server';
 import { handleUpload } from './handle-upload';
+import { killAllLocalExecutionChildren } from './local-execution';
 
 export type ViteBundler = {
     build: typeof build;
@@ -210,6 +211,13 @@ export const getVitePlugin = ({
                     log,
                 ),
             );
+
+            // Local execution forks a real child process per backend-function
+            // call (see local-execution.ts). Without this, killing the dev
+            // server mid-execution would leave that child orphaned.
+            server.httpServer?.once('close', () => {
+                killAllLocalExecutionChildren();
+            });
         },
     };
 };

--- a/packages/plugins/apps/src/vite/local-exec-child.js
+++ b/packages/plugins/apps/src/vite/local-exec-child.js
@@ -68,13 +68,33 @@ function makeActionsProxy(pathParts = []) {
     });
 }
 
+// @datadog/apps-backend's buildRuntimeFromJsFunctionWithActions (injected into
+// every bundle when that package is installed, regardless of which specific
+// function is called -- see virtual-entry.ts's SET_BACKEND_CONTEXT_SNIPPET)
+// requires $.Source.{initiator,runAsUser} to each be a User object with
+// non-empty id/orgId strings. In production this comes from the real
+// workflow-execution's trigger/run-as identity (domains/workflow's Go proto
+// data); no equivalent identity exists for a local fork, and no impersonation
+// (initiator vs. runAsUser) is meaningful when one developer is running their
+// own code locally, so both roles use the same clearly-synthetic identity.
+const LOCAL_DEV_USER = {
+    id: 'local-dev-user',
+    orgId: 'local-dev-org',
+    email: null,
+    name: 'Local Development',
+};
+
 process.on('message', async function onExecute(msg) {
     if (!msg || msg.type !== 'execute') {
         return;
     }
 
     try {
-        const $ = { backendFunctionArgs: msg.backendFunctionArgs, Actions: makeActionsProxy() };
+        const $ = {
+            backendFunctionArgs: msg.backendFunctionArgs,
+            Actions: makeActionsProxy(),
+            Source: { initiator: LOCAL_DEV_USER, runAsUser: LOCAL_DEV_USER },
+        };
         globalThis.$ = $;
 
         // The real bundled code (from vite.build(), format:'es', no externals

--- a/packages/plugins/apps/src/vite/local-execution.integration.test.ts
+++ b/packages/plugins/apps/src/vite/local-execution.integration.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { outputFileSync } from '@dd/core/helpers/fs';
-import { getTempWorkingDir } from '@dd/tests/_jest/helpers/env';
+import { getTempWorkingDir, prepareWorkingDir } from '@dd/tests/_jest/helpers/env';
 import { getMockLogger } from '@dd/tests/_jest/helpers/mocks';
 import { build } from 'vite';
 
@@ -246,5 +246,48 @@ describe('executeScriptLocally (real bundle, no mocks)', () => {
 
         await expect(execution).rejects.toThrow();
         expect(child?.killed).toBe(true);
+    }, 20_000);
+
+    test('supplies a valid $.Source so @datadog/apps-backend does not throw, when the package is installed', async () => {
+        // Unlike the other tests in this file (a bare temp dir with only the
+        // one .backend.ts file written into it), this uses the real fixture
+        // project tree, which has a real @datadog/apps-backend installed --
+        // matching a real scaffolded app, and the exact condition that
+        // exposed this bug: isDatadogAppsBackendInstalled(workingDir) resolves
+        // true here, so generateDevVirtualEntryContent injects
+        // SET_BACKEND_CONTEXT_SNIPPET, which throws unless $.Source is valid.
+        const workingDir = await prepareWorkingDir(`local-exec-poc-apps-backend-${Date.now()}`);
+        const sourceCode = `
+            import { getExecutionUser, getInitiatingUser } from '@datadog/apps-backend/user';
+            export async function usesSdk() {
+                const [executionUser, initiatingUser] = await Promise.all([
+                    getExecutionUser(),
+                    getInitiatingUser(),
+                ]);
+                return { executionUser, initiatingUser };
+            }
+        `;
+        const code = await bundleRealBackendFunction(workingDir, 'usesSdk', sourceCode);
+
+        // Confirms the bundle actually took the @datadog/apps-backend branch
+        // (the bug this test guards would otherwise be silently untested if
+        // the fixture stopped resolving as installed for some other reason).
+        // Asserts on the snippet's literal comment, not the imported
+        // identifiers -- Rollup renames those during bundling.
+        expect(code).toContain('Supply the backend runtime context');
+
+        const func: BackendFunction = {
+            relativePath: 'src/usesSdk',
+            name: 'usesSdk',
+            absolutePath: `${workingDir}/src/usesSdk.backend.ts`,
+            allowedConnectionIds: [],
+        };
+
+        const outputs = await executeScriptLocally(code, func, [], log);
+
+        expect(outputs.data).toMatchObject({
+            executionUser: { id: 'local-dev-user', orgId: 'local-dev-org' },
+            initiatingUser: { id: 'local-dev-user', orgId: 'local-dev-org' },
+        });
     }, 20_000);
 });


### PR DESCRIPTION
## Motivation

- Milestone 2 of the [local Node execution kickoff plan](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7025394455) — wires the fork/IPC path #461 prototyped and #471 hardened into the real `npm run dev` request path for the first time. Before this PR, `local-execution.ts` was fully built and tested but unreachable from any actual dev-server request.
- Design doc: [Local Node execution for High Code Apps backend functions](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7012712651) — Rollout section: "no toggle at all — `npm run dev` unconditionally uses local execution; the cloud round-trip becomes a separately-purposed command."
- [APPS-2792](https://datadoghq.atlassian.net/browse/APPS-2792)

## Architecture

```
Browser (frontend)
   │  executeBackendFunction(name, args)
   ▼
Vite dev-server middleware
   │
   ├──────────────────────────┬───────────────────────────────┐
   ▼                          ▼
POST /__dd/executeAction      POST /__dd/executeActionViaCloud
(no auth required)            (auth required, unchanged)
   │                          │
   ▼                          ▼
executeScriptLocally()        executeScriptViaDatadog()
(#461/#471 — forked           (existing preview-async +
 child process, real          long-poll round trip against
 OS-process isolation)        the real Deno prod runtime)
   │                          │
   └──────────┬───────────────┘
              ▼
   Same ExecuteActionResponse contract either way:
   {success:true, result:{data}} | {success:false, error}
```

`/__dd/executeAction` is the customer-facing default and is now unconditionally local — no config field, no flag, per the design doc's rollout decision. `/__dd/executeActionViaCloud` is new and additive: it preserves today's exact cloud round-trip (same `executeScriptViaDatadog`/`pollQueryExecution` code, untouched) under a distinctly-purposed endpoint. No `npm run dev:verify` CLI command exists yet to give customers an ergonomic way to reach it — that's now tracked as Milestone 3 in the kickoff doc, not deferred — and the existing test suite has deep coverage of this path that would otherwise be silently orphaned.

## Changes

| What changed | File |
|---|---|
| `/__dd/executeAction` now runs backend functions via `executeScriptLocally` (a real forked child process) instead of the cloud round-trip | `packages/plugins/apps/src/vite/dev-server.ts` |
| `/__dd/executeAction` requires no auth, since local execution's `$.Actions` calls are stubbed today (see Follow-ups) | `packages/plugins/apps/src/vite/dev-server.ts` |
| New `/__dd/executeActionViaCloud` endpoint preserves the original `executeScriptViaDatadog` cloud round-trip byte-for-byte, including its auth gate | `packages/plugins/apps/src/vite/dev-server.ts` |
| Startup log warning updated to reference `/__dd/executeActionViaCloud` (the endpoint that actually needs credentials) instead of the old `/__dd/executeAction` name | `packages/plugins/apps/src/vite/dev-server.ts` |
| Wire `killAllLocalExecutionChildren()` (from #471) into the dev server's own shutdown via `server.httpServer`'s `close` event | `packages/plugins/apps/src/vite/index.ts` |
| Renamed the entire original cloud-round-trip test suite to target `/__dd/executeActionViaCloud` instead of `/__dd/executeAction`, preserving full existing coverage | `packages/plugins/apps/src/vite/dev-server.test.ts` |
| Fixed the routing-level test for `/__dd/executeAction` to assert against real local-execution bundle content instead of a stale nock mock | `packages/plugins/apps/src/vite/dev-server.test.ts` |
| Added a companion routing test for `/__dd/executeActionViaCloud` | `packages/plugins/apps/src/vite/dev-server.test.ts` |
| Added a new 5-test suite covering the local-execution handler directly (missing functionRef, unknown function, real forked-child result, crash-as-500, no-credentials-configured) | `packages/plugins/apps/src/vite/dev-server.test.ts` |
| Register `local-exec-child.js` in `buildPlugin.toBuild` so it's copied into the published `dist/src` output next to the compiled bundle | `packages/plugins/apps/package.json` |
| Local execution's `$` context now includes a `Source: { initiator, runAsUser }` object with a synthetic local-dev identity, so `@datadog/apps-backend`'s injected runtime-context setup no longer throws | `packages/plugins/apps/src/vite/local-exec-child.js` |
| New integration test reusing the `apps_backend_project` fixture (real `@datadog/apps-backend`) confirms a function calling `getExecutionUser()`/`getInitiatingUser()` runs cleanly under local execution | `packages/plugins/apps/src/vite/local-execution.integration.test.ts` |

## QA Instructions

```bash
yarn install
```

```bash
BUILD_PLUGINS_ENV=test FORCE_COLOR=true JEST_CONFIG_TRANSPILE_ONLY=true VITE_CJS_IGNORE_WARNING=true NODE_OPTIONS="--experimental-vm-modules" yarn workspace @dd/tests exec jest --config jest.config.ts packages/plugins/apps/src/vite/dev-server.test.ts
# Expected: 26 tests passing ✅ VERIFIED
```

```bash
BUILD_PLUGINS_ENV=test FORCE_COLOR=true JEST_CONFIG_TRANSPILE_ONLY=true VITE_CJS_IGNORE_WARNING=true NODE_OPTIONS="--experimental-vm-modules" yarn workspace @dd/tests exec jest --config jest.config.ts packages/plugins/apps
# Expected: 24 test suites, 298 tests, all passing ✅ VERIFIED
```

```bash
cd ~/dd/build-plugins/packages/plugins/apps && npx tsc -b tsconfig.client.json --emitDeclarationOnly && npx tsc --noEmit
# Expected: no output, clean exit ✅ VERIFIED
```

```bash
yarn eslint packages/plugins/apps/src/vite/dev-server.ts packages/plugins/apps/src/vite/dev-server.test.ts packages/plugins/apps/src/vite/index.ts
# Expected: no output, clean exit ✅ VERIFIED
```

### Manual QA — real dev server, both endpoints

**Setup** (one app covers every scenario below — `@datadog/apps-backend` and `@datadog/action-catalog` are scaffold defaults). Three terminals are used in total: **Terminal A** builds this branch and is done after that; **Terminal B** runs the dev server and stays occupied by it; **Terminal C** is opened later, once the dev server is running, to send requests to it.

**Terminal A — folder: this repo (`~/dd/build-plugins`):**

```bash
cd ~/dd/build-plugins
yarn install
yarn workspace @datadog/vite-plugin build
```

Terminal A isn't needed again after this — the built plugin is linked by absolute path below, not by anything left running in this terminal.

**Terminal B — folder: a fresh scaffolded app outside this repo (`~/qa-app`):**

```bash
# 1. Scaffold a fresh test app under $HOME
npm create @datadog/apps@latest -- ~/qa-app --template vite-react -y
cd ~/qa-app

# 2. Link Terminal A's build in
npm link ~/dd/build-plugins/packages/published/vite-plugin
# If this resolves to unbuilt TS source instead of dist (npm link's known gap with this
# package's workspace-mode `exports` field), edit vite.config.ts's import instead:
#   import { datadogVitePlugin } from '@datadog/vite-plugin/dist/src';
```

Still Terminal B, still in `~/qa-app`:

```bash
# 3. Add QA backend functions
cat > src/qaCheck.backend.ts << 'EOF'
export async function qaCheck(n: number) {
    return { doubled: n * 2 };
}
EOF

cat > src/qaIdentity.backend.ts << 'EOF'
import { getExecutionUser, getInitiatingUser } from '@datadog/apps-backend/user';
export async function qaIdentity() {
    const [executionUser, initiatingUser] = await Promise.all([getExecutionUser(), getInitiatingUser()]);
    return { executionUser, initiatingUser };
}
EOF

cat > src/slowCheck.backend.ts << 'EOF'
export async function slowCheck() {
    await new Promise((r) => setTimeout(r, 15000));
    return { done: true };
}
EOF

cat > src/streamLogs.backend.ts << 'EOF'
export async function streamLogs() {
    console.log('[qa] step 1: starting');
    await new Promise((r) => setTimeout(r, 1000));
    console.log('[qa] step 2: one second in');
    await new Promise((r) => setTimeout(r, 1000));
    console.log('[qa] step 3: done');
    return { done: true };
}
EOF

cat > src/doubleNumber.backend.ts << 'EOF'
export async function doubleNumber(n: number) {
    return { doubled: n * 2 };
}
EOF

# Wire the imports so Vite's backend-function transform discovers them (prepended, portable across sed dialects)
{ printf "import './qaCheck.backend';\nimport './qaIdentity.backend';\nimport './slowCheck.backend';\nimport './streamLogs.backend';\nimport './doubleNumber.backend';\n\n"; cat src/App.tsx; } > /tmp/App.tsx.new && mv /tmp/App.tsx.new src/App.tsx
```

Still Terminal B, still in `~/qa-app` — this command blocks and keeps running, so leave it in the foreground here:

```bash
# 4. Start local execution — no dd-auth, fixed port
npm run dev -- --port 5180 --strictPort
```

**Terminal C — open a new terminal, folder: `~/qa-app` again** (Terminal B is now occupied by the running dev server; everything below runs here instead):

```bash
cd ~/qa-app

# 5. Warm up the module graph once (Vite transforms lazily on first request)
curl -sS http://localhost:5180/ > /dev/null
curl -sS http://localhost:5180/src/main.tsx > /dev/null
```

```bash
# 6. Capture each function's real hashed name (registered name is {hash}.{exportName}, not the bare export name) — extracted automatically, no copy-paste needed
QACHECK=$(curl -sS http://localhost:5180/src/qaCheck.backend.ts | sed -n 's/.*executeBackendFunction("\([^"]*\)".*/\1/p')
QAIDENTITY=$(curl -sS http://localhost:5180/src/qaIdentity.backend.ts | sed -n 's/.*executeBackendFunction("\([^"]*\)".*/\1/p')
STREAMLOGS=$(curl -sS http://localhost:5180/src/streamLogs.backend.ts | sed -n 's/.*executeBackendFunction("\([^"]*\)".*/\1/p')
DOUBLENUMBER=$(curl -sS http://localhost:5180/src/doubleNumber.backend.ts | sed -n 's/.*executeBackendFunction("\([^"]*\)".*/\1/p')
SLOWCHECK=$(curl -sS http://localhost:5180/src/slowCheck.backend.ts | sed -n 's/.*executeBackendFunction("\([^"]*\)".*/\1/p')
echo "$QACHECK / $QAIDENTITY / $STREAMLOGS / $DOUBLENUMBER / $SLOWCHECK"
# Expected: five non-empty "<hash>.<exportName>" strings, space-separated ✅ VERIFIED
```

Local execution tests:

```bash
curl -sS -X POST http://localhost:5180/__dd/executeAction \
  -H 'Content-Type: application/json' \
  -d "{\"functionName\":\"$QACHECK\",\"args\":[21]}"
# Expected: {"success":true,"result":{"data":{"doubled":42}}} ✅ VERIFIED

curl -sS -X POST http://localhost:5180/__dd/executeAction \
  -H 'Content-Type: application/json' \
  -d "{\"functionName\":\"$QAIDENTITY\",\"args\":[]}"
# Expected: {"success":true,"result":{"data":{"executionUser":{"id":"local-dev-user","orgId":"local-dev-org","email":null,"name":"Local Development"},"initiatingUser":{...}}}} ✅ VERIFIED

curl -sS -X POST http://localhost:5180/__dd/executeAction \
  -H 'Content-Type: application/json' \
  -d "{\"functionName\":\"$STREAMLOGS\",\"args\":[]}"
# Expected: {"success":true,"result":{"data":{"done":true}}} in the response, and the three [qa] step lines print live in the dev-server terminal, one second apart ✅ VERIFIED
```

Timing check:

```bash
curl -sS -X POST http://localhost:5180/__dd/executeAction -H 'Content-Type: application/json' \
  -d "{\"functionName\":\"$DOUBLENUMBER\",\"args\":[21]}" -w '\n⏱  %{time_total}s\n'
# Expected: {"success":true,"result":{"data":{"doubled":42}}}, ⏱ ~0.1s ✅ VERIFIED (0.111s)
```

Shutdown cleanup — no orphaned child process (still Terminal C, until the Ctrl-C note below):

```bash
curl -sS -X POST http://localhost:5180/__dd/executeAction -H 'Content-Type: application/json' \
  -d "{\"functionName\":\"$SLOWCHECK\",\"args\":[]}" &
sleep 1 && pgrep -f local-exec-child.js
# Expected: one matching PID (child running mid-request) ✅ VERIFIED
```

Switch to **Terminal B** (where `npm run dev` is still running in the foreground) and press Ctrl-C to stop it. Then back in **Terminal C**:

```bash
pgrep -f local-exec-child.js
# Expected: no output (child was killed with the dev server) ✅ VERIFIED
```

Cloud round trip — the same `$QACHECK`/`$DOUBLENUMBER`/`$STREAMLOGS` variables from step 6 stay valid — the registered name only depends on the file's relative path, not the running server instance.

**Terminal B — folder: still `~/qa-app`** — restart with credentials, fixed port:

```bash
dd-auth --domain dd.datad0g.com -- npm run dev -- --port 5182 --strictPort
```

**Terminal C — folder: still `~/qa-app`:**

```bash
curl -sS -X POST http://localhost:5182/__dd/executeActionViaCloud \
  -H 'Content-Type: application/json' \
  -d "{\"functionName\":\"$QACHECK\",\"args\":[21]}"
# Expected: {"success":true,"result":{"data":{"doubled":42}}} ✅ VERIFIED

# same server instance — confirms both endpoints coexist
curl -sS -X POST http://localhost:5182/__dd/executeAction \
  -H 'Content-Type: application/json' \
  -d "{\"functionName\":\"$QACHECK\",\"args\":[7]}"
# Expected: {"success":true,"result":{"data":{"doubled":14}}} ✅ VERIFIED

curl -sS -X POST http://localhost:5182/__dd/executeActionViaCloud -H 'Content-Type: application/json' \
  -d "{\"functionName\":\"$DOUBLENUMBER\",\"args\":[21]}" -w '\n⏱  %{time_total}s\n'
# Expected: {"success":true,"result":{"data":{"doubled":42}}}, ⏱ multi-hundred-ms (real network + queue overhead) ✅ VERIFIED (0.725s)

curl -sS -X POST http://localhost:5182/__dd/executeActionViaCloud \
  -H 'Content-Type: application/json' \
  -d "{\"functionName\":\"$STREAMLOGS\",\"args\":[]}"
# Expected: the three [qa] step lines print all at once, only after the response lands — not live ✅ VERIFIED
```

Action-catalog build-time validation — no server needed, so Ctrl-C Terminal B's dev server first. Runs in either terminal, folder `~/qa-app`:

```bash
echo "import { postMessage } from '@datadog/action-catalog/slack/chat';" > src/_check.backend.ts
npx tsc --noEmit
# Expected: TS2305 "has no exported member 'postMessage'" ✅ VERIFIED
rm src/_check.backend.ts
```

## Blast Radius

- **This is the first PR in the stack that changes shipping behavior**: `npm run dev`'s `/__dd/executeAction` now executes locally by default, unconditionally, per the design doc's rollout decision — no feature flag, matching the "no toggle" recommendation (Datadog's own internal canary/experiment gate, if wanted before this becomes the default for all customers, is out of scope for this PR; see design doc's Rollout section).
- The existing cloud round-trip is fully preserved and still reachable, just under a new endpoint name (`/__dd/executeActionViaCloud`) — no existing caller of the old `/__dd/executeAction` endpoint is silently broken without an equivalent path forward, though callers relying specifically on cloud execution at the old URL will need to switch to the new one.
- `$.Actions` calls made during local execution remain stubbed (per #461/#471) — real action side effects are only available via `/__dd/executeActionViaCloud` today. This is a known, called-out gap tracked against the single-action-execution endpoint dependency, not something this PR silently papers over.
- The `@datadog/apps-backend` `Source`-context gap found during this PR's manual QA (see above) is now fixed and re-verified against a real scaffolded app — local execution is safe as the default for apps using that package. The synthetic local-dev identity means `getExecutionUser()`/`getInitiatingUser()` won't reflect a real user locally (no live-session identity is available without the credentials local execution deliberately doesn't require) — acceptable for now since nothing in the design doc's scope depends on that identity being real, but worth knowing if a backend function's own logic ever branches on it.
- Risk: **medium**. Low risk to code correctness (thoroughly tested, real manual QA above, including the two gaps found and fixed) but a genuine behavior change to a customer-facing default — flagged as the "no toggle" decision the design doc argues for explicitly, not an accidental side effect.

## Out of Scope / Follow-ups

| Item | Status | Next step |
|---|---|---|
| Local execution's `$.Source` uses a synthetic local-dev identity, not a real user's — `getExecutionUser()`/`getInitiatingUser()` won't reflect real identity locally | Independent | No whoami-style endpoint exists in this package's auth layer today; fetching real identity via the already-authenticated parent process (when credentials are configured) is a real, separate enhancement, not a blocker — nothing in scope today depends on the identity being real |
| `npm run dev:verify` as a distinctly-named command for the cloud round-trip | Tracked (Milestone 3) | Now a fully in-scope, gating deliverable — losing easy cloud-path access the moment `npm run dev` defaults to local execution is a real workflow regression, not just a missing nicety. Two PRs needed: mode-aware routing in this package (`packages/plugins/apps/`), plus a `create-apps` template change in `web-ui` (owned by `@DataDog/app-builder-high-code`) to add the script and an example backend function. `/__dd/executeActionViaCloud` is reachable today via a manual curl call in the meantime. |
| Backward-compatible rollout (`bump.yaml` major bump + `MIGRATIONS.md` entry) | Not started | Now tracked under Product Launch (not a standalone milestone), gated on Milestones 3/4/5/6 landing (Milestone 7, telemetry, expected in place too), per the kickoff doc |
| Real (non-stubbed) `$.Actions` execution during local runs | Blocked | Same dependency as #461/#471 — see the RFC's Open Questions section for the REST-vs-MCP comparison |
| Internal canary/experiment gate for gradual rollout before this is unconditional for all customers | Not started | Design doc's Rollout section proposes this as a Datadog-internal gate, invisible to customers — separate from this PR's scope |

## Documentation

- [Kickoff doc](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7025394455) — Milestone 2
- [Design doc](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7012712651)


[APPS-2792]: https://datadoghq.atlassian.net/browse/APPS-2792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ












